### PR TITLE
Narrow exception handling in _get_bool_property to LookupError

### DIFF
--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -426,6 +426,6 @@ class Pybind11Exporter:
         """Safely read a boolean property from a node."""
         try:
             value = node.get_property(name)
-        except Exception:
+        except LookupError:
             return False
         return bool(value)


### PR DESCRIPTION
## Summary
Improved exception handling specificity in the `_get_bool_property` method by catching only `LookupError` instead of the overly broad `Exception` class.

## Changes
- Changed exception handler from `except Exception:` to `except LookupError:` in the `_get_bool_property` method
- This more precisely targets the expected exception type when a property is not found on a node

## Details
The `node.get_property(name)` call is expected to raise a `LookupError` (or its subclasses like `KeyError`) when a property doesn't exist. By catching only `LookupError` instead of all exceptions, we:
- Make the code's intent clearer about what exceptions are expected
- Avoid accidentally suppressing unexpected errors that indicate real bugs
- Follow Python best practices for specific exception handling

https://claude.ai/code/session_01AaGtanR1LJfq272wn48Avu