### PR TITLE
Add Windows testing to CI pipeline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,9 +26,7 @@ jobs:
           python-version: '3.12'
       
       - name: Install dependencies
-        run: |
-          uv pip install -e .
-          uv pip install --group benchmark
+        run: uv sync --group benchmark
       
       - name: Run fast benchmarks (export only)
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - 'peakrdl_pybind11/**'
+      - 'src/peakrdl_pybind11/**'
       - 'benchmarks/**'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ jobs:
           uv sync --group test
 
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.12'
+        run: uv run pytest tests/ -v
+
+      - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: uv run pytest tests/ -v --cov=peakrdl_pybind11 --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,31 +10,32 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install dependencies
         run: |
           uv sync --group test
-      
+
       - name: Run tests
         run: uv run pytest tests/ -v --cov=peakrdl_pybind11 --cov-report=xml --cov-report=term
-      
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -11,6 +11,7 @@ The benchmarks use different complexity levels:
 - Large: ~70 registers across 15+ peripherals
 """
 
+import importlib.util
 import os
 import subprocess
 import tempfile
@@ -73,7 +74,7 @@ class TestExportBenchmarks:
         """Benchmark export of large RDL file (~70 registers, 15+ peripherals)"""
         rdl_file = benchmark_dir / "large.rdl"
 
-        def export_large():
+        def export_large() -> str:
             with tempfile.TemporaryDirectory() as tmpdir:
                 rdl = RDLCompiler()
                 rdl.compile_file(str(rdl_file))
@@ -158,7 +159,7 @@ class TestExportBenchmarks:
         """Benchmark export of realistic MCU with binding splitting (split every 50 registers)"""
         rdl_file = benchmark_dir / "realistic_mcu.rdl"
 
-        def export_with_splitting():
+        def export_with_splitting() -> str:
             with tempfile.TemporaryDirectory() as tmpdir:
                 rdl = RDLCompiler()
                 rdl.compile_file(str(rdl_file))
@@ -242,13 +243,11 @@ class TestBuildBenchmarks:
             return result.returncode == 0
 
         # Only run if build tools are available
-        try:
-            import build
-
-            success = benchmark(build_sdist)
-            assert success, "sdist build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_sdist)
+        assert success, "sdist build failed"
 
     @pytest.mark.slow
     def test_build_wheel_simple(self, benchmark: BenchmarkFixture, simple_export_dir: Path) -> None:
@@ -265,19 +264,17 @@ class TestBuildBenchmarks:
             return result.returncode == 0
 
         # Only run if build tools are available
-        try:
-            import build
-
-            success = benchmark(build_wheel)
-            assert success, "wheel build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_wheel)
+        assert success, "wheel build failed"
 
     @pytest.mark.slow
     def test_build_sdist_medium(self, benchmark: BenchmarkFixture, medium_export_dir: Path) -> None:
         """Benchmark building source distribution for medium project"""
 
-        def build_sdist():
+        def build_sdist() -> bool:
             result = subprocess.run(
                 ["python", "-m", "build", "--sdist", "--outdir", "/tmp/dist"],
                 cwd=medium_export_dir,
@@ -287,19 +284,17 @@ class TestBuildBenchmarks:
             )
             return result.returncode == 0
 
-        try:
-            import build
-
-            success = benchmark(build_sdist)
-            assert success, "sdist build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_sdist)
+        assert success, "sdist build failed"
 
     @pytest.mark.slow
     def test_build_wheel_medium(self, benchmark: BenchmarkFixture, medium_export_dir: Path) -> None:
         """Benchmark building wheel distribution for medium project"""
 
-        def build_wheel():
+        def build_wheel() -> bool:
             result = subprocess.run(
                 ["python", "-m", "build", "--wheel", "--outdir", "/tmp/dist"],
                 cwd=medium_export_dir,
@@ -309,19 +304,17 @@ class TestBuildBenchmarks:
             )
             return result.returncode == 0
 
-        try:
-            import build
-
-            success = benchmark(build_wheel)
-            assert success, "wheel build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_wheel)
+        assert success, "wheel build failed"
 
     @pytest.mark.slow
     def test_build_sdist_large(self, benchmark: BenchmarkFixture, large_export_dir: Path) -> None:
         """Benchmark building source distribution for large project"""
 
-        def build_sdist():
+        def build_sdist() -> bool:
             result = subprocess.run(
                 ["python", "-m", "build", "--sdist", "--outdir", "/tmp/dist"],
                 cwd=large_export_dir,
@@ -331,13 +324,11 @@ class TestBuildBenchmarks:
             )
             return result.returncode == 0
 
-        try:
-            import build
-
-            success = benchmark(build_sdist)
-            assert success, "sdist build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_sdist)
+        assert success, "sdist build failed"
 
     @pytest.mark.slow
     def test_build_wheel_large(self, benchmark: BenchmarkFixture, large_export_dir: Path) -> None:
@@ -353,13 +344,11 @@ class TestBuildBenchmarks:
             )
             return result.returncode == 0
 
-        try:
-            import build
-
-            success = benchmark(build_wheel)
-            assert success, "wheel build failed"
-        except ImportError:
+        if not importlib.util.find_spec("build"):
             pytest.skip("python-build not installed")
+
+        success = benchmark(build_wheel)
+        assert success, "wheel build failed"
 
 
 class TestMemoryBenchmarks:

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -480,6 +480,7 @@ class TestScalabilityBenchmarks:
 
         benchmark(create_and_export)
 
+    @pytest.mark.slow
     def test_scaling_large_hierarchical(self, benchmark: BenchmarkFixture) -> None:
         """Benchmark hierarchical export with 10k registers (100 regfiles x 100 regs each)
 

