### PR TITLE
Add PyBind11 backend implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# peakrdl-pybind
+
+`peakrdl-pybind` is a [PeakRDL](https://github.com/SystemRDL/PeakRDL) backend that emits a C++/PyBind11
+register access model. The backend walks an elaborated SystemRDL design, renders a set of C++
+sources through Jinja2 templates, and produces a scikit-build-core project that can be built into a
+wheel. Once built, the generated Python module exposes the register map in a Python friendly API so
+hardware tests can directly read/write registers from scripts.
+
+## Features
+
+* Generates PyBind11 bindings for address maps, blocks, registers, and fields.
+* Provides a `Master` interface that allows the Python module to delegate memory accesses to an
+  externally supplied implementation (OpenOCD, simulator, etc.).
+* Supports register and field level access policies, masking, and read-modify-write helpers.
+* Optional generation of typing stubs for IDE assistance.
+* Command line interface and PeakRDL backend entry point for easy integration into existing flows.
+
+## Usage
+
+```bash
+peakrdl-pybind --soc-name aurora --top top --out ./build/aurora \
+    --gen-pyi --with-examples
+
+cd build/aurora
+python -m build
+pip install dist/aurora-*.whl
+```
+
+After installation, tests can interact with the register map using the generated module:
+
+```python
+import aurora as soc
+
+class MyMaster(soc.Master):
+    def read32(self, addr: int) -> int:
+        ...
+
+    def write32(self, addr: int, data: int, wstrb: int = 0xF) -> None:
+        ...
+
+soc.attach_master(MyMaster())
+value = soc.top.uart0.LCR.read()
+soc.top.uart0.LCR.modify(DLAB=1, WLS=3)
+```
+
+See [`docs/`](docs/) for more detailed documentation on architecture, CLI options, and template
+structure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,50 @@
+# PeakRDL PyBind Backend Architecture
+
+This document captures the high level architecture of the `peakrdl-pybind` backend. It serves as a
+quick reference for contributors and explains how the Python backend, the templates, and the emitted
+artifacts interact.
+
+## Backend Overview
+
+The backend entry point is `peakrdl_pybind.backend.PyBindBackend`. When invoked from PeakRDL it
+receives an elaborated SystemRDL top level node and user supplied options. The backend walks the node
+hierarchy, normalises register addresses and field widths, and constructs an intermediate
+representation (IR). The IR is a pure Python data structure that is passed to Jinja2 templates to
+render the final C++ sources, build files, and optional typing stubs.
+
+## Key Modules
+
+* `backend.py`: Backend entry point, CLI option parsing, IR builder orchestration.
+* `ir.py`: Helper dataclasses that describe address spaces, blocks, registers, fields, and enums.
+* `render.py`: Wrapper around the Jinja2 environment with convenience helpers for template filters
+  (bit masking, wstrb computation, etc.).
+* `templates/`: Jinja2 templates for C++, CMake, pyproject.toml, and typing stubs.
+
+## Generated Artifacts
+
+The backend emits the following file structure:
+
+```
+<soc-package>/
+├── cpp/
+│   ├── master.hpp
+│   ├── master.cpp
+│   ├── reg_model.hpp
+│   ├── reg_model.cpp
+│   ├── accessors.hpp
+│   ├── accessors.cpp
+│   └── soc_module.cpp
+├── CMakeLists.txt
+├── pyproject.toml
+└── typing/
+    └── soc.pyi
+```
+
+Each source file is generated from a dedicated template. Templates are authored with readability in
+mind and leverage macros to keep the output consistent across registers and address spaces.
+
+## Testing
+
+Pytest based tests live in `tests/` and exercise the IR builder and template rendering using the
+example SystemRDL fragment from the engineering specification. The tests rely on a lightweight mock
+of the SystemRDL node classes to avoid a hard dependency during unit testing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "peakrdl-pybind"
+version = "0.1.0"
+description = "PeakRDL backend that generates PyBind11 register access modules"
+readme = "README.md"
+authors = [
+  {name = "PeakRDL Contributors"}
+]
+license = {file = "LICENSE"}
+requires-python = ">=3.9"
+dependencies = [
+  "peakrdl>=1.0",
+  "systemrdl-compiler>=1.28",
+  "jinja2>=3.1",
+  "click>=8.1",
+  "packaging>=23"
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest",
+  "pytest-regressions"
+]
+
+[project.entry-points."systemrdl_backends"]
+peakrdl_pybind = "peakrdl_pybind.backend:PyBindBackend"
+
+[project.scripts]
+peakrdl-pybind = "peakrdl_pybind.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+pythonpath = ["src"]

--- a/src/peakrdl_pybind/__init__.py
+++ b/src/peakrdl_pybind/__init__.py
@@ -1,0 +1,7 @@
+"""PeakRDL backend that generates PyBind11 register access modules."""
+
+from .backend import PyBindBackend
+
+__all__ = ["PyBindBackend"]
+
+__version__ = "0.1.0"

--- a/src/peakrdl_pybind/backend.py
+++ b/src/peakrdl_pybind/backend.py
@@ -1,0 +1,145 @@
+"""Backend entry point implementation."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency during tests
+    from peakrdl.plugins.exporter import ExporterBackend  # type: ignore
+except Exception:  # pragma: no cover - fallback for PeakRDL versions without ExporterBackend
+    class ExporterBackend:  # type: ignore[misc]
+        """Fallback backend base class."""
+
+        def __init__(self) -> None:  # noqa: D401 - simple stub
+            """Initialise the fallback backend."""
+
+        def get_additional_args(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+            return parser
+
+        def run(self, top_node, options):  # pragma: no cover - interface stub
+            raise NotImplementedError
+
+
+from .ir import IRBuilder
+from .render import TemplateRenderer
+
+
+@dataclass
+class PyBindOptions:
+    """Options that control code generation."""
+
+    soc_name: str
+    namespace: Optional[str]
+    out_dir: Path
+    word_bytes: int = 4
+    little_endian: bool = True
+    gen_pyi: bool = False
+    with_examples: bool = False
+    access_checks: bool = True
+    emit_reset_writes: bool = False
+
+    def module_name(self) -> str:
+        base = self.namespace or f"soc_{self.soc_name}"
+        return base
+
+
+class PyBindBackend(ExporterBackend):
+    """PeakRDL backend that emits a PyBind11 extension."""
+
+    short_description = "Generate a PyBind11 register access module"
+
+    def __init__(self) -> None:
+        super().__init__()  # type: ignore[misc]
+        self.renderer = TemplateRenderer()
+
+    # ------------------------------------------------------------------
+    # PeakRDL integration helpers
+    # ------------------------------------------------------------------
+    def get_additional_args(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover - exercised via CLI
+        parser.add_argument("--soc-name", required=True, help="Name of the generated SoC package")
+        parser.add_argument("--out", dest="out_dir", required=True, help="Output directory")
+        parser.add_argument("--namespace", dest="namespace", help="Python package namespace")
+        parser.add_argument("--word-bytes", dest="word_bytes", type=int, default=4, help="Bus word size in bytes")
+        parser.add_argument("--little-endian", dest="little_endian", action="store_true", default=True)
+        parser.add_argument("--big-endian", dest="little_endian", action="store_false")
+        parser.add_argument("--gen-pyi", dest="gen_pyi", action="store_true", default=False)
+        parser.add_argument("--with-examples", dest="with_examples", action="store_true", default=False)
+        parser.add_argument("--no-access-checks", dest="access_checks", action="store_false", default=True)
+        parser.add_argument("--emit-reset-writes", dest="emit_reset_writes", action="store_true", default=False)
+        return parser
+
+    def _options_from_namespace(self, namespace: argparse.Namespace) -> PyBindOptions:
+        return PyBindOptions(
+            soc_name=namespace.soc_name,
+            namespace=getattr(namespace, "namespace", None),
+            out_dir=Path(namespace.out_dir),
+            word_bytes=int(getattr(namespace, "word_bytes", 4)),
+            little_endian=bool(getattr(namespace, "little_endian", True)),
+            gen_pyi=bool(getattr(namespace, "gen_pyi", False)),
+            with_examples=bool(getattr(namespace, "with_examples", False)),
+            access_checks=bool(getattr(namespace, "access_checks", True)),
+            emit_reset_writes=bool(getattr(namespace, "emit_reset_writes", False)),
+        )
+
+    # ------------------------------------------------------------------
+    # Entry point used by both CLI and PeakRDL
+    # ------------------------------------------------------------------
+    def run(self, top_node, options: PyBindOptions | argparse.Namespace) -> None:
+        if isinstance(options, argparse.Namespace):
+            options = self._options_from_namespace(options)
+
+        out_dir = options.out_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+        module_name = options.module_name()
+        cpp_namespace = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in module_name)
+
+        builder = IRBuilder(
+            word_bytes=options.word_bytes,
+            little_endian=options.little_endian,
+            access_checks=options.access_checks,
+            emit_reset_writes=options.emit_reset_writes,
+        )
+        soc_ir = builder.build(top_node, soc_name=options.soc_name, namespace=module_name)
+
+        all_registers = list(soc_ir.top.flatten_registers())
+
+        top_descriptor = "{}".format(
+            "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in soc_ir.top.path.replace(".", "_"))) + "_desc"
+
+        context = {
+            "soc": soc_ir,
+            "module_name": module_name,
+            "namespace": cpp_namespace,
+            "word_bytes": options.word_bytes,
+            "little_endian": options.little_endian,
+            "access_checks": options.access_checks,
+            "emit_reset_writes": options.emit_reset_writes,
+            "registers": all_registers,
+            "top_descriptor": top_descriptor,
+        }
+
+        # Core C++ sources
+        self.renderer.render_to_path("cpp/master.hpp.jinja", context, out_dir / "cpp" / "master.hpp")
+        self.renderer.render_to_path("cpp/master.cpp.jinja", context, out_dir / "cpp" / "master.cpp")
+        self.renderer.render_to_path("cpp/accessors.hpp.jinja", context, out_dir / "cpp" / "accessors.hpp")
+        self.renderer.render_to_path("cpp/accessors.cpp.jinja", context, out_dir / "cpp" / "accessors.cpp")
+        self.renderer.render_to_path("cpp/reg_model.hpp.jinja", context, out_dir / "cpp" / "reg_model.hpp")
+        self.renderer.render_to_path("cpp/reg_model.cpp.jinja", context, out_dir / "cpp" / "reg_model.cpp")
+        self.renderer.render_to_path("cpp/soc_module.cpp.jinja", context, out_dir / "cpp" / "soc_module.cpp")
+
+        # Build system files
+        self.renderer.render_to_path("CMakeLists.txt.jinja", context, out_dir / "CMakeLists.txt")
+        self.renderer.render_to_path("pyproject.toml.jinja", context, out_dir / "pyproject.toml")
+
+        if options.gen_pyi:
+            self.renderer.render_to_path("typing/soc.pyi.jinja", context, out_dir / "typing" / f"{module_name}.pyi")
+
+        if options.with_examples:
+            self.renderer.render_to_path("masters/openocd_master.cpp.jinja", context, out_dir / "masters" / "openocd_master.cpp")
+            self.renderer.render_to_path("masters/ssh_devmem_master.cpp.jinja", context, out_dir / "masters" / "ssh_devmem_master.cpp")
+
+
+__all__ = ["PyBindBackend", "PyBindOptions"]

--- a/src/peakrdl_pybind/cli.py
+++ b/src/peakrdl_pybind/cli.py
@@ -1,0 +1,73 @@
+"""Command line interface for the PyBind backend."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from systemrdl import RDLCompiler
+
+from .backend import PyBindBackend, PyBindOptions
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("rdl", nargs=-1, type=click.Path(exists=True, dir_okay=False))
+@click.option("--soc-name", required=True, help="Name of the SoC/package to generate")
+@click.option("--top", "top_symbol", required=True, help="Top-level addrmap symbol to elaborate")
+@click.option("--out", "out_dir", required=True, type=click.Path(file_okay=False), help="Output directory")
+@click.option("--namespace", default=None, help="Python package namespace for the generated module")
+@click.option("--word-bytes", default=4, show_default=True, type=click.IntRange(1, 8), help="Bus word size in bytes")
+@click.option("--little-endian/--big-endian", default=True, show_default=True, help="Target endianness")
+@click.option("--gen-pyi/--no-gen-pyi", default=False, help="Emit typing stub (.pyi)")
+@click.option("--with-examples/--no-with-examples", default=False, help="Generate example master implementations")
+@click.option("--no-access-checks", is_flag=True, help="Disable software access policy checks")
+@click.option("--emit-reset-writes", is_flag=True, help="Emit helper that writes reset values")
+def main(
+    rdl: tuple[str, ...],
+    soc_name: str,
+    top_symbol: str,
+    out_dir: str,
+    namespace: Optional[str],
+    word_bytes: int,
+    little_endian: bool,
+    gen_pyi: bool,
+    with_examples: bool,
+    no_access_checks: bool,
+    emit_reset_writes: bool,
+) -> None:
+    if not rdl:
+        raise click.UsageError("At least one RDL file must be provided")
+
+    compiler = RDLCompiler()
+    for path in rdl:
+        compiler.compile_file(path)
+
+    try:
+        top_node = compiler.elaborate(top_symbol)
+    except Exception as exc:  # pragma: no cover - pass through compiler failures
+        raise click.ClickException(str(exc)) from exc
+
+    options = PyBindOptions(
+        soc_name=soc_name,
+        namespace=namespace,
+        out_dir=Path(out_dir),
+        word_bytes=word_bytes,
+        little_endian=little_endian,
+        gen_pyi=gen_pyi,
+        with_examples=with_examples,
+        access_checks=not no_access_checks,
+        emit_reset_writes=emit_reset_writes,
+    )
+
+    backend = PyBindBackend()
+    backend.run(top_node, options)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        main.main(standalone_mode=False)
+    except SystemExit as exc:
+        if exc.code:
+            sys.exit(exc.code)

--- a/src/peakrdl_pybind/ir.py
+++ b/src/peakrdl_pybind/ir.py
@@ -1,0 +1,383 @@
+"""Intermediate representation helpers for the PyBind backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence
+
+
+@dataclass
+class EnumIR:
+    """Enumerated value for a field."""
+
+    name: str
+    value: int
+    description: Optional[str] = None
+
+
+@dataclass
+class FieldIR:
+    """Description of a register field."""
+
+    name: str
+    lsb: int
+    msb: int
+    access: str
+    reset: Optional[int]
+    description: Optional[str] = None
+    enums: List[EnumIR] = field(default_factory=list)
+
+    @property
+    def width(self) -> int:
+        return self.msb - self.lsb + 1
+
+    @property
+    def mask(self) -> int:
+        return ((1 << self.width) - 1) << self.lsb
+
+
+@dataclass
+class RegisterIR:
+    """Description of a register."""
+
+    name: str
+    path: str
+    absolute_address: int
+    width: int
+    reset: Optional[int]
+    volatile: bool
+    access: str
+    description: Optional[str] = None
+    fields: List[FieldIR] = field(default_factory=list)
+    array_dimensions: Sequence[int] = field(default_factory=tuple)
+    stride: Optional[int] = None
+
+    @property
+    def is_array(self) -> bool:
+        return bool(self.array_dimensions)
+
+    @property
+    def element_count(self) -> int:
+        count = 1
+        for dim in self.array_dimensions:
+            count *= dim
+        return count
+
+
+@dataclass
+class BlockIR:
+    """Address space/regfile/block description."""
+
+    name: str
+    path: str
+    absolute_address: int
+    description: Optional[str] = None
+    registers: List[RegisterIR] = field(default_factory=list)
+    blocks: List["BlockIR"] = field(default_factory=list)
+    array_dimensions: Sequence[int] = field(default_factory=tuple)
+    stride: Optional[int] = None
+
+    def flatten_registers(self) -> Iterable[RegisterIR]:
+        yield from self.registers
+        for block in self.blocks:
+            yield from block.flatten_registers()
+
+    @property
+    def is_array(self) -> bool:
+        return bool(self.array_dimensions)
+
+
+@dataclass
+class SocIR:
+    """Root object representing the generated SoC."""
+
+    soc_name: str
+    namespace: str
+    top: BlockIR
+    word_bytes: int
+    little_endian: bool
+    access_checks: bool = True
+    emit_reset_writes: bool = False
+
+
+class IRBuilder:
+    """Builds the IR from a SystemRDL elaborated design."""
+
+    def __init__(
+        self,
+        *,
+        word_bytes: int = 4,
+        little_endian: bool = True,
+        access_checks: bool = True,
+        emit_reset_writes: bool = False,
+    ) -> None:
+        self.word_bytes = word_bytes
+        self.little_endian = little_endian
+        self.access_checks = access_checks
+        self.emit_reset_writes = emit_reset_writes
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(self, top_node, *, soc_name: str, namespace: str) -> SocIR:
+        block = self._collect_block(top_node, parent_path=namespace)
+        return SocIR(
+            soc_name=soc_name,
+            namespace=namespace,
+            top=block,
+            word_bytes=self.word_bytes,
+            little_endian=self.little_endian,
+            access_checks=self.access_checks,
+            emit_reset_writes=self.emit_reset_writes,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _collect_block(self, node, *, parent_path: str) -> BlockIR:
+        name = self._get_inst_name(node)
+        path = f"{parent_path}.{name}" if parent_path else name
+        desc = self._get_property(node, "desc")
+        abs_addr = self._get_absolute_address(node)
+        array_dims = tuple(self._get_array_dimensions(node))
+        stride = self._get_stride(node)
+
+        registers: List[RegisterIR] = []
+        blocks: List[BlockIR] = []
+
+        for child in self._iter_children(node):
+            kind = self._classify_node(child)
+            if kind == "reg":
+                registers.append(self._collect_register(child, parent_path=f"{path}.{self._get_inst_name(child)}"))
+            elif kind in {"addrmap", "regfile", "block"}:
+                blocks.append(self._collect_block(child, parent_path=path))
+
+        registers.sort(key=lambda r: (r.absolute_address, r.name))
+        blocks.sort(key=lambda b: (b.absolute_address, b.name))
+
+        return BlockIR(
+            name=name,
+            path=path,
+            absolute_address=abs_addr,
+            description=desc,
+            registers=registers,
+            blocks=blocks,
+            array_dimensions=array_dims,
+            stride=stride,
+        )
+
+    def _collect_register(self, node, *, parent_path: str) -> RegisterIR:
+        name = self._get_inst_name(node)
+        path = parent_path
+        abs_addr = self._get_absolute_address(node)
+        width = self._get_bit_width(node)
+        reset = self._get_reset(node)
+        volatile = bool(self._get_property(node, "volatile") or False)
+        access = self._stringify_access(self._get_property(node, "sw"))
+        desc = self._get_property(node, "desc")
+        array_dims = tuple(self._get_array_dimensions(node))
+        stride = self._get_stride(node)
+        if stride is None and array_dims:
+            stride = max(self.word_bytes, (width + 7) // 8)
+
+        fields: List[FieldIR] = []
+        for field_node in self._iter_fields(node):
+            fields.append(self._collect_field(field_node, parent_path=f"{path}.{self._get_inst_name(field_node)}"))
+
+        fields.sort(key=lambda f: (f.lsb, f.name))
+
+        return RegisterIR(
+            name=name,
+            path=path,
+            absolute_address=abs_addr,
+            width=width,
+            reset=reset,
+            volatile=volatile,
+            access=access,
+            description=desc,
+            fields=fields,
+            array_dimensions=array_dims,
+            stride=stride,
+        )
+
+    def _collect_field(self, node, *, parent_path: str) -> FieldIR:
+        name = self._get_inst_name(node)
+        desc = self._get_property(node, "desc")
+        lsb = getattr(node, "lsb", 0)
+        msb = getattr(node, "msb", lsb)
+        reset_val = self._get_reset(node)
+        access = self._stringify_access(self._get_property(node, "sw"))
+        enums = [
+            EnumIR(name=enum_name, value=enum_value, description=enum_desc)
+            for enum_name, enum_value, enum_desc in self._iter_enums(node)
+        ]
+
+        return FieldIR(
+            name=name,
+            lsb=lsb,
+            msb=msb,
+            access=access,
+            reset=reset_val,
+            description=desc,
+            enums=enums,
+        )
+
+    # ------------------------------------------------------------------
+    # Introspection utilities
+    # ------------------------------------------------------------------
+    def _classify_node(self, node) -> str:
+        type_name = getattr(node, "type_name", None) or node.__class__.__name__
+        type_name = type_name.lower()
+        if "field" in type_name:
+            return "field"
+        if "regfile" in type_name:
+            return "regfile"
+        if "addrmap" in type_name:
+            return "addrmap"
+        if type_name in {"reg", "register", "registernode"}:
+            return "reg"
+        if "mem" in type_name:
+            return "mem"
+        if "signal" in type_name:
+            return "signal"
+        return type_name
+
+    def _iter_children(self, node) -> Iterable:
+        children: Iterable = []
+        if hasattr(node, "children") and callable(getattr(node, "children")):
+            children = list(node.children())
+        elif hasattr(node, "children"):
+            children = getattr(node, "children")  # type: ignore[assignment]
+        elif hasattr(node, "inst") and hasattr(node.inst, "children"):
+            children = list(node.inst.children())
+        return [child for child in children if self._classify_node(child) != "field"]
+
+    def _iter_fields(self, node) -> Iterable:
+        if hasattr(node, "fields") and callable(getattr(node, "fields")):
+            return list(node.fields())
+        if hasattr(node, "field_children"):
+            return list(getattr(node, "field_children"))
+        children = []
+        if hasattr(node, "children") and callable(getattr(node, "children")):
+            children = list(node.children())
+        return [child for child in children if self._classify_node(child) == "field"]
+
+    def _iter_enums(self, node) -> Iterable:
+        enums = []
+        enum_dict = getattr(node, "enumerated_values", None)
+        if isinstance(enum_dict, dict):
+            for name, value in enum_dict.items():
+                enums.append((name, int(value), None))
+        elif hasattr(node, "enum_definition") and node.enum_definition is not None:
+            enum_def = node.enum_definition
+            items = getattr(enum_def, "items", None)
+            if items:
+                for enum_item in items:
+                    enums.append((enum_item.name, int(enum_item.value), getattr(enum_item, "description", None)))
+        return enums
+
+    def _get_inst_name(self, node) -> str:
+        return getattr(node, "inst_name", getattr(node, "name", "unnamed"))
+
+    def _get_absolute_address(self, node) -> int:
+        for attr in ("absolute_address", "addr", "absolute_address_offset"):
+            if hasattr(node, attr):
+                value = getattr(node, attr)
+                if value is not None:
+                    return int(value)
+        getter = getattr(node, "get_absolute_address", None)
+        if callable(getter):
+            return int(getter())
+        getter = getattr(node, "get_address", None)
+        if callable(getter):
+            return int(getter())
+        offset = getattr(node, "address_offset", 0)
+        if hasattr(node, "parent") and node.parent is not None:
+            return self._get_absolute_address(node.parent) + int(offset)
+        return int(offset)
+
+    def _get_bit_width(self, node) -> int:
+        for attr in ("width", "bit_width", "total_bit_width"):
+            if hasattr(node, attr):
+                value = getattr(node, attr)
+                if value is not None:
+                    return int(value)
+        getter = getattr(node, "get_property", None)
+        if callable(getter):
+            width_prop = getter("width")
+            if width_prop is not None:
+                try:
+                    return int(width_prop)
+                except TypeError:
+                    pass
+        return self.word_bytes * 8
+
+    def _get_reset(self, node) -> Optional[int]:
+        getter = getattr(node, "get_property", None)
+        if callable(getter):
+            try:
+                reset_prop = getter("reset")
+            except Exception:  # pragma: no cover - defensive fallback
+                reset_prop = None
+            if reset_prop is not None:
+                if isinstance(reset_prop, dict):
+                    value = reset_prop.get("value")
+                    if value is not None:
+                        return int(value)
+                try:
+                    return int(reset_prop)
+                except (TypeError, ValueError):
+                    pass
+        return None
+
+    def _get_property(self, node, prop: str):
+        getter = getattr(node, "get_property", None)
+        if callable(getter):
+            try:
+                return getter(prop)
+            except Exception:  # pragma: no cover - property missing
+                return None
+        return getattr(node, prop, None)
+
+    def _stringify_access(self, value) -> str:
+        if value is None:
+            return "rw"
+        if isinstance(value, str):
+            return value
+        if hasattr(value, "name"):
+            return str(value.name)
+        return str(value)
+
+    def _get_array_dimensions(self, node) -> Sequence[int]:
+        dims = getattr(node, "array_dimensions", None)
+        if dims:
+            return [int(d) for d in dims]
+        if getattr(node, "is_array", False):
+            for attr in ("dimensions", "shape"):
+                candidate = getattr(node, attr, None)
+                if candidate:
+                    return [int(d) for d in candidate]
+        return []
+
+    def _get_stride(self, node) -> Optional[int]:
+        for attr in ("array_stride", "stride", "address_stride"):
+            if hasattr(node, attr):
+                value = getattr(node, attr)
+                if value is not None:
+                    return int(value)
+        getter = getattr(node, "get_address_stride", None)
+        if callable(getter):
+            stride = getter()
+            if stride is not None:
+                return int(stride)
+        return None
+
+
+__all__ = [
+    "EnumIR",
+    "FieldIR",
+    "RegisterIR",
+    "BlockIR",
+    "SocIR",
+    "IRBuilder",
+]

--- a/src/peakrdl_pybind/render.py
+++ b/src/peakrdl_pybind/render.py
@@ -1,0 +1,86 @@
+"""Template rendering helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from functools import reduce
+from operator import mul
+
+from jinja2 import Environment, PackageLoader, StrictUndefined
+
+
+def _to_dict(value: Any) -> Any:
+    if is_dataclass(value):
+        return {k: _to_dict(v) for k, v in asdict(value).items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_dict(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _to_dict(v) for k, v in value.items()}
+    return value
+
+
+def _c_identifier(value: str) -> str:
+    return "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in value)
+
+
+def _snake_case(value: str) -> str:
+    result = []
+    for ch in value:
+        if ch.isupper() and result:
+            result.append("_")
+        result.append(ch.lower())
+    return "".join(result)
+
+
+def _camel_case(value: str) -> str:
+    parts = [part for part in value.replace("_", " ").split() if part]
+    return "".join(part.capitalize() for part in parts)
+
+
+def _hex(value: int, width: int = 0) -> str:
+    fmt = "#0{}x".format(width + 2) if width else "#x"
+    return format(value, fmt)
+
+
+def _product(values):
+    seq = list(values)
+    if not seq:
+        return 1
+    return reduce(mul, seq, 1)
+
+
+class TemplateRenderer:
+    """Thin wrapper around Jinja2 with helpful filters."""
+
+    def __init__(self) -> None:
+        self.env = Environment(
+            loader=PackageLoader("peakrdl_pybind", "templates"),
+            autoescape=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+            undefined=StrictUndefined,
+        )
+        self.env.filters.update(
+            {
+                "c_ident": _c_identifier,
+                "snake": _snake_case,
+                "camel": _camel_case,
+                "hex": _hex,
+                "product": _product,
+            }
+        )
+
+    def render_to_path(self, template: str, context: Dict[str, Any], destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        template_obj = self.env.get_template(template)
+        rendered = template_obj.render(**context)
+        destination.write_text(rendered.rstrip() + "\n", encoding="utf-8")
+
+    def dataclass_context(self, **kwargs: Any) -> Dict[str, Any]:
+        return {key: _to_dict(value) for key, value in kwargs.items()}
+
+
+__all__ = ["TemplateRenderer"]

--- a/src/peakrdl_pybind/templates/CMakeLists.txt.jinja
+++ b/src/peakrdl_pybind/templates/CMakeLists.txt.jinja
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.18)
+project({{ module_name }} LANGUAGES CXX)
+
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module({{ namespace }}
+  MODULE
+  cpp/master.cpp
+  cpp/accessors.cpp
+  cpp/reg_model.cpp
+  cpp/soc_module.cpp
+)
+
+target_include_directories({{ namespace }} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cpp)
+target_compile_features({{ namespace }} PRIVATE cxx_std_17)
+set_target_properties({{ namespace }} PROPERTIES OUTPUT_NAME "{{ module_name }}")

--- a/src/peakrdl_pybind/templates/cpp/accessors.cpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/accessors.cpp.jinja
@@ -1,0 +1,110 @@
+#include "accessors.hpp"
+
+#include <algorithm>
+
+namespace {{ namespace }} {
+
+namespace {
+
+inline uint64_t make_mask(unsigned width) {
+  if (width >= 64) {
+    return 0xFFFFFFFFFFFFFFFFull;
+  }
+  return (width == 0) ? 0 : ((1ull << width) - 1ull);
+}
+
+inline uint32_t make_wstrb(unsigned bytes) {
+  if (bytes >= SOC_WORD_BYTES) {
+    return (1u << SOC_WORD_BYTES) - 1u;
+  }
+  return (1u << bytes) - 1u;
+}
+
+} // namespace
+
+uint64_t read_register(const RegisterDescriptor& desc, uint64_t address, Master& master, bool access_checks) {
+  enforce_access(desc.access, false, access_checks);
+  const unsigned word_bits = SOC_WORD_BYTES * 8;
+  const unsigned words = (desc.width + word_bits - 1) / word_bits;
+  uint64_t value = 0;
+  for (unsigned i = 0; i < words; ++i) {
+    uint32_t word = master.read32(address + i * SOC_WORD_BYTES);
+    if (SOC_LITTLE_ENDIAN) {
+      value |= static_cast<uint64_t>(word) << (i * word_bits);
+    } else {
+      unsigned shift = (words - i - 1) * word_bits;
+      value |= static_cast<uint64_t>(word) << shift;
+    }
+  }
+  const unsigned width = std::min<unsigned>(desc.width, 64);
+  value &= make_mask(width);
+  return value;
+}
+
+void write_register(const RegisterDescriptor& desc, uint64_t address, Master& master, uint64_t value, bool access_checks) {
+  enforce_access(desc.access, true, access_checks);
+  const unsigned word_bits = SOC_WORD_BYTES * 8;
+  const unsigned words = (desc.width + word_bits - 1) / word_bits;
+  const unsigned width = std::min<unsigned>(desc.width, 64);
+  const uint64_t mask = make_mask(width);
+  value &= mask;
+
+  if (width < word_bits) {
+    uint64_t current = read_register(desc, address, master, false);
+    const uint64_t preserve = ~mask;
+    value = (current & preserve) | (value & mask);
+  }
+
+  for (unsigned i = 0; i < words; ++i) {
+    unsigned shift = SOC_LITTLE_ENDIAN ? i * word_bits : (words - i - 1) * word_bits;
+    uint32_t word = static_cast<uint32_t>((value >> shift) & 0xFFFFFFFFu);
+    unsigned bytes = SOC_WORD_BYTES;
+    if (i == words - 1) {
+      unsigned remaining_bits = desc.width - i * word_bits;
+      if (remaining_bits < word_bits) {
+        bytes = (remaining_bits + 7) / 8;
+      }
+    }
+    master.write32(address + i * SOC_WORD_BYTES, word, make_wstrb(bytes));
+  }
+}
+
+void enforce_access(AccessType access, bool is_write, bool access_checks) {
+  if (!access_checks) {
+    return;
+  }
+  if (is_write) {
+    if (access == AccessType::RO) {
+      throw AccessError("Register is read-only");
+    }
+  } else {
+    if (access == AccessType::WO) {
+      throw AccessError("Register is write-only");
+    }
+  }
+}
+
+void enforce_field_access(AccessType access, bool is_write, bool access_checks) {
+  enforce_access(access, is_write, access_checks);
+}
+
+uint64_t field_mask(const FieldDescriptor& field) {
+  unsigned width = field.msb - field.lsb + 1;
+  return make_mask(width) << field.lsb;
+}
+
+uint64_t set_field_value(uint64_t reg_value, const FieldDescriptor& field, uint64_t field_value) {
+  uint64_t mask = field_mask(field);
+  unsigned width = field.msb - field.lsb + 1;
+  uint64_t clean_value = (field_value & make_mask(width)) << field.lsb;
+  reg_value &= ~mask;
+  reg_value |= clean_value;
+  return reg_value;
+}
+
+uint64_t get_field_value(uint64_t reg_value, const FieldDescriptor& field) {
+  uint64_t mask = field_mask(field);
+  return (reg_value & mask) >> field.lsb;
+}
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/cpp/accessors.hpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/accessors.hpp.jinja
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "master.hpp"
+
+namespace {{ namespace }} {
+
+constexpr unsigned SOC_WORD_BYTES = {{ word_bytes }};
+constexpr bool SOC_LITTLE_ENDIAN = {{ 'true' if little_endian else 'false' }};
+
+class AccessError : public std::runtime_error {
+public:
+  explicit AccessError(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+enum class AccessType {
+  RW,
+  RO,
+  WO,
+  W1C,
+  W0C,
+  W1S,
+  W0S,
+  W1T,
+  W0T
+};
+
+struct FieldDescriptor {
+  const char* name;
+  uint8_t lsb;
+  uint8_t msb;
+  AccessType access;
+  uint32_t reset;
+};
+
+struct RegisterDescriptor {
+  const char* name;
+  const char* path;
+  uint64_t address;
+  uint16_t width;
+  bool volatile_;
+  AccessType access;
+  uint32_t reset;
+  const FieldDescriptor* fields;
+  size_t field_count;
+};
+
+struct RegisterEntry {
+  const char* name;
+  const RegisterDescriptor* descriptor;
+  uint64_t offset;
+};
+
+struct RegisterArrayEntry {
+  const char* name;
+  const RegisterDescriptor* descriptor;
+  size_t count;
+  uint64_t stride;
+  uint64_t offset;
+  const size_t* dimensions;
+  size_t dimension_count;
+};
+
+struct BlockDescriptor;
+
+struct BlockEntry {
+  const char* name;
+  const BlockDescriptor* descriptor;
+  uint64_t offset;
+};
+
+struct BlockArrayEntry {
+  const char* name;
+  const BlockDescriptor* descriptor;
+  size_t count;
+  uint64_t stride;
+  uint64_t offset;
+  const size_t* dimensions;
+  size_t dimension_count;
+};
+
+struct BlockDescriptor {
+  const char* name;
+  uint64_t base_address;
+  const RegisterEntry* registers;
+  size_t register_count;
+  const RegisterArrayEntry* reg_arrays;
+  size_t reg_array_count;
+  const BlockEntry* blocks;
+  size_t block_count;
+  const BlockArrayEntry* block_arrays;
+  size_t block_array_count;
+};
+
+uint64_t read_register(const RegisterDescriptor& desc, uint64_t address, Master& master, bool access_checks);
+void write_register(const RegisterDescriptor& desc, uint64_t address, Master& master, uint64_t value, bool access_checks);
+
+void enforce_access(AccessType access, bool is_write, bool access_checks);
+void enforce_field_access(AccessType access, bool is_write, bool access_checks);
+uint64_t field_mask(const FieldDescriptor& field);
+uint64_t set_field_value(uint64_t reg_value, const FieldDescriptor& field, uint64_t field_value);
+uint64_t get_field_value(uint64_t reg_value, const FieldDescriptor& field);
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/cpp/master.cpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/master.cpp.jinja
@@ -1,0 +1,26 @@
+#include "master.hpp"
+
+namespace {{ namespace }} {
+
+void Master::read_block(uint64_t addr, uint8_t* dst, size_t len) {
+  const unsigned step = word_bytes();
+  for (size_t offset = 0; offset < len; offset += step) {
+    uint32_t value = read32(addr + offset);
+    for (unsigned b = 0; b < step && (offset + b) < len; ++b) {
+      dst[offset + b] = static_cast<uint8_t>((value >> (8 * b)) & 0xFF);
+    }
+  }
+}
+
+void Master::write_block(uint64_t addr, const uint8_t* src, size_t len) {
+  const unsigned step = word_bytes();
+  for (size_t offset = 0; offset < len; offset += step) {
+    uint32_t value = 0;
+    for (unsigned b = 0; b < step && (offset + b) < len; ++b) {
+      value |= static_cast<uint32_t>(src[offset + b]) << (8 * b);
+    }
+    write32(addr + offset, value);
+  }
+}
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/cpp/master.hpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/master.hpp.jinja
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {{ namespace }} {
+
+class Master {
+public:
+  virtual ~Master() = default;
+
+  virtual uint32_t read32(uint64_t addr) = 0;
+  virtual void write32(uint64_t addr, uint32_t data, uint32_t wstrb = 0xF) = 0;
+
+  virtual void read_block(uint64_t addr, uint8_t* dst, size_t len);
+  virtual void write_block(uint64_t addr, const uint8_t* src, size_t len);
+
+  virtual bool little_endian() const { return {{ 'true' if little_endian else 'false' }}; }
+  virtual unsigned word_bytes() const { return {{ word_bytes }}; }
+};
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/cpp/reg_model.cpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/reg_model.cpp.jinja
@@ -1,0 +1,397 @@
+#include "reg_model.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace {{ namespace }} {
+
+namespace {
+
+Master& require_master(std::shared_ptr<Master>* slot) {
+  if (!slot) {
+    throw AccessError("Invalid master slot");
+  }
+  auto& ref = *slot;
+  if (!ref) {
+    throw AccessError("No master attached");
+  }
+  return *ref;
+}
+
+const FieldDescriptor* find_field(const RegisterDescriptor* desc, const std::string& name) {
+  for (size_t i = 0; i < desc->field_count; ++i) {
+    if (name == desc->fields[i].name) {
+      return &desc->fields[i];
+    }
+  }
+  return nullptr;
+}
+
+const RegisterEntry* find_register(const BlockDescriptor* desc, const std::string& name) {
+  for (size_t i = 0; i < desc->register_count; ++i) {
+    if (name == desc->registers[i].name) {
+      return &desc->registers[i];
+    }
+  }
+  return nullptr;
+}
+
+const RegisterArrayEntry* find_register_array(const BlockDescriptor* desc, const std::string& name) {
+  for (size_t i = 0; i < desc->reg_array_count; ++i) {
+    if (name == desc->reg_arrays[i].name) {
+      return &desc->reg_arrays[i];
+    }
+  }
+  return nullptr;
+}
+
+const BlockEntry* find_block(const BlockDescriptor* desc, const std::string& name) {
+  for (size_t i = 0; i < desc->block_count; ++i) {
+    if (name == desc->blocks[i].name) {
+      return &desc->blocks[i];
+    }
+  }
+  return nullptr;
+}
+
+const BlockArrayEntry* find_block_array(const BlockDescriptor* desc, const std::string& name) {
+  for (size_t i = 0; i < desc->block_array_count; ++i) {
+    if (name == desc->block_arrays[i].name) {
+      return &desc->block_arrays[i];
+    }
+  }
+  return nullptr;
+}
+
+std::vector<size_t> dimensions_from_entry(const size_t* dims, size_t count) {
+  if (!dims) {
+    return {};
+  }
+  std::vector<size_t> result;
+  result.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    result.push_back(dims[i]);
+  }
+  return result;
+}
+
+} // namespace
+
+FieldProxy::FieldProxy(const RegisterDescriptor* reg, const FieldDescriptor* field, uint64_t address, std::shared_ptr<Master>* master_slot, bool access_checks)
+    : reg_(reg), field_(field), address_(address), master_slot_(master_slot), access_checks_(access_checks) {}
+
+uint64_t FieldProxy::get() const {
+  auto& master = require_master(master_slot_);
+  uint64_t reg_value = read_register(*reg_, address_, master, access_checks_);
+  return get_field_value(reg_value, *field_);
+}
+
+void FieldProxy::set(uint64_t value) const {
+  enforce_field_access(field_->access, true, access_checks_);
+  auto& master = require_master(master_slot_);
+  uint64_t reg_value = read_register(*reg_, address_, master, false);
+  reg_value = set_field_value(reg_value, *field_, value);
+  write_register(*reg_, address_, master, reg_value, false);
+}
+
+RegisterProxy::RegisterProxy(const RegisterDescriptor* desc, uint64_t address, std::shared_ptr<Master>* master_slot, bool access_checks)
+    : descriptor_(desc), address_(address), master_slot_(master_slot), access_checks_(access_checks) {}
+
+uint64_t RegisterProxy::read() const {
+  auto& master = require_master(master_slot_);
+  return read_register(*descriptor_, address_, master, access_checks_);
+}
+
+void RegisterProxy::write(uint64_t value) const {
+  auto& master = require_master(master_slot_);
+  write_register(*descriptor_, address_, master, value, access_checks_);
+}
+
+void RegisterProxy::set_bits(uint64_t mask) const {
+  auto& master = require_master(master_slot_);
+  uint64_t value = read_register(*descriptor_, address_, master, false);
+  value |= mask;
+  write_register(*descriptor_, address_, master, value, false);
+}
+
+void RegisterProxy::clear_bits(uint64_t mask) const {
+  auto& master = require_master(master_slot_);
+  uint64_t value = read_register(*descriptor_, address_, master, false);
+  value &= ~mask;
+  write_register(*descriptor_, address_, master, value, false);
+}
+
+void RegisterProxy::modify(pybind11::kwargs kwargs) const {
+  if (kwargs.size() == 0) {
+    return;
+  }
+  auto& master = require_master(master_slot_);
+  uint64_t value = read_register(*descriptor_, address_, master, false);
+  for (auto& item : kwargs) {
+    std::string key = py::cast<std::string>(item.first);
+    const FieldDescriptor* field = find_field(descriptor_, key);
+    if (!field) {
+      throw py::key_error("Unknown field: " + key);
+    }
+    enforce_field_access(field->access, true, access_checks_);
+    uint64_t field_value = py::cast<uint64_t>(item.second);
+    value = set_field_value(value, *field, field_value);
+  }
+  write_register(*descriptor_, address_, master, value, false);
+}
+
+FieldProxy RegisterProxy::field(const std::string& name) const {
+  const FieldDescriptor* field = find_field(descriptor_, name);
+  if (!field) {
+    throw py::attribute_error("Register has no field named '" + name + "'");
+  }
+  return FieldProxy(descriptor_, field, address_, master_slot_, access_checks_);
+}
+
+std::vector<std::string> RegisterProxy::field_names() const {
+  std::vector<std::string> names;
+  names.reserve(descriptor_->field_count);
+  for (size_t i = 0; i < descriptor_->field_count; ++i) {
+    names.emplace_back(descriptor_->fields[i].name);
+  }
+  return names;
+}
+
+RegisterArrayProxy::RegisterArrayProxy(const RegisterDescriptor* desc, uint64_t address, size_t count, uint64_t stride, std::vector<size_t> dims, std::shared_ptr<Master>* master_slot, bool access_checks)
+    : descriptor_(desc), address_(address), count_(count), stride_(stride), dims_(std::move(dims)), master_slot_(master_slot), access_checks_(access_checks) {}
+
+RegisterProxy RegisterArrayProxy::at(size_t index) const {
+  if (index >= count_) {
+    throw py::index_error("Register array index out of range");
+  }
+  return RegisterProxy(descriptor_, address_ + index * stride_, master_slot_, access_checks_);
+}
+
+BlockProxy::BlockProxy(const BlockDescriptor* desc, uint64_t base, std::shared_ptr<Master>* master_slot, bool access_checks)
+    : descriptor_(desc), base_(base), master_slot_(master_slot), access_checks_(access_checks) {}
+
+RegisterProxy BlockProxy::register_at(size_t index) const {
+  if (index >= descriptor_->register_count) {
+    throw py::index_error("Register index out of range");
+  }
+  const auto& entry = descriptor_->registers[index];
+  return RegisterProxy(entry.descriptor, base_ + entry.offset, master_slot_, access_checks_);
+}
+
+RegisterProxy BlockProxy::register_named(const std::string& name) const {
+  const RegisterEntry* entry = find_register(descriptor_, name);
+  if (!entry) {
+    throw py::attribute_error("Unknown register: " + name);
+  }
+  return RegisterProxy(entry->descriptor, base_ + entry->offset, master_slot_, access_checks_);
+}
+
+RegisterArrayProxy BlockProxy::reg_array_named(const std::string& name) const {
+  const RegisterArrayEntry* entry = find_register_array(descriptor_, name);
+  if (!entry) {
+    throw py::attribute_error("Unknown register array: " + name);
+  }
+  auto dims = dimensions_from_entry(entry->dimensions, entry->dimension_count);
+  return RegisterArrayProxy(entry->descriptor, base_ + entry->offset, entry->count, entry->stride, std::move(dims), master_slot_, access_checks_);
+}
+
+BlockProxy BlockProxy::block_named(const std::string& name) const {
+  const BlockEntry* entry = find_block(descriptor_, name);
+  if (!entry) {
+    throw py::attribute_error("Unknown block: " + name);
+  }
+  return BlockProxy(entry->descriptor, base_ + entry->offset, master_slot_, access_checks_);
+}
+
+BlockArrayProxy BlockProxy::block_array_named(const std::string& name) const {
+  const BlockArrayEntry* entry = find_block_array(descriptor_, name);
+  if (!entry) {
+    throw py::attribute_error("Unknown block array: " + name);
+  }
+  auto dims = dimensions_from_entry(entry->dimensions, entry->dimension_count);
+  return BlockArrayProxy(entry->descriptor, base_ + entry->offset, entry->count, entry->stride, std::move(dims), master_slot_, access_checks_);
+}
+
+BlockArrayProxy::BlockArrayProxy(const BlockDescriptor* desc, uint64_t base, size_t count, uint64_t stride, std::vector<size_t> dims, std::shared_ptr<Master>* master_slot, bool access_checks)
+    : descriptor_(desc), base_(base), count_(count), stride_(stride), dims_(std::move(dims)), master_slot_(master_slot), access_checks_(access_checks) {}
+
+BlockProxy BlockArrayProxy::at(size_t index) const {
+  if (index >= count_) {
+    throw py::index_error("Block array index out of range");
+  }
+  return BlockProxy(descriptor_, base_ + index * stride_, master_slot_, access_checks_);
+}
+
+} // namespace {{ namespace }}
+
+{% macro access_enum(access) -%}
+AccessType::{{ access|upper }}
+{%- endmacro %}
+
+{% macro field_array_name(reg) -%}
+{{ reg.path|replace('.', '_')|c_ident }}_fields
+{%- endmacro %}
+
+{% macro register_name(reg) -%}
+{{ reg.path|replace('.', '_')|c_ident }}
+{%- endmacro %}
+
+{% macro block_name(block) -%}
+{{ block.path|replace('.', '_')|c_ident }}
+{%- endmacro %}
+
+{% macro emit_register(reg) -%}
+{% set fid = field_array_name(reg) %}
+static const FieldDescriptor {{ fid }}[] = {
+  {%- for field in reg.fields %}
+  {"{{ field.name }}", {{ field.lsb }}, {{ field.msb }}, {{ access_enum(field.access) }}, {{ field.reset if field.reset is not none else 0 }}},
+  {%- endfor %}
+};
+static const RegisterDescriptor {{ register_name(reg) }}_desc = {
+  "{{ reg.name }}",
+  "{{ reg.path }}",
+  {{ reg.absolute_address }},
+  {{ reg.width }},
+  {{ 'true' if reg.volatile else 'false' }},
+  {{ access_enum(reg.access) }},
+  {{ reg.reset if reg.reset is not none else 0 }},
+  {{ fid }},
+  {{ reg.fields|length }}
+};
+{%- endmacro %}
+
+// Descriptor tables generated below.
+{% macro emit_block_tables(block) -%}
+{% set bid = block_name(block) %}
+{% for child in block.blocks %}
+{{ emit_block_tables(child) }}
+{% endfor %}
+{% for reg in block.registers %}
+{{ emit_register(reg) }}
+{% endfor %}
+{% set array_regs = block.registers | selectattr('is_array') | list %}
+{% for reg in array_regs %}
+{% set rid = register_name(reg) %}
+{% if reg.array_dimensions %}
+static const size_t {{ rid }}_dims[] = { {{ reg.array_dimensions|join(', ') }} };
+{% endif %}
+{% endfor %}
+{% set block_arrays = block.blocks | selectattr('is_array') | list %}
+{% for child in block_arrays %}
+{% set cid = block_name(child) %}
+{% if child.array_dimensions %}
+static const size_t {{ cid }}_dims[] = { {{ child.array_dimensions|join(', ') }} };
+{% endif %}
+{% endfor %}
+{% set single_regs = block.registers | selectattr('is_array', 'equalto', False) | list %}
+{% if single_regs %}
+static const RegisterEntry {{ bid }}_registers[] = {
+  {%- for reg in single_regs %}
+  { "{{ reg.name }}", &{{ register_name(reg) }}_desc, {{ reg.absolute_address - block.absolute_address }} },
+  {%- endfor %}
+};
+{% endif %}
+{% if array_regs %}
+static const RegisterArrayEntry {{ bid }}_reg_arrays[] = {
+  {%- for reg in array_regs %}
+  { "{{ reg.name }}", &{{ register_name(reg) }}_desc, {{ reg.element_count }}, {{ reg.stride }}, {{ reg.absolute_address - block.absolute_address }}, {% if reg.array_dimensions %}{{ register_name(reg) }}_dims{% else %}nullptr{% endif %}, {{ reg.array_dimensions|length }} },
+  {%- endfor %}
+};
+{% endif %}
+{% set block_entries = block.blocks | selectattr('is_array', 'equalto', False) | list %}
+{% if block_entries %}
+static const BlockEntry {{ bid }}_blocks[] = {
+  {%- for child in block_entries %}
+  { "{{ child.name }}", &{{ block_name(child) }}_desc, {{ child.absolute_address - block.absolute_address }} },
+  {%- endfor %}
+};
+{% endif %}
+{% if block_arrays %}
+static const BlockArrayEntry {{ bid }}_block_arrays[] = {
+  {%- for child in block_arrays %}
+  { "{{ child.name }}", &{{ block_name(child) }}_desc, {{ child.array_dimensions|product }}, {{ child.stride if child.stride is not none else 0 }}, {{ child.absolute_address - block.absolute_address }}, {% if child.array_dimensions %}{{ block_name(child) }}_dims{% else %}nullptr{% endif %}, {{ child.array_dimensions|length }} },
+  {%- endfor %}
+};
+{% endif %}
+static const BlockDescriptor {{ bid }}_desc = {
+  "{{ block.name }}",
+  {{ block.absolute_address }},
+  {% if single_regs %}{{ bid }}_registers{% else %}nullptr{% endif %},
+  {{ single_regs|length }},
+  {% if array_regs %}{{ bid }}_reg_arrays{% else %}nullptr{% endif %},
+  {{ array_regs|length }},
+  {% if block_entries %}{{ bid }}_blocks{% else %}nullptr{% endif %},
+  {{ block_entries|length }},
+  {% if block_arrays %}{{ bid }}_block_arrays{% else %}nullptr{% endif %},
+  {{ block_arrays|length }}
+};
+{% endmacro %}
+
+{{ emit_block_tables(soc.top) }}
+
+void bind_reg_model(pybind11::module_& m, std::shared_ptr<Master>* master_slot, const BlockDescriptor* top_block, bool access_checks) {
+  py::register_exception<AccessError>(m, "AccessError");
+
+  py::class_<FieldProxy>(m, "Field")
+      .def("get", &FieldProxy::get)
+      .def("set", &FieldProxy::set, py::arg("value"))
+      .def_property_readonly("lsb", &FieldProxy::lsb)
+      .def_property_readonly("msb", &FieldProxy::msb)
+      .def_property_readonly("name", &FieldProxy::name)
+      .def_property_readonly("access", [](const FieldProxy& self) { return static_cast<int>(self.access()); });
+
+  py::class_<RegisterProxy>(m, "Register")
+      .def("read", &RegisterProxy::read)
+      .def("write", &RegisterProxy::write, py::arg("value"))
+      .def("set_bits", &RegisterProxy::set_bits, py::arg("mask"))
+      .def("clear_bits", &RegisterProxy::clear_bits, py::arg("mask"))
+      .def("modify", &RegisterProxy::modify)
+      .def("field", &RegisterProxy::field, py::arg("name"))
+      .def_property_readonly("fields", &RegisterProxy::field_names)
+      .def_property_readonly("address", &RegisterProxy::address)
+      .def_property_readonly("width", &RegisterProxy::width)
+      .def_property_readonly("reset", &RegisterProxy::reset)
+      .def_property_readonly("path", &RegisterProxy::path)
+      .def_property_readonly("volatile", &RegisterProxy::is_volatile)
+      .def("__getattr__", [](const RegisterProxy& self, const std::string& name) { return self.field(name); });
+
+  py::class_<RegisterArrayProxy>(m, "RegisterArray")
+      .def("__len__", &RegisterArrayProxy::size)
+      .def("__getitem__", &RegisterArrayProxy::at)
+      .def_property_readonly("dimensions", &RegisterArrayProxy::dimensions);
+
+  py::class_<BlockProxy>(m, "Block")
+      .def("register", &BlockProxy::register_named, py::arg("name"))
+      .def("register_array", &BlockProxy::reg_array_named, py::arg("name"))
+      .def("block", &BlockProxy::block_named, py::arg("name"))
+      .def("block_array", &BlockProxy::block_array_named, py::arg("name"))
+      .def_property_readonly("base_address", &BlockProxy::base_address)
+      .def("__getattr__", [](const BlockProxy& self, const std::string& name) -> py::object {
+        auto* desc = self.descriptor();
+        if (find_register(desc, name)) {
+          return py::cast(self.register_named(name));
+        }
+        if (find_register_array(desc, name)) {
+          return py::cast(self.reg_array_named(name));
+        }
+        if (find_block(desc, name)) {
+          return py::cast(self.block_named(name));
+        }
+        if (find_block_array(desc, name)) {
+          return py::cast(self.block_array_named(name));
+        }
+        throw py::attribute_error("Unknown attribute: " + name);
+      });
+
+  py::class_<BlockArrayProxy>(m, "BlockArray")
+      .def("__len__", &BlockArrayProxy::size)
+      .def("__getitem__", &BlockArrayProxy::at)
+      .def_property_readonly("dimensions", &BlockArrayProxy::dimensions);
+
+  m.attr("top") = BlockProxy(top_block, top_block->base_address, master_slot, access_checks);
+}
+
+} // namespace {{ module_name }}

--- a/src/peakrdl_pybind/templates/cpp/reg_model.hpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/reg_model.hpp.jinja
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "accessors.hpp"
+
+namespace {{ namespace }} {
+
+class FieldProxy {
+public:
+  FieldProxy(const RegisterDescriptor* reg, const FieldDescriptor* field, uint64_t address, std::shared_ptr<Master>* master_slot, bool access_checks);
+
+  uint64_t get() const;
+  void set(uint64_t value) const;
+  const char* name() const { return field_->name; }
+  uint8_t lsb() const { return field_->lsb; }
+  uint8_t msb() const { return field_->msb; }
+  AccessType access() const { return field_->access; }
+
+private:
+  const RegisterDescriptor* reg_;
+  const FieldDescriptor* field_;
+  uint64_t address_;
+  std::shared_ptr<Master>* master_slot_;
+  bool access_checks_;
+};
+
+class RegisterProxy {
+public:
+  RegisterProxy(const RegisterDescriptor* desc, uint64_t address, std::shared_ptr<Master>* master_slot, bool access_checks);
+
+  uint64_t read() const;
+  void write(uint64_t value) const;
+  void set_bits(uint64_t mask) const;
+  void clear_bits(uint64_t mask) const;
+  void modify(pybind11::kwargs kwargs) const;
+  uint64_t address() const { return address_; }
+  uint16_t width() const { return descriptor_->width; }
+  uint32_t reset() const { return descriptor_->reset; }
+  const char* path() const { return descriptor_->path; }
+  bool is_volatile() const { return descriptor_->volatile_; }
+
+  FieldProxy field(const std::string& name) const;
+  std::vector<std::string> field_names() const;
+
+private:
+  const RegisterDescriptor* descriptor_;
+  uint64_t address_;
+  std::shared_ptr<Master>* master_slot_;
+  bool access_checks_;
+};
+
+class RegisterArrayProxy {
+public:
+  RegisterArrayProxy(const RegisterDescriptor* desc, uint64_t address, size_t count, uint64_t stride, std::vector<size_t> dims, std::shared_ptr<Master>* master_slot, bool access_checks);
+  RegisterProxy at(size_t index) const;
+  size_t size() const { return count_; }
+  const std::vector<size_t>& dimensions() const { return dims_; }
+
+private:
+  const RegisterDescriptor* descriptor_;
+  uint64_t address_;
+  size_t count_;
+  uint64_t stride_;
+  std::vector<size_t> dims_;
+  std::shared_ptr<Master>* master_slot_;
+  bool access_checks_;
+};
+
+class BlockProxy {
+public:
+  BlockProxy(const BlockDescriptor* desc, uint64_t base, std::shared_ptr<Master>* master_slot, bool access_checks);
+
+  RegisterProxy register_at(size_t index) const;
+  RegisterProxy register_named(const std::string& name) const;
+  RegisterArrayProxy reg_array_named(const std::string& name) const;
+  BlockProxy block_named(const std::string& name) const;
+  class BlockArrayProxy block_array_named(const std::string& name) const;
+  uint64_t base_address() const { return base_; }
+  const BlockDescriptor* descriptor() const { return descriptor_; }
+
+private:
+  const BlockDescriptor* descriptor_;
+  uint64_t base_;
+  std::shared_ptr<Master>* master_slot_;
+  bool access_checks_;
+};
+
+class BlockArrayProxy {
+public:
+  BlockArrayProxy(const BlockDescriptor* desc, uint64_t base, size_t count, uint64_t stride, std::vector<size_t> dims, std::shared_ptr<Master>* master_slot, bool access_checks);
+  BlockProxy at(size_t index) const;
+  size_t size() const { return count_; }
+  const std::vector<size_t>& dimensions() const { return dims_; }
+
+private:
+  const BlockDescriptor* descriptor_;
+  uint64_t base_;
+  size_t count_;
+  uint64_t stride_;
+  std::vector<size_t> dims_;
+  std::shared_ptr<Master>* master_slot_;
+  bool access_checks_;
+};
+
+void bind_reg_model(pybind11::module_& m, std::shared_ptr<Master>* master_slot, const BlockDescriptor* top_block, bool access_checks);
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/cpp/soc_module.cpp.jinja
+++ b/src/peakrdl_pybind/templates/cpp/soc_module.cpp.jinja
@@ -1,0 +1,36 @@
+#include <memory>
+
+#include <pybind11/pybind11.h>
+
+#include "master.hpp"
+#include "reg_model.hpp"
+
+namespace py = pybind11;
+
+namespace {{ namespace }} {
+
+static std::shared_ptr<Master> g_master;
+
+static std::shared_ptr<Master>* master_slot() {
+  return &g_master;
+}
+
+} // namespace {{ namespace }}
+
+PYBIND11_MODULE({{ module_name }}, m) {
+  m.doc() = "Auto-generated register bindings";
+
+  py::class_<{{ namespace }}::Master, std::shared_ptr<{{ namespace }}::Master>>(m, "Master")
+      .def("read32", &{{ namespace }}::Master::read32)
+      .def("write32", &{{ namespace }}::Master::write32, py::arg("addr"), py::arg("data"), py::arg("wstrb") = 0xF)
+      .def("read_block", &{{ namespace }}::Master::read_block, py::arg("addr"), py::arg("dst"), py::arg("length"))
+      .def("write_block", &{{ namespace }}::Master::write_block, py::arg("addr"), py::arg("src"), py::arg("length"))
+      .def("little_endian", &{{ namespace }}::Master::little_endian)
+      .def("word_bytes", &{{ namespace }}::Master::word_bytes);
+
+  m.def("attach_master", [](std::shared_ptr<{{ namespace }}::Master> master) {
+    {{ namespace }}::g_master = std::move(master);
+  });
+
+  {{ namespace }}::bind_reg_model(m, {{ namespace }}::master_slot(), &{{ top_descriptor }}, {{ 'true' if access_checks else 'false' }});
+}

--- a/src/peakrdl_pybind/templates/masters/openocd_master.cpp.jinja
+++ b/src/peakrdl_pybind/templates/masters/openocd_master.cpp.jinja
@@ -1,0 +1,36 @@
+#include <array>
+#include <stdexcept>
+#include <string>
+
+#include "master.hpp"
+
+namespace {{ namespace }} {
+
+class OpenOCDMaster : public Master {
+public:
+  OpenOCDMaster(std::string host, int port);
+  ~OpenOCDMaster();
+
+  uint32_t read32(uint64_t addr) override;
+  void write32(uint64_t addr, uint32_t data, uint32_t wstrb = 0xF) override;
+
+private:
+  std::string host_;
+  int port_;
+};
+
+OpenOCDMaster::OpenOCDMaster(std::string host, int port) : host_(std::move(host)), port_(port) {}
+OpenOCDMaster::~OpenOCDMaster() = default;
+
+uint32_t OpenOCDMaster::read32(uint64_t addr) {
+  throw std::runtime_error("OpenOCD master example is not implemented");
+}
+
+void OpenOCDMaster::write32(uint64_t addr, uint32_t data, uint32_t wstrb) {
+  (void)addr;
+  (void)data;
+  (void)wstrb;
+  throw std::runtime_error("OpenOCD master example is not implemented");
+}
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/masters/ssh_devmem_master.cpp.jinja
+++ b/src/peakrdl_pybind/templates/masters/ssh_devmem_master.cpp.jinja
@@ -1,0 +1,34 @@
+#include <stdexcept>
+#include <string>
+
+#include "master.hpp"
+
+namespace {{ namespace }} {
+
+class SSHDevmemMaster : public Master {
+public:
+  SSHDevmemMaster(std::string host, std::string user);
+
+  uint32_t read32(uint64_t addr) override;
+  void write32(uint64_t addr, uint32_t data, uint32_t wstrb = 0xF) override;
+
+private:
+  std::string host_;
+  std::string user_;
+};
+
+SSHDevmemMaster::SSHDevmemMaster(std::string host, std::string user) : host_(std::move(host)), user_(std::move(user)) {}
+
+uint32_t SSHDevmemMaster::read32(uint64_t addr) {
+  (void)addr;
+  throw std::runtime_error("SSH devmem master example is not implemented");
+}
+
+void SSHDevmemMaster::write32(uint64_t addr, uint32_t data, uint32_t wstrb) {
+  (void)addr;
+  (void)data;
+  (void)wstrb;
+  throw std::runtime_error("SSH devmem master example is not implemented");
+}
+
+} // namespace {{ namespace }}

--- a/src/peakrdl_pybind/templates/pyproject.toml.jinja
+++ b/src/peakrdl_pybind/templates/pyproject.toml.jinja
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["scikit-build-core>=0.5", "pybind11", "setuptools"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "{{ module_name }}"
+version = "0.1.0"
+description = "Auto-generated register bindings"
+requires-python = ">=3.9"
+
+[tool.scikit-build]
+build-dir = "build"
+
+[tool.scikit-build.cmake]
+args = ["-DPYBIND11_FINDPYTHON=ON"]

--- a/src/peakrdl_pybind/templates/typing/soc.pyi.jinja
+++ b/src/peakrdl_pybind/templates/typing/soc.pyi.jinja
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator, Protocol
+
+class Master(Protocol):
+    def read32(self, addr: int) -> int: ...
+    def write32(self, addr: int, data: int, wstrb: int = ...) -> None: ...
+    def read_block(self, addr: int, dst: bytearray, length: int) -> None: ...
+    def write_block(self, addr: int, src: bytes, length: int) -> None: ...
+    def little_endian(self) -> bool: ...
+    def word_bytes(self) -> int: ...
+
+def attach_master(master: Master) -> None: ...
+
+class Field:
+    name: str
+    lsb: int
+    msb: int
+    def get(self) -> int: ...
+    def set(self, value: int) -> None: ...
+
+class Register:
+    path: str
+    address: int
+    width: int
+    reset: int
+    volatile: bool
+    def read(self) -> int: ...
+    def write(self, value: int) -> None: ...
+    def set_bits(self, mask: int) -> None: ...
+    def clear_bits(self, mask: int) -> None: ...
+    def modify(self, **fields: int) -> None: ...
+    def field(self, name: str) -> Field: ...
+
+class RegisterArray:
+    def __len__(self) -> int: ...
+    def __getitem__(self, idx: int) -> Register: ...
+    @property
+    def dimensions(self) -> tuple[int, ...]: ...
+
+class Block:
+    base_address: int
+    def register(self, name: str) -> Register: ...
+    def register_array(self, name: str) -> RegisterArray: ...
+    def block(self, name: str) -> Block: ...
+    def block_array(self, name: str) -> BlockArray: ...
+
+class BlockArray:
+    def __len__(self) -> int: ...
+    def __getitem__(self, idx: int) -> Block: ...
+    @property
+    def dimensions(self) -> tuple[int, ...]: ...
+
+{% macro block_class_name(block) -%}
+{{ block.path|replace('.', '_')|camel }}Block
+{%- endmacro %}
+
+{% macro emit_block_stub(block) -%}
+class {{ block_class_name(block) }}(Block):
+{% set single_regs = block.registers | selectattr('is_array', 'equalto', False) | list %}
+{% set array_regs = block.registers | selectattr('is_array') | list %}
+{% set single_blocks = block.blocks | selectattr('is_array', 'equalto', False) | list %}
+{% set block_arrays = block.blocks | selectattr('is_array') | list %}
+{%- if not single_regs and not array_regs and not single_blocks and not block_arrays %}
+    ...
+{%- else %}
+{% for reg in single_regs %}
+    {{ reg.name|c_ident }}: Register
+{% endfor %}
+{% for reg in array_regs %}
+    {{ reg.name|c_ident }}: RegisterArray
+{% endfor %}
+{% for child in single_blocks %}
+    {{ child.name|c_ident }}: {{ block_class_name(child) }}
+{% endfor %}
+{% for child in block_arrays %}
+    {{ child.name|c_ident }}: BlockArray
+{% endfor %}
+{%- endif %}
+{% for child in block.blocks %}
+{{ emit_block_stub(child) }}
+{% endfor %}
+{%- endmacro %}
+
+{{ emit_block_stub(soc.top) }}
+
+top: {{ block_class_name(soc.top) }}

--- a/tests/test_ir_builder.py
+++ b/tests/test_ir_builder.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+pytest.importorskip("jinja2")
+
+from peakrdl_pybind.backend import PyBindBackend, PyBindOptions
+from peakrdl_pybind.ir import IRBuilder
+
+
+@dataclass
+class MockField:
+    inst_name: str
+    lsb: int
+    msb: int
+    reset: int
+    access: str = "rw"
+
+    def get_property(self, name: str):
+        if name == "reset":
+            return self.reset
+        if name == "sw":
+            return self.access
+        if name == "desc":
+            return f"Field {self.inst_name}"
+        return None
+
+
+class MockRegister:
+    def __init__(self, inst_name: str, address: int, width: int, fields, *, array_dimensions=None, stride=None):
+        self.inst_name = inst_name
+        self.absolute_address = address
+        self.width = width
+        self._fields = list(fields)
+        self.array_dimensions = array_dimensions
+        self.array_stride = stride
+
+    def get_property(self, name: str):
+        if name == "reset":
+            return 0
+        if name == "sw":
+            return "rw"
+        if name == "desc":
+            return f"Register {self.inst_name}"
+        if name == "volatile":
+            return False
+        return None
+
+    def fields(self):
+        return list(self._fields)
+
+
+class MockBlock:
+    def __init__(self, inst_name: str, address: int, *, registers=None, blocks=None, array_dimensions=None, stride=None):
+        self.inst_name = inst_name
+        self.absolute_address = address
+        self._registers = list(registers or [])
+        self._blocks = list(blocks or [])
+        self.array_dimensions = array_dimensions
+        self.array_stride = stride
+
+    def children(self):
+        return [*self._registers, *self._blocks]
+
+    def get_property(self, name: str):
+        if name == "desc":
+            return f"Block {self.inst_name}"
+        return None
+
+
+@pytest.fixture
+def mock_design():
+    lcr = MockRegister(
+        "LCR",
+        address=0x1000,
+        width=8,
+        fields=[MockField("DLAB", 7, 7, 0), MockField("WLS", 0, 1, 3)],
+    )
+    uart_reg = MockRegister(
+        "CTRL",
+        address=0x2000,
+        width=32,
+        fields=[MockField("enable", 0, 0, 0)],
+    )
+    timer_array = MockRegister(
+        "TIMER",
+        address=0x3000,
+        width=16,
+        fields=[MockField("value", 0, 7, 0)],
+        array_dimensions=(2,),
+        stride=4,
+    )
+    uart_block = MockBlock(
+        "uart",
+        address=0x2000,
+        registers=[uart_reg],
+        array_dimensions=(4,),
+        stride=0x100,
+    )
+    top = MockBlock("top", address=0, registers=[lcr, timer_array], blocks=[uart_block])
+    return top
+
+
+def test_ir_builder_collects_registers(mock_design):
+    builder = IRBuilder(word_bytes=4, little_endian=True)
+    soc = builder.build(mock_design, soc_name="aurora", namespace="soc_aurora")
+
+    assert soc.top.name == "top"
+    singles = [reg for reg in soc.top.registers if not reg.is_array]
+    arrays = [reg for reg in soc.top.registers if reg.is_array]
+    assert len(singles) == 1
+    lcr = singles[0]
+    assert lcr.name == "LCR"
+    assert lcr.fields[0].name == "DLAB"
+    assert len(arrays) == 1
+    assert arrays[0].name == "TIMER"
+    assert arrays[0].array_dimensions == (2,)
+    assert soc.top.blocks[0].name == "uart"
+    assert soc.top.blocks[0].array_dimensions == (4,)
+
+
+def test_backend_renders_expected_files(tmp_path: Path, mock_design):
+    out_dir = tmp_path / "aurora"
+    opts = PyBindOptions(
+        soc_name="aurora",
+        namespace="aurora",
+        out_dir=out_dir,
+        word_bytes=4,
+        little_endian=True,
+        gen_pyi=True,
+        with_examples=True,
+        access_checks=True,
+        emit_reset_writes=False,
+    )
+
+    backend = PyBindBackend()
+    backend.run(mock_design, opts)
+
+    expected = [
+        out_dir / "cpp" / "master.hpp",
+        out_dir / "cpp" / "reg_model.cpp",
+        out_dir / "cpp" / "soc_module.cpp",
+        out_dir / "pyproject.toml",
+        out_dir / "CMakeLists.txt",
+        out_dir / "typing" / "aurora.pyi",
+        out_dir / "masters" / "openocd_master.cpp",
+    ]
+    for path in expected:
+        assert path.exists(), f"Expected generated file {path}"
+
+    content = (out_dir / "cpp" / "soc_module.cpp").read_text()
+    assert "PYBIND11_MODULE" in content


### PR DESCRIPTION
## Summary
- implement the peakrdl-pybind backend, CLI, and templating infrastructure for generating PyBind11 register bindings
- add documentation, project metadata, and example templates for masters and typing stubs
- include unit tests that exercise the IR builder and ensure the backend renders core files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f5721c32f88325bf216e604ac56ee4