### PR TITLE
Fix duplicate and missing regfile/addrmap pybind11 registrations (#30, #31)

### DIFF
--- a/src/peakrdl_pybind11/templates/bindings.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings.cpp.jinja
@@ -114,33 +114,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
         {% endfor %}
         ;
     {% endfor %}
-    
-    {% for addrmap in nodes.addrmaps %}
-    {% if addrmap != top_node %}
-    // Addrmap class: {{ addrmap.inst_name }}
-    py::class_<{{ addrmap.inst_name }}_t, NodeBase>(m, "{{ addrmap.inst_name }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() }}"{% endif %})
-        .def(py::init<uint64_t>())
-        {% for child in addrmap.children() %}
-        {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ addrmap.inst_name }}_t::{{ child.inst_name }})
-        {% endif %}
-        {% endfor %}
-        ;
-    {% endif %}
-    {% endfor %}
-    
-    {% for regfile in nodes.regfiles %}
-    // Regfile class: {{ regfile.inst_name }}
-    py::class_<{{ regfile.inst_name }}_t, NodeBase>(m, "{{ regfile.inst_name }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() }}"{% endif %})
-        .def(py::init<uint64_t>())
-        {% for child in regfile.children() %}
-        {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ regfile.inst_name }}_t::{{ child.inst_name }})
-        {% endif %}
-        {% endfor %}
-        ;
-    {% endfor %}
-    
+
     {% for addrmap in nodes.addrmaps %}
     {% if addrmap != top_node %}
     // Addrmap class: {{ addrmap.inst_name }}

--- a/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
@@ -95,7 +95,33 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     {% for i in range(num_chunks) %}
     bind_registers_chunk_{{ i }}(m);
     {% endfor %}
-    
+
+    {% for regfile in nodes.regfiles %}
+    // Regfile class: {{ regfile.inst_name }}
+    py::class_<{{ regfile.inst_name }}_t, NodeBase>(m, "{{ regfile.inst_name }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() }}"{% endif %})
+        .def(py::init<uint64_t>())
+        {% for child in regfile.children() %}
+        {% if child.inst_name %}
+        .def_readonly("{{ child.inst_name }}", &{{ regfile.inst_name }}_t::{{ child.inst_name }})
+        {% endif %}
+        {% endfor %}
+        ;
+    {% endfor %}
+
+    {% for addrmap in nodes.addrmaps %}
+    {% if addrmap != top_node %}
+    // Addrmap class: {{ addrmap.inst_name }}
+    py::class_<{{ addrmap.inst_name }}_t, NodeBase>(m, "{{ addrmap.inst_name }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() }}"{% endif %})
+        .def(py::init<uint64_t>())
+        {% for child in addrmap.children() %}
+        {% if child.inst_name %}
+        .def_readonly("{{ child.inst_name }}", &{{ addrmap.inst_name }}_t::{{ child.inst_name }})
+        {% endif %}
+        {% endfor %}
+        ;
+    {% endif %}
+    {% endfor %}
+
     {% for mem in nodes.mems %}
     {%- set entry_reg = mem.children()|list|first %}
     // Memory class: {{ mem.inst_name }}

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -80,10 +80,6 @@ addrmap hier_soc {
 # ---------------------------------------------------------------------------
 # Issue #30: regfiles/addrmaps registered twice in single-file bindings
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    reason="Issue #30: bindings.cpp.jinja registers regfile/addrmap classes twice",
-    strict=True,
-)
 def test_issue_30_no_duplicate_class_registrations() -> None:
     out = _export(HIERARCHICAL_RDL, "hier_soc", split_bindings=0)
     bindings = _read(os.path.join(out, "hier_soc_bindings.cpp"))
@@ -100,10 +96,6 @@ def test_issue_30_no_duplicate_class_registrations() -> None:
 # ---------------------------------------------------------------------------
 # Issue #31: split-bindings never registers regfile/addrmap
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    reason="Issue #31: bindings_main.cpp.jinja omits regfile/addrmap class registration",
-    strict=True,
-)
 def test_issue_31_split_bindings_register_regfiles() -> None:
     out = _export(HIERARCHICAL_RDL, "hier_soc", split_by_hierarchy=True)
 


### PR DESCRIPTION
## Summary

`bindings.cpp.jinja` registered each regfile and addrmap **twice** in the
same `PYBIND11_MODULE` block, causing pybind11 to throw "type already
registered" at module import for any RDL with a regfile in single-file
mode. Removed the duplicated loops.

`bindings_main.cpp.jinja` (split-bindings mode) never registered regfile
or addrmap classes at all — only registers and fields landed in chunks,
and the main file only handled `Master`/`RegisterBase`/`FieldBase`/
`NodeBase`, memories, and the SoC. Any hierarchical design crossing the
split threshold (default >100 registers, or `--split-by-hierarchy`)
failed at module import. Added the regfile and addrmap registration loops
to the main template after the chunk dispatchers.

Drops the corresponding xfail markers in `tests/test_known_bugs.py`.

Closes #30 #31.

## Test plan

- [x] `uv run pytest tests/` — 48 passed, 8 skipped, 4 xfailed (was 6 xfailed)
- [x] Both #30 and #31 regression tests now pass green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