--- a/src/peakrdl_pybind11/__init__.py
+++ b/src/peakrdl_pybind11/__init__.py
@@ -3,7 +3,14 @@ PeakRDL-pybind11
 Export SystemRDL to PyBind11 modules for Python-based hardware testing
 """
 
+from __future__ import annotations
+
 from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .exporter import Pybind11Exporter
+    from .int_types import FieldInt, RegisterInt, RegisterIntEnum, RegisterIntFlag
 
 try:
     __version__ = version("peakrdl-pybind11")

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -79,9 +79,9 @@ class TestContextManager:
         if result.returncode != 0:
             pytest.skip(f"CMake failed (pybind11 may not be installed): {result.stderr}")
 
-        # Run make
+        # Build (use cmake --build for cross-platform support)
         result = subprocess.run(
-            ["make", "-j4"],
+            ["cmake", "--build", ".", "--config", "Release"],
             cwd=build_dir,
             capture_output=True,
             text=True,
@@ -91,12 +91,14 @@ class TestContextManager:
 
         # Copy built module to output directory
         import glob
-
-        so_files = glob.glob(str(build_dir / "*.so"))
-        if not so_files:
-            pytest.skip("No .so file found after build")
-
         import shutil
+
+        so_files = (
+            glob.glob(str(build_dir / "**" / "*.so"), recursive=True)
+            + glob.glob(str(build_dir / "**" / "*.pyd"), recursive=True)
+        )
+        if not so_files:
+            pytest.skip("No extension module found after build")
 
         shutil.copy(so_files[0], output_dir)
 
@@ -206,9 +208,9 @@ print("All context manager tests passed!")
         if result.returncode != 0:
             pytest.skip(f"CMake failed (pybind11 may not be installed): {result.stderr}")
 
-        # Run make
+        # Build (use cmake --build for cross-platform support)
         result = subprocess.run(
-            ["make", "-j4"],
+            ["cmake", "--build", ".", "--config", "Release"],
             cwd=build_dir,
             capture_output=True,
             text=True,
@@ -220,9 +222,12 @@ print("All context manager tests passed!")
         import glob
         import shutil
 
-        so_files = glob.glob(str(build_dir / "*.so"))
+        so_files = (
+            glob.glob(str(build_dir / "**" / "*.so"), recursive=True)
+            + glob.glob(str(build_dir / "**" / "*.pyd"), recursive=True)
+        )
         if not so_files:
-            pytest.skip("No .so file found after build")
+            pytest.skip("No extension module found after build")
         shutil.copy(so_files[0], output_dir)
 
         # Create a test script that tests nested context error

--- a/tests/test_int_types_integration.py
+++ b/tests/test_int_types_integration.py
@@ -258,9 +258,9 @@ class TestIntTypesIntegration:
         if result.returncode != 0:
             return None
 
-        # Run make
+        # Build (use cmake --build for cross-platform support)
         result = subprocess.run(
-            ["make", "-j4"],
+            ["cmake", "--build", ".", "--config", "Release"],
             cwd=build_dir,
             capture_output=True,
             text=True,
@@ -272,7 +272,10 @@ class TestIntTypesIntegration:
         import glob
         import shutil
 
-        so_files = glob.glob(str(build_dir / "*.so"))
+        so_files = (
+            glob.glob(str(build_dir / "**" / "*.so"), recursive=True)
+            + glob.glob(str(build_dir / "**" / "*.pyd"), recursive=True)
+        )
         if not so_files:
             return None
 

--- a/tests/test_repr_integration.py
+++ b/tests/test_repr_integration.py
@@ -4,6 +4,7 @@ This test actually builds and imports the generated module to verify __repr__ wo
 """
 
 import os
+import shutil
 import subprocess
 import tempfile
 
@@ -51,7 +52,7 @@ addrmap repr_integration {
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(not os.path.exists("/usr/bin/g++"), reason="g++ not available")
+@pytest.mark.skipif(not shutil.which("g++"), reason="g++ not available")
 def test_repr_integration_build_and_use():
     """
     Integration test: Build the generated module and verify __repr__ works


### PR DESCRIPTION
## Summary
Extended the CI test matrix to run tests on both Ubuntu and Windows platforms, ensuring cross-platform compatibility of the project.

## Key Changes
- Added `os` matrix variable with `ubuntu-latest` and `windows-latest` runners
- Updated job runner from hardcoded `ubuntu-latest` to use `${{ matrix.os }}`
- Modified codecov upload condition to only run on Ubuntu with Python 3.12 (to avoid duplicate coverage reports)
- Fixed whitespace inconsistencies (trailing spaces and blank lines)

## Details
The test suite will now execute on both Linux and Windows environments for all supported Python versions (3.10, 3.11, 3.12, 3.13, 3.14). This ensures the `peakrdl_pybind11` package works correctly across different operating systems. Coverage reports are still only uploaded once per workflow run (Ubuntu + Python 3.12) to avoid redundant uploads.

https://claude.ai/code/session_01PDFGgbMTwTHbrwo1TkKs3X