### PR TITLE
Tighten master backends; mask MockMaster reads by width (#36)

### DIFF
--- a/src/peakrdl_pybind11/masters/mock.py
+++ b/src/peakrdl_pybind11/masters/mock.py
@@ -12,8 +12,9 @@ class MockMaster(MasterBase):
         self.memory: dict[int, int] = {}
 
     def read(self, address: int, width: int) -> int:
-        """Read from simulated memory"""
-        return self.memory.get(address, 0)
+        """Read from simulated memory, masked to ``width`` bytes."""
+        mask = (1 << (width * 8)) - 1
+        return self.memory.get(address, 0) & mask
 
     def write(self, address: int, value: int, width: int) -> None:
         """Write to simulated memory"""

--- a/src/peakrdl_pybind11/masters/openocd.py
+++ b/src/peakrdl_pybind11/masters/openocd.py
@@ -59,15 +59,12 @@ class OpenOCDMaster(MasterBase):
 
         data = b""
         while True:
-            try:
-                chunk = self.socket.recv(4096)
-                if not chunk:
-                    break
-                data += chunk
-                # OpenOCD ends responses with a specific marker
-                if data.endswith(b"\x1a"):
-                    break
-            except TimeoutError:
+            chunk = self.socket.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+            # OpenOCD ends responses with a specific marker
+            if data.endswith(b"\x1a"):
                 break
 
         return data.decode("utf-8", errors="ignore").rstrip("\x1a")
@@ -100,13 +97,12 @@ class OpenOCDMaster(MasterBase):
         # Parse response (format: "0xADDRESS: VALUE")
         try:
             parts = response.split(":")
-            if len(parts) >= 2:
-                value_str = parts[1].strip().split()[0]
-                return int(value_str, 16)
-        except Exception as e:
-            raise RuntimeError(f"Failed to parse OpenOCD response: {response}: {e}") from e
-
-        return 0
+            if len(parts) < 2:
+                raise ValueError("missing ':' separator")
+            value_str = parts[1].strip().split()[0]
+            return int(value_str, 16)
+        except (ValueError, IndexError) as e:
+            raise RuntimeError(f"Failed to parse OpenOCD response: {response!r}: {e}") from e
 
     def write(self, address: int, value: int, width: int) -> None:
         """
@@ -157,5 +153,11 @@ class OpenOCDMaster(MasterBase):
             self.socket = None
 
     def __del__(self) -> None:
-        """Cleanup on deletion"""
-        self.close()
+        """Cleanup on deletion. Avoid issuing protocol commands during GC."""
+        sock = getattr(self, "socket", None)
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+            self.socket = None

--- a/src/peakrdl_pybind11/masters/ssh.py
+++ b/src/peakrdl_pybind11/masters/ssh.py
@@ -18,7 +18,6 @@ class SSHMaster(MasterBase):
         self,
         host: str,
         username: str | None = None,
-        password: str | None = None,
         key_file: str | None = None,
         tool: str = "devmem",
     ) -> None:
@@ -28,13 +27,15 @@ class SSHMaster(MasterBase):
         Args:
             host: SSH host to connect to
             username: SSH username (optional, uses current user if not specified)
-            password: SSH password (optional, uses key-based auth if not specified)
             key_file: Path to SSH private key file (optional)
             tool: Memory access tool on remote system (default: "devmem")
+
+        Note:
+            Password authentication is not supported. Use SSH keys via
+            ``key_file`` (or your ssh-agent / ``~/.ssh/config``).
         """
         self.host = host
         self.username = username
-        self.password = password
         self.key_file = key_file
         self.tool = tool
 
@@ -56,22 +57,22 @@ class SSHMaster(MasterBase):
             result = subprocess.run(
                 [*self.ssh_cmd, "echo", "test"], capture_output=True, text=True, timeout=10
             )
-            if result.returncode != 0:
-                raise RuntimeError(f"SSH connection test failed: {result.stderr}")
-        except Exception as e:
+        except (OSError, subprocess.TimeoutExpired) as e:
             raise RuntimeError(f"Failed to connect via SSH to {self.host}: {e}") from e
+        if result.returncode != 0:
+            raise RuntimeError(f"SSH connection test to {self.host} failed: {result.stderr.strip()}")
 
     def _run_remote_command(self, command: str) -> str:
         """Execute a command on the remote system"""
         try:
             result = subprocess.run([*self.ssh_cmd, command], capture_output=True, text=True, timeout=30)
-            if result.returncode != 0:
-                raise RuntimeError(f"Remote command failed: {result.stderr}")
-            return result.stdout.strip()
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"Remote command timed out: {command}") from None
-        except Exception as e:
+        except OSError as e:
             raise RuntimeError(f"Failed to execute remote command: {e}") from e
+        if result.returncode != 0:
+            raise RuntimeError(f"Remote command failed: {result.stderr.strip()}")
+        return result.stdout.strip()
 
     def read(self, address: int, width: int) -> int:
         """

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -358,11 +358,3 @@ def test_issue_36_mock_master_read_honours_width() -> None:
     assert master.read(0x100, 1) == 0xEF
     assert master.read(0x100, 2) == 0xBEEF
     assert master.read(0x100, 4) == 0xDEADBEEF
-
-
-# Wrap the width-narrowing assertions in xfail so the rest of the suite stays
-# green. The first read above currently returns 0xDEADBEEF, not 0xEF.
-test_issue_36_mock_master_read_honours_width = pytest.mark.xfail(
-    reason="Issue #36: MockMaster.read does not mask by width",
-    strict=True,
-)(test_issue_36_mock_master_read_honours_width)


### PR DESCRIPTION
## Summary

- **MockMaster.read** now masks the stored value by the requested byte
  width, matching write's existing masking behavior. A 1-byte read of an
  address holding `0xDEADBEEF` now returns `0xEF`, not the full 32-bit
  value.

- **OpenOCDMaster**:
  - `read()` no longer silently returns `0` when response parsing fails;
    it raises `RuntimeError` with the offending response text.
  - `_recv()` no longer treats `TimeoutError` as end-of-message; it now
    propagates so callers see the timeout instead of getting partial
    buffered output that then mis-parses.
  - `__del__` closes the socket directly instead of issuing the `"exit"`
    protocol command during garbage collection.

- **SSHMaster**:
  - Removed the documented-but-unused `password` parameter; only
    key-based / agent / ssh-config auth was ever supported. Updated
    docstring accordingly.
  - `_test_connection` and `_run_remote_command` no longer wrap their
    inner `RuntimeError`s in another `RuntimeError`; the catch-all
    `except Exception` was producing nested error messages.

Closes #36.

## Test plan

- [x] `uv run pytest tests/` — 49 passed, 8 skipped, 3 xfailed
- [x] #36 width-masking regression test now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
