### PR TITLE
Initialize PyBind backend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# PeakRDL PyBind Backend
+
+This repository provides the `peakrdl-pybind` backend for the
+[SystemRDL compiler](https://systemrdl-compiler.readthedocs.io/). The backend
+turns a SystemRDL description into a C++/PyBind11 extension module that can be
+imported from Python tests to perform register accesses through a pluggable
+*Master* interface.
+
+The project is currently under development. The initial goal is to provide a
+solid skeleton for the backend, including the command-line interface, template
+rendering pipeline, and basic documentation.
+
+## Development environment
+
+Install the package in editable mode with the optional testing dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[test]'
+```
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+## Command Line Interface
+
+The backend exposes a `peakrdl-pybind` command that wraps the backend entry
+point. The command mirrors the options described in the engineering
+specification and acts as a friendly shim around the SystemRDL compiler.
+
+## Templates
+
+The `src/peakrdl_pybind/templates` directory contains Jinja2 templates used to
+render the generated C++ sources, build system files, and optional Python typing
+stubs.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "peakrdl-pybind"
+version = "0.1.0"
+description = "PeakRDL backend that generates PyBind11 register access modules"
+readme = "README.md"
+authors = [
+  { name = "PeakRDL PyBind Contributors" }
+]
+license = { file = "LICENSE" }
+requires-python = ">=3.9"
+dependencies = [
+  "systemrdl-compiler>=1.25",
+  "jinja2>=3.1",
+  "click>=8",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=7",
+]
+
+[project.scripts]
+peakrdl-pybind = "peakrdl_pybind.cli:main"
+
+[project.entry-points."systemrdl_backends"]
+peakrdl_pybind = "peakrdl_pybind.backend:PyBindBackend"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"peakrdl_pybind" = ["templates/*.jinja"]

--- a/src/peakrdl_pybind/__init__.py
+++ b/src/peakrdl_pybind/__init__.py
@@ -1,0 +1,5 @@
+"""PeakRDL backend that emits PyBind11-based register access modules."""
+
+from .backend import PyBindBackend
+
+__all__ = ["PyBindBackend"]

--- a/src/peakrdl_pybind/backend.py
+++ b/src/peakrdl_pybind/backend.py
@@ -1,0 +1,143 @@
+"""Backend implementation for generating PyBind11-based register models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from systemrdl.node import AddrmapNode, FieldNode, Node
+else:  # pragma: no cover - runtime fallback when SystemRDL is unavailable
+    AddrmapNode = Any  # type: ignore[assignment]
+    FieldNode = Any  # type: ignore[assignment]
+    Node = Any  # type: ignore[assignment]
+
+
+@dataclass
+class FieldInfo:
+    """Description of a single field extracted from the SystemRDL AST."""
+
+    name: str
+    lsb: int
+    msb: int
+    access: str
+    reset: Optional[int]
+
+
+@dataclass
+class RegisterInfo:
+    """Description of a register and its fields."""
+
+    name: str
+    path: str
+    absolute_address: int
+    width: int
+    reset: Optional[int]
+    access: str
+    volatile: bool
+    fields: List[FieldInfo] = field(default_factory=list)
+
+
+@dataclass
+class BackendOptions:
+    """Normalized backend options passed from the CLI/backend API."""
+
+    soc_name: str
+    output: Path
+    word_bytes: int = 4
+    little_endian: bool = True
+    generate_examples: bool = False
+    generate_pyi: bool = False
+    namespace: Optional[str] = None
+    no_access_checks: bool = False
+    emit_reset_writes: bool = False
+
+
+class PyBindBackend:
+    """PeakRDL backend that renders a PyBind11-based register model."""
+
+    short_desc = "Generate a PyBind11 backed Python module"
+
+    def __init__(self) -> None:
+        templates_path = Path(__file__).parent / "templates"
+        self._environment = Environment(
+            loader=FileSystemLoader(str(templates_path)),
+            trim_blocks=True,
+            lstrip_blocks=True,
+            undefined=StrictUndefined,
+        )
+
+    # -- Backend API -----------------------------------------------------
+    def build(self, node: AddrmapNode, output_dir: str, **kwargs: object) -> None:
+        """Entry point used by the SystemRDL compiler."""
+
+        options = self._parse_options(output_dir, **kwargs)
+        registers = list(self._collect_registers(node))
+        context = {
+            "options": options,
+            "registers": registers,
+        }
+        self._render_templates(options.output, context)
+
+    # -- Internal helpers ------------------------------------------------
+    def _parse_options(self, output_dir: str, **kwargs: object) -> BackendOptions:
+        if "soc_name" not in kwargs:
+            raise ValueError("soc_name option is required")
+        namespace = kwargs.get("namespace")
+        options = BackendOptions(
+            soc_name=str(kwargs["soc_name"]),
+            output=Path(output_dir),
+            word_bytes=int(kwargs.get("word_bytes", 4)),
+            little_endian=bool(kwargs.get("little_endian", True)),
+            generate_examples=bool(kwargs.get("with_examples", False)),
+            generate_pyi=bool(kwargs.get("gen_pyi", False)),
+            namespace=str(namespace) if namespace else None,
+            no_access_checks=bool(kwargs.get("no_access_checks", False)),
+            emit_reset_writes=bool(kwargs.get("emit_reset_writes", False)),
+        )
+        options.output.mkdir(parents=True, exist_ok=True)
+        return options
+
+    def _collect_registers(self, node: Node) -> Iterable[RegisterInfo]:
+        if getattr(node, "is_reg", False):
+            yield self._build_register(node)
+        for child in node.children():
+            yield from self._collect_registers(child)
+
+    def _build_register(self, node: Node) -> RegisterInfo:
+        fields = [self._build_field(field) for field in node.fields()]
+        return RegisterInfo(
+            name=node.inst_name,
+            path=node.get_path(),
+            absolute_address=node.absolute_address,
+            width=node.get_property("regwidth"),
+            reset=node.get_property("reset") if node.has_property("reset") else None,
+            access=node.get_property("sw"),
+            volatile=bool(node.get_property("volatile"))
+            if node.has_property("volatile")
+            else False,
+            fields=fields,
+        )
+
+    def _build_field(self, node: FieldNode) -> FieldInfo:
+        lsb = node.get_property("lsb")
+        msb = node.get_property("msb")
+        access = node.get_property("sw")
+        reset = node.get_property("reset") if node.has_property("reset") else None
+        return FieldInfo(name=node.inst_name, lsb=lsb, msb=msb, access=access, reset=reset)
+
+    def _render_templates(self, output_dir: Path, context: Dict[str, object]) -> None:
+        for template_name in self._environment.list_templates():
+            template = self._environment.get_template(template_name)
+            rendered = template.render(**context)
+            suffix = ".jinja"
+            target_name = (
+                template_name[:- len(suffix)] if template_name.endswith(suffix) else template_name
+            )
+            target_path = output_dir / target_name
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(rendered)
+

--- a/src/peakrdl_pybind/cli.py
+++ b/src/peakrdl_pybind/cli.py
@@ -1,0 +1,52 @@
+"""Command line interface for the peakrdl-pybind backend."""
+
+from __future__ import annotations
+
+import argparse
+
+from systemrdl import RDLCompiler
+
+from .backend import PyBindBackend
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rdl", help="Path to the top-level SystemRDL file")
+    parser.add_argument("--soc-name", required=True, help="Name of the generated SoC package")
+    parser.add_argument("--out", required=True, help="Output directory for generated sources")
+    parser.add_argument("--top", required=True, help="Name of the top-level addrmap symbol")
+    parser.add_argument("--word-bytes", type=int, default=4, choices=(1, 2, 4, 8))
+    parser.add_argument("--little-endian", action="store_true", default=True)
+    parser.add_argument("--big-endian", action="store_false", dest="little_endian")
+    parser.add_argument("--with-examples", action="store_true")
+    parser.add_argument("--gen-pyi", action="store_true")
+    parser.add_argument("--namespace", help="Override the generated Python package namespace")
+    parser.add_argument("--no-access-checks", action="store_true")
+    parser.add_argument("--emit-reset-writes", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    compiler = RDLCompiler()
+    compiler.compile_file(args.rdl)
+    root = compiler.elaborate(args.top)
+
+    backend = PyBindBackend()
+    backend.build(
+        node=root,
+        output_dir=args.out,
+        soc_name=args.soc_name,
+        word_bytes=args.word_bytes,
+        little_endian=args.little_endian,
+        with_examples=args.with_examples,
+        gen_pyi=args.gen_pyi,
+        namespace=args.namespace,
+        no_access_checks=args.no_access_checks,
+        emit_reset_writes=args.emit_reset_writes,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/peakrdl_pybind/templates/CMakeLists.txt.jinja
+++ b/src/peakrdl_pybind/templates/CMakeLists.txt.jinja
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.18)
+project({{ options.soc_name }}_soc LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(pybind11 REQUIRED)
+
+pybind11_add_module({{ options.namespace or ('soc_' + options.soc_name) }}
+    soc_module.cpp
+    master.cpp
+    reg_model.cpp
+)
+
+target_include_directories({{ options.namespace or ('soc_' + options.soc_name) }}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/src/peakrdl_pybind/templates/master.cpp.jinja
+++ b/src/peakrdl_pybind/templates/master.cpp.jinja
@@ -1,0 +1,7 @@
+#include "master.hpp"
+
+namespace soc {
+
+// Intentionally empty: virtual destructor defined inline in header.
+
+} // namespace soc

--- a/src/peakrdl_pybind/templates/master.hpp.jinja
+++ b/src/peakrdl_pybind/templates/master.hpp.jinja
@@ -1,0 +1,14 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+
+namespace soc {
+
+class Master {
+public:
+  virtual ~Master() = default;
+  virtual std::uint32_t read32(std::uint64_t addr) = 0;
+  virtual void write32(std::uint64_t addr, std::uint32_t data, std::uint32_t wstrb = 0xF) = 0;
+};
+
+} // namespace soc

--- a/src/peakrdl_pybind/templates/pyproject.toml.jinja
+++ b/src/peakrdl_pybind/templates/pyproject.toml.jinja
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["scikit-build-core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "{{ options.namespace or ('soc_' + options.soc_name) }}"
+version = "0.1.0"
+description = "Auto-generated SoC register bindings"
+requires-python = ">=3.9"
+
+[tool.scikit-build]
+wheel.packages = ["."]

--- a/src/peakrdl_pybind/templates/reg_model.cpp.jinja
+++ b/src/peakrdl_pybind/templates/reg_model.cpp.jinja
@@ -1,0 +1,34 @@
+#include "reg_model.hpp"
+
+namespace soc {
+
+namespace {
+
+{% for reg in registers %}
+static const FieldDesc {{ reg.name }}_fields[] = {
+{% for field in reg.fields %}
+    {"{{ field.name }}", {{ field.lsb }}, {{ field.msb }}, "{{ field.access }}"},
+{% endfor %}
+};
+
+static const RegDesc {{ reg.name }}_desc = {
+    "{{ reg.path }}",
+    {{ reg.absolute_address }},
+    {{ reg.width }},
+    {{ reg.reset or 0 }},
+    "{{ reg.access }}",
+    {{ "true" if reg.volatile else "false" }},
+    {{ reg.name }}_fields,
+    {{ reg.fields | length }},
+};
+{% endfor %}
+
+} // namespace
+
+void bind_reg_model(pybind11::module_& m, std::shared_ptr<Master>* master) {
+    (void)m;
+    (void)master;
+    // Binding logic will be implemented in future revisions.
+}
+
+} // namespace soc

--- a/src/peakrdl_pybind/templates/reg_model.hpp.jinja
+++ b/src/peakrdl_pybind/templates/reg_model.hpp.jinja
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+
+#include "master.hpp"
+
+namespace soc {
+
+struct FieldDesc {
+  const char* name;
+  std::uint8_t lsb;
+  std::uint8_t msb;
+  const char* access;
+};
+
+struct RegDesc {
+  const char* path;
+  std::uint64_t address;
+  std::uint16_t width;
+  std::uint32_t reset;
+  const char* access;
+  bool is_volatile;
+  const FieldDesc* fields;
+  std::size_t field_count;
+};
+
+void bind_reg_model(pybind11::module_& m, std::shared_ptr<Master>* master);
+
+} // namespace soc

--- a/src/peakrdl_pybind/templates/soc_module.cpp.jinja
+++ b/src/peakrdl_pybind/templates/soc_module.cpp.jinja
@@ -1,0 +1,25 @@
+#include <memory>
+
+#include <pybind11/pybind11.h>
+
+#include "master.hpp"
+#include "reg_model.hpp"
+
+namespace py = pybind11;
+
+namespace {
+std::shared_ptr<soc::Master> g_master;
+}
+
+PYBIND11_MODULE({{ options.namespace or ('soc_' + options.soc_name) }}, m) {
+    m.doc() = "Auto-generated SoC register bindings";
+
+    py::class_<soc::Master, std::shared_ptr<soc::Master>>(m, "Master")
+        .def(py::init<>())
+        .def("read32", &soc::Master::read32)
+        .def("write32", &soc::Master::write32, py::arg("addr"), py::arg("data"), py::arg("wstrb") = 0xF);
+
+    m.def("attach_master", [](std::shared_ptr<soc::Master> master) { g_master = std::move(master); });
+
+    soc::bind_reg_model(m, &g_master);
+}

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest.importorskip("jinja2")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from peakrdl_pybind.backend import PyBindBackend
+
+
+def test_parse_options(tmp_path: Path) -> None:
+    backend = PyBindBackend()
+    options = backend._parse_options(  # type: ignore[attr-defined]
+        output_dir=str(tmp_path),
+        soc_name="aurora",
+        word_bytes=8,
+        little_endian=False,
+        with_examples=True,
+        gen_pyi=True,
+        namespace="aurora_soc",
+        no_access_checks=True,
+        emit_reset_writes=True,
+    )
+    assert options.output == tmp_path
+    assert options.word_bytes == 8
+    assert not options.little_endian
+    assert options.generate_examples
+    assert options.generate_pyi
+    assert options.namespace == "aurora_soc"
+    assert options.no_access_checks
+    assert options.emit_reset_writes
+
+
+def test_render_templates_round_trip(tmp_path: Path) -> None:
+    backend = PyBindBackend()
+    context = {
+        "options": backend._parse_options(str(tmp_path), soc_name="aurora"),  # type: ignore[attr-defined]
+        "registers": [],
+    }
+    backend._render_templates(tmp_path, context)  # type: ignore[attr-defined]
+    generated = {p.name for p in tmp_path.iterdir() if p.is_file()}
+    assert "CMakeLists.txt" in generated
+    assert "soc_module.cpp" in generated


### PR DESCRIPTION
## Summary
- add initial package metadata, CLI entry point, and backend skeleton for the PeakRDL PyBind backend
- scaffold Jinja2 templates for generated C++ sources and build assets
- introduce a pytest smoke test that exercises option parsing and template rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f5721c32f88325bf216e604ac56ee4