### PR TITLE
Sanitize Python/C++ reserved-word inst_names (#34)

### DIFF
--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -2,11 +2,40 @@
 Main exporter implementation for PeakRDL-pybind11
 """
 
+import keyword
 import os
 import re
 from collections import OrderedDict
 from pathlib import Path
 from typing import TypedDict
+
+# Words that cannot be used as identifiers in either Python or C++.
+_RESERVED_WORDS: frozenset[str] = frozenset(
+    set(keyword.kwlist)
+    | set(keyword.softkwlist)
+    | {
+        # C++ keywords / reserved identifiers that could collide with an RDL
+        # inst_name. Not exhaustive -- focused on commonly-used names.
+        "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
+        "bitor", "bool", "break", "case", "catch", "char", "char8_t",
+        "char16_t", "char32_t", "class", "compl", "concept", "const",
+        "consteval", "constexpr", "constinit", "const_cast", "continue",
+        "co_await", "co_return", "co_yield", "decltype", "default", "delete",
+        "do", "double", "dynamic_cast", "else", "enum", "explicit", "export",
+        "extern", "false", "float", "for", "friend", "goto", "if", "inline",
+        "int", "long", "mutable", "namespace", "new", "noexcept", "not",
+        "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected",
+        "public", "register", "reinterpret_cast", "requires", "return",
+        "short", "signed", "sizeof", "static", "static_assert", "static_cast",
+        "struct", "switch", "template", "this", "thread_local", "throw",
+        "true", "try", "typedef", "typeid", "typename", "union", "unsigned",
+        "using", "virtual", "void", "volatile", "wchar_t", "while", "xor",
+        "xor_eq",
+        # Identifiers used by the generator itself; collisions would shadow
+        # generated members.
+        "Master", "RegisterBase", "FieldBase", "NodeBase", "MemoryBase",
+    }
+)
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from systemrdl.node import AddrmapNode, FieldNode, MemNode, Node, RegfileNode, RegNode, RootNode
@@ -37,6 +66,7 @@ class Pybind11Exporter:
         self.env.filters["pybind_name"] = self._pybind_name_from_node
         self.env.filters["enum_member"] = self._enum_member_name
         self.env.filters["cpp_string"] = self._cpp_string_escape
+        self.env.filters["safe_id"] = self._sanitize_identifier
         self.soc_name: str | None = None
         self.soc_version: str = "0.1.0"
         self.top_node: AddrmapNode | None = None
@@ -102,12 +132,17 @@ class Pybind11Exporter:
             self._generate_pyi_stubs(nodes)
 
     def _sanitize_identifier(self, name: str) -> str:
-        """Sanitize a name to be a valid Python/C++ identifier"""
-        # Replace invalid characters with underscores
+        """Sanitize a name to be a valid Python/C++ identifier.
+
+        Replaces non-identifier characters with underscores, prefixes a
+        leading digit, and appends a trailing underscore to any sanitized
+        name that collides with a Python or C++ reserved word.
+        """
         name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-        # Ensure it doesn't start with a digit
         if name and name[0].isdigit():
             name = "_" + name
+        if name in _RESERVED_WORDS:
+            name = name + "_"
         return name or "soc"
 
     def _pybind_name_from_node(self, value: Node | str) -> str:

--- a/src/peakrdl_pybind11/templates/bindings.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings.cpp.jinja
@@ -87,29 +87,29 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
         .def("__str__", &NodeBase::__repr__);
     
     {% for reg in nodes.regs %}
-    // Register class: {{ reg.inst_name }}
-    py::class_<{{ reg.inst_name }}_t, RegisterBase>(m, "{{ reg.inst_name }}_t"{% if reg.get_property('desc') %}, "{{ reg.get_html_desc() | cpp_string }}"{% endif %})
+    // Register class: {{ reg.inst_name | safe_id }}
+    py::class_<{{ reg.inst_name | safe_id }}_t, RegisterBase>(m, "{{ reg.inst_name | safe_id }}_t"{% if reg.get_property('desc') %}, "{{ reg.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for field in reg.fields() %}
-        .def_readonly("{{ field.inst_name }}", &{{ reg.inst_name }}_t::{{ field.inst_name }})
+        .def_readonly("{{ field.inst_name | safe_id }}", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }})
         {% endfor %}
         ;
     
     {% for field in reg.fields() %}
-    // Field class: {{ reg.inst_name }}.{{ field.inst_name }}
-    py::class_<{{ reg.inst_name }}_t::{{ field.inst_name }}_field, FieldBase>(m, "{{ reg.inst_name }}_{{ field.inst_name }}_field"{% if field.get_property('desc') %}, "{{ field.get_html_desc() | cpp_string }}"{% endif %})
-        .def("read", &{{ reg.inst_name }}_t::{{ field.inst_name }}_field::read, "Read field value")
-        .def("write", &{{ reg.inst_name }}_t::{{ field.inst_name }}_field::write, "Write field value");
+    // Field class: {{ reg.inst_name | safe_id }}.{{ field.inst_name | safe_id }}
+    py::class_<{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field, FieldBase>(m, "{{ reg.inst_name | safe_id }}_{{ field.inst_name | safe_id }}_field"{% if field.get_property('desc') %}, "{{ field.get_html_desc() | cpp_string }}"{% endif %})
+        .def("read", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field::read, "Read field value")
+        .def("write", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field::write, "Write field value");
     {% endfor %}
     {% endfor %}
     
     {% for regfile in nodes.regfiles %}
-    // Regfile class: {{ regfile.inst_name }}
-    py::class_<{{ regfile.inst_name }}_t, NodeBase>(m, "{{ regfile.inst_name }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() | cpp_string }}"{% endif %})
+    // Regfile class: {{ regfile.inst_name | safe_id }}
+    py::class_<{{ regfile.inst_name | safe_id }}_t, NodeBase>(m, "{{ regfile.inst_name | safe_id }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for child in regfile.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ regfile.inst_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ regfile.inst_name | safe_id }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;
@@ -117,12 +117,12 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
 
     {% for addrmap in nodes.addrmaps %}
     {% if addrmap != top_node %}
-    // Addrmap class: {{ addrmap.inst_name }}
-    py::class_<{{ addrmap.inst_name }}_t, NodeBase>(m, "{{ addrmap.inst_name }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() | cpp_string }}"{% endif %})
+    // Addrmap class: {{ addrmap.inst_name | safe_id }}
+    py::class_<{{ addrmap.inst_name | safe_id }}_t, NodeBase>(m, "{{ addrmap.inst_name | safe_id }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ addrmap.inst_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ addrmap.inst_name | safe_id }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;
@@ -131,12 +131,12 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     
     {% for mem in nodes.mems %}
     {%- set entry_reg = mem.children()|list|first %}
-    // Memory class: {{ mem.inst_name }}
-    py::class_<{{ mem.inst_name }}_t, NodeBase>(m, "{{ mem.inst_name }}_t"{% if mem.get_property('desc') %}, "{{ mem.get_html_desc() | cpp_string }}"{% endif %})
+    // Memory class: {{ mem.inst_name | safe_id }}
+    py::class_<{{ mem.inst_name | safe_id }}_t, NodeBase>(m, "{{ mem.inst_name | safe_id }}_t"{% if mem.get_property('desc') %}, "{{ mem.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
-        .def("__len__", &{{ mem.inst_name }}_t::size, "Get number of entries")
+        .def("__len__", &{{ mem.inst_name | safe_id }}_t::size, "Get number of entries")
         .def("__getitem__", 
-            []({{ mem.inst_name }}_t &mem, size_t i) -> {{ entry_reg.inst_name }}_t& {
+            []({{ mem.inst_name | safe_id }}_t &mem, size_t i) -> {{ entry_reg.inst_name | safe_id }}_t& {
                 if (i >= mem.size()) {
                     throw py::index_error("Memory index out of range");
                 }
@@ -145,7 +145,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
             py::return_value_policy::reference_internal,
             "Access memory entry by index")
         .def("__getitem__",
-            []({{ mem.inst_name }}_t &mem, py::slice slice) -> py::list {
+            []({{ mem.inst_name | safe_id }}_t &mem, py::slice slice) -> py::list {
                 size_t start, stop, step, slicelength;
                 if (!slice.compute(mem.size(), &start, &stop, &step, &slicelength)) {
                     throw py::error_already_set();
@@ -159,7 +159,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
             },
             "Access memory entries by slice")
         .def("__iter__",
-            []({{ mem.inst_name }}_t &mem) {
+            []({{ mem.inst_name | safe_id }}_t &mem) {
                 return py::make_iterator(mem.begin(), mem.end());
             },
             py::keep_alive<0, 1>(),
@@ -172,7 +172,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
         .def("attach_master", &{{ soc_name }}_t::attach_master, "Attach a master interface")
         {% for child in top_node.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ soc_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ soc_name }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;

--- a/src/peakrdl_pybind11/templates/bindings_chunk.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings_chunk.cpp.jinja
@@ -15,19 +15,19 @@ using namespace {{ soc_name }};
 
 void bind_registers_chunk_{{ chunk_idx }}(py::module& m) {
     {% for reg in regs %}
-    // Register class: {{ reg.inst_name }}
-    py::class_<{{ reg.inst_name }}_t, RegisterBase>(m, "{{ reg.inst_name }}_t"{% if reg.get_property('desc') %}, "{{ reg.get_html_desc() | cpp_string }}"{% endif %})
+    // Register class: {{ reg.inst_name | safe_id }}
+    py::class_<{{ reg.inst_name | safe_id }}_t, RegisterBase>(m, "{{ reg.inst_name | safe_id }}_t"{% if reg.get_property('desc') %}, "{{ reg.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for field in reg.fields() %}
-        .def_readonly("{{ field.inst_name }}", &{{ reg.inst_name }}_t::{{ field.inst_name }})
+        .def_readonly("{{ field.inst_name | safe_id }}", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }})
         {% endfor %}
         ;
     
     {% for field in reg.fields() %}
-    // Field class: {{ reg.inst_name }}.{{ field.inst_name }}
-    py::class_<{{ reg.inst_name }}_t::{{ field.inst_name }}_field, FieldBase>(m, "{{ reg.inst_name }}_{{ field.inst_name }}_field"{% if field.get_property('desc') %}, "{{ field.get_html_desc() | cpp_string }}"{% endif %})
-        .def("read", &{{ reg.inst_name }}_t::{{ field.inst_name }}_field::read, "Read field value")
-        .def("write", &{{ reg.inst_name }}_t::{{ field.inst_name }}_field::write, "Write field value");
+    // Field class: {{ reg.inst_name | safe_id }}.{{ field.inst_name | safe_id }}
+    py::class_<{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field, FieldBase>(m, "{{ reg.inst_name | safe_id }}_{{ field.inst_name | safe_id }}_field"{% if field.get_property('desc') %}, "{{ field.get_html_desc() | cpp_string }}"{% endif %})
+        .def("read", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field::read, "Read field value")
+        .def("write", &{{ reg.inst_name | safe_id }}_t::{{ field.inst_name | safe_id }}_field::write, "Write field value");
     {% endfor %}
     {% endfor %}
 }

--- a/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
@@ -97,12 +97,12 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     {% endfor %}
 
     {% for regfile in nodes.regfiles %}
-    // Regfile class: {{ regfile.inst_name }}
-    py::class_<{{ regfile.inst_name }}_t, NodeBase>(m, "{{ regfile.inst_name }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() | cpp_string }}"{% endif %})
+    // Regfile class: {{ regfile.inst_name | safe_id }}
+    py::class_<{{ regfile.inst_name | safe_id }}_t, NodeBase>(m, "{{ regfile.inst_name | safe_id }}_t"{% if regfile.get_property('desc') %}, "{{ regfile.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for child in regfile.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ regfile.inst_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ regfile.inst_name | safe_id }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;
@@ -110,12 +110,12 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
 
     {% for addrmap in nodes.addrmaps %}
     {% if addrmap != top_node %}
-    // Addrmap class: {{ addrmap.inst_name }}
-    py::class_<{{ addrmap.inst_name }}_t, NodeBase>(m, "{{ addrmap.inst_name }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() | cpp_string }}"{% endif %})
+    // Addrmap class: {{ addrmap.inst_name | safe_id }}
+    py::class_<{{ addrmap.inst_name | safe_id }}_t, NodeBase>(m, "{{ addrmap.inst_name | safe_id }}_t"{% if addrmap.get_property('desc') %}, "{{ addrmap.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ addrmap.inst_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ addrmap.inst_name | safe_id }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;
@@ -124,12 +124,12 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
 
     {% for mem in nodes.mems %}
     {%- set entry_reg = mem.children()|list|first %}
-    // Memory class: {{ mem.inst_name }}
-    py::class_<{{ mem.inst_name }}_t, NodeBase>(m, "{{ mem.inst_name }}_t"{% if mem.get_property('desc') %}, "{{ mem.get_html_desc() | cpp_string }}"{% endif %})
+    // Memory class: {{ mem.inst_name | safe_id }}
+    py::class_<{{ mem.inst_name | safe_id }}_t, NodeBase>(m, "{{ mem.inst_name | safe_id }}_t"{% if mem.get_property('desc') %}, "{{ mem.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
-        .def("__len__", &{{ mem.inst_name }}_t::size, "Get number of entries")
+        .def("__len__", &{{ mem.inst_name | safe_id }}_t::size, "Get number of entries")
         .def("__getitem__", 
-            []({{ mem.inst_name }}_t &mem, size_t i) -> {{ entry_reg.inst_name }}_t& {
+            []({{ mem.inst_name | safe_id }}_t &mem, size_t i) -> {{ entry_reg.inst_name | safe_id }}_t& {
                 if (i >= mem.size()) {
                     throw py::index_error("Memory index out of range");
                 }
@@ -138,7 +138,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
             py::return_value_policy::reference_internal,
             "Access memory entry by index")
         .def("__getitem__",
-            []({{ mem.inst_name }}_t &mem, py::slice slice) -> py::list {
+            []({{ mem.inst_name | safe_id }}_t &mem, py::slice slice) -> py::list {
                 size_t start, stop, step, slicelength;
                 if (!slice.compute(mem.size(), &start, &stop, &step, &slicelength)) {
                     throw py::error_already_set();
@@ -152,7 +152,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
             },
             "Access memory entries by slice")
         .def("__iter__",
-            []({{ mem.inst_name }}_t &mem) {
+            []({{ mem.inst_name | safe_id }}_t &mem) {
                 return py::make_iterator(mem.begin(), mem.end());
             },
             py::keep_alive<0, 1>(),
@@ -165,7 +165,7 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
         .def("attach_master", &{{ soc_name }}_t::attach_master, "Attach a master interface")
         {% for child in top_node.children() %}
         {% if child.inst_name %}
-        .def_readonly("{{ child.inst_name }}", &{{ soc_name }}_t::{{ child.inst_name }})
+        .def_readonly("{{ child.inst_name | safe_id }}", &{{ soc_name }}_t::{{ child.inst_name | safe_id }})
         {% endif %}
         {% endfor %}
         ;

--- a/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
@@ -1,13 +1,13 @@
 {% for addrmap in nodes.addrmaps %}
 {% if addrmap != top_node %}
-// Addrmap: {{ addrmap.inst_name }}
-class {{ addrmap.inst_name }}_t : public NodeBase {
+// Addrmap: {{ addrmap.inst_name | safe_id }}
+class {{ addrmap.inst_name | safe_id }}_t : public NodeBase {
 public:
-    {{ addrmap.inst_name }}_t(uint64_t base_offset)
-        : NodeBase("{{ addrmap.inst_name }}", base_offset) {
+    {{ addrmap.inst_name | safe_id }}_t(uint64_t base_offset)
+        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset) {
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
-        {{ child.inst_name }}.set_master(master_);
+        {{ child.inst_name | safe_id }}.set_master(master_);
         {% endif %}
         {% endfor %}
     }
@@ -16,7 +16,7 @@ public:
         NodeBase::set_master(master);
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
-        {{ child.inst_name }}.set_master(master);
+        {{ child.inst_name | safe_id }}.set_master(master);
         {% endif %}
         {% endfor %}
     }
@@ -27,7 +27,7 @@ public:
 
     {% for child in addrmap.children() %}
     {% if child.inst_name %}
-    {{ child.inst_name }}_t {{ child.inst_name }}{offset_};
+    {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{offset_};
     {% endif %}
     {% endfor %}
 };

--- a/src/peakrdl_pybind11/templates/descriptors/forward_declarations.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/forward_declarations.hpp.jinja
@@ -1,16 +1,16 @@
 {% for addrmap in nodes.addrmaps %}
 {% if addrmap != top_node %}
-// Forward declaration for {{ addrmap.inst_name }}
-class {{ addrmap.inst_name }}_t;
+// Forward declaration for {{ addrmap.inst_name | safe_id }}
+class {{ addrmap.inst_name | safe_id }}_t;
 {% endif %}
 {% endfor %}
 
 {% for regfile in nodes.regfiles %}
-// Forward declaration for {{ regfile.inst_name }}
-class {{ regfile.inst_name }}_t;
+// Forward declaration for {{ regfile.inst_name | safe_id }}
+class {{ regfile.inst_name | safe_id }}_t;
 {% endfor %}
 
 {% for mem in nodes.mems %}
-// Forward declaration for memory {{ mem.inst_name }}
-class {{ mem.inst_name }}_t;
+// Forward declaration for memory {{ mem.inst_name | safe_id }}
+class {{ mem.inst_name | safe_id }}_t;
 {% endfor %}

--- a/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
@@ -1,18 +1,18 @@
 {% for mem in nodes.mems %}
-// Memory: {{ mem.inst_name }}
+// Memory: {{ mem.inst_name | safe_id }}
 {%- set entry_reg = mem.children()|list|first %}
 
-class {{ mem.inst_name }}_t : public MemoryBase<{{ entry_reg.inst_name }}_t> {
+class {{ mem.inst_name | safe_id }}_t : public MemoryBase<{{ entry_reg.inst_name | safe_id }}_t> {
 public:
-    {{ mem.inst_name }}_t(uint64_t base_offset)
-        : MemoryBase<{{ entry_reg.inst_name }}_t>("{{ mem.inst_name }}", base_offset, {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
+    {{ mem.inst_name | safe_id }}_t(uint64_t base_offset)
+        : MemoryBase<{{ entry_reg.inst_name | safe_id }}_t>("{{ mem.inst_name | safe_id }}", base_offset, {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
 
     void set_offset(uint64_t base_offset) {
         offset_ = base_offset;
         // Update all entry offsets
         size_t entry_size = {{ entry_reg.size }};
         for (size_t i = 0; i < entries_.size(); ++i) {
-            entries_[i] = {{ entry_reg.inst_name }}_t(base_offset + i * entry_size);
+            entries_[i] = {{ entry_reg.inst_name | safe_id }}_t(base_offset + i * entry_size);
         }
         // Re-apply master if set
         if (master_) {

--- a/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
@@ -1,12 +1,12 @@
 {% for regfile in nodes.regfiles %}
-// Regfile: {{ regfile.inst_name }}
-class {{ regfile.inst_name }}_t : public NodeBase {
+// Regfile: {{ regfile.inst_name | safe_id }}
+class {{ regfile.inst_name | safe_id }}_t : public NodeBase {
 public:
-    {{ regfile.inst_name }}_t(uint64_t base_offset)
-        : NodeBase("{{ regfile.inst_name }}", base_offset) {
+    {{ regfile.inst_name | safe_id }}_t(uint64_t base_offset)
+        : NodeBase("{{ regfile.inst_name | safe_id }}", base_offset) {
         {% for child in regfile.children() %}
         {% if child.inst_name %}
-        {{ child.inst_name }}.set_master(master_);
+        {{ child.inst_name | safe_id }}.set_master(master_);
         {% endif %}
         {% endfor %}
     }
@@ -15,7 +15,7 @@ public:
         NodeBase::set_master(master);
         {% for child in regfile.children() %}
         {% if child.inst_name %}
-        {{ child.inst_name }}.set_master(master);
+        {{ child.inst_name | safe_id }}.set_master(master);
         {% endif %}
         {% endfor %}
     }
@@ -26,7 +26,7 @@ public:
 
     {% for child in regfile.children() %}
     {% if child.inst_name %}
-    {{ child.inst_name }}_t {{ child.inst_name }}{offset_};
+    {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{offset_};
     {% endif %}
     {% endfor %}
 };

--- a/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
@@ -1,16 +1,16 @@
 {% for reg in nodes.regs %}
-// Register: {{ reg.inst_name }}
-class {{ reg.inst_name }}_t : public RegisterBase {
+// Register: {{ reg.inst_name | safe_id }}
+class {{ reg.inst_name | safe_id }}_t : public RegisterBase {
 public:
-    {{ reg.inst_name }}_t(uint64_t base_offset)
-        : RegisterBase("{{ reg.inst_name }}", base_offset + 0x{{ "%x" | format(reg.absolute_address) }}, {{ reg.size }}) {}
+    {{ reg.inst_name | safe_id }}_t(uint64_t base_offset)
+        : RegisterBase("{{ reg.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(reg.absolute_address) }}, {{ reg.size }}) {}
 
     {% for field in reg.fields() %}
-    // Field: {{ field.inst_name }}
-    class {{ field.inst_name }}_field : public FieldBase {
+    // Field: {{ field.inst_name | safe_id }}
+    class {{ field.inst_name | safe_id }}_field : public FieldBase {
     public:
-        {{ field.inst_name }}_field({{ reg.inst_name }}_t* parent)
-            : FieldBase("{{ field.inst_name }}", parent->offset(),
+        {{ field.inst_name | safe_id }}_field({{ reg.inst_name | safe_id }}_t* parent)
+            : FieldBase("{{ field.inst_name | safe_id }}", parent->offset(),
                        {{ field.low }}, {{ field.width }},
                        {{ 'true' if field.is_hw_readable or field.is_sw_readable else 'false' }},
                        {{ 'true' if field.is_hw_writable or field.is_sw_writable else 'false' }}),
@@ -18,7 +18,7 @@ public:
 
         uint64_t read() {
             if (!is_readable()) {
-                throw std::runtime_error("Field {{ field.inst_name }} is not readable");
+                throw std::runtime_error("Field {{ field.inst_name | safe_id }} is not readable");
             }
             uint64_t reg_val = parent_->read();
             return (reg_val & mask()) >> lsb_;
@@ -26,17 +26,17 @@ public:
 
         void write(uint64_t value) {
             if (!is_writable()) {
-                throw std::runtime_error("Field {{ field.inst_name }} is not writable");
+                throw std::runtime_error("Field {{ field.inst_name | safe_id }} is not writable");
             }
             uint64_t field_val = (value << lsb_) & mask();
             parent_->modify(field_val, mask());
         }
 
     private:
-        {{ reg.inst_name }}_t* parent_;
+        {{ reg.inst_name | safe_id }}_t* parent_;
     };
 
-    {{ field.inst_name }}_field {{ field.inst_name }}{this};
+    {{ field.inst_name | safe_id }}_field {{ field.inst_name | safe_id }}{this};
     {% endfor %}
 };
 

--- a/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
@@ -4,7 +4,7 @@ public:
     {{ soc_name }}_t() : NodeBase("{{ soc_name }}", 0) {
         {% for child in top_node.children() %}
         {% if child.inst_name and not child.__class__.__name__ == 'RegNode' %}
-        {{ child.inst_name }}.set_offset(offset_);
+        {{ child.inst_name | safe_id }}.set_offset(offset_);
         {% endif %}
         {% endfor %}
     }
@@ -18,7 +18,7 @@ public:
         offset_ = offset;
         {% for child in top_node.children() %}
         {% if child.inst_name and not child.__class__.__name__ == 'RegNode' %}
-        {{ child.inst_name }}.set_offset(offset_);
+        {{ child.inst_name | safe_id }}.set_offset(offset_);
         {% endif %}
         {% endfor %}
     }
@@ -26,14 +26,14 @@ public:
     void propagate_master(Master* master) {
         {% for child in top_node.children() %}
         {% if child.inst_name %}
-        {{ child.inst_name }}.set_master(master);
+        {{ child.inst_name | safe_id }}.set_master(master);
         {% endif %}
         {% endfor %}
     }
 
     {% for child in top_node.children() %}
     {% if child.inst_name %}
-    {{ child.inst_name }}_t {{ child.inst_name }}{0x{{ "%x" | format(child.absolute_address if child.absolute_address else 0) }}};
+    {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{0x{{ "%x" | format(child.absolute_address if child.absolute_address else 0) }}};
     {% endif %}
     {% endfor %}
 };

--- a/src/peakrdl_pybind11/templates/runtime.py.jinja
+++ b/src/peakrdl_pybind11/templates/runtime.py.jinja
@@ -83,43 +83,43 @@ __all__.append('wrap_master')
 # Generated flag/enum types from SystemRDL fields
 {% if nodes.flag_regs %}
 {% for reg in nodes.flag_regs %}
-class {{ reg.inst_name }}_f(RegisterIntFlag):
-    """Bit flags for {{ reg.inst_name }}."""
+class {{ reg.inst_name | safe_id }}_f(RegisterIntFlag):
+    """Bit flags for {{ reg.inst_name | safe_id }}."""
     {% set fields = reg.fields()|list %}
     {% if fields %}
     {% for field in fields %}
-    {{ field.inst_name }} = {{ ((2 ** field.width) - 1) * (2 ** field.low) if field.width > 1 else (2 ** field.low) }}
+    {{ field.inst_name | safe_id }} = {{ ((2 ** field.width) - 1) * (2 ** field.low) if field.width > 1 else (2 ** field.low) }}
     {% set alias = field.inst_name | enum_member %}
     {% if alias != field.inst_name %}
-    {{ alias }} = {{ field.inst_name }}
+    {{ alias }} = {{ field.inst_name | safe_id }}
     {% endif %}
     {% endfor %}
     {% else %}
     pass
     {% endif %}
 
-__all__.append('{{ reg.inst_name }}_f')
+__all__.append('{{ reg.inst_name | safe_id }}_f')
 {% endfor %}
 {% endif %}
 
 {% if nodes.enum_regs %}
 {% for reg in nodes.enum_regs %}
-class {{ reg.inst_name }}_e(RegisterIntEnum):
-    """Enum for {{ reg.inst_name }}."""
+class {{ reg.inst_name | safe_id }}_e(RegisterIntEnum):
+    """Enum for {{ reg.inst_name | safe_id }}."""
     {% set fields = reg.fields()|list %}
     {% if fields %}
     {% for field in fields %}
-    {{ field.inst_name }} = {{ 2 ** field.low }}
+    {{ field.inst_name | safe_id }} = {{ 2 ** field.low }}
     {% set alias = field.inst_name | enum_member %}
     {% if alias != field.inst_name %}
-    {{ alias }} = {{ field.inst_name }}
+    {{ alias }} = {{ field.inst_name | safe_id }}
     {% endif %}
     {% endfor %}
     {% else %}
     pass
     {% endif %}
 
-__all__.append('{{ reg.inst_name }}_e')
+__all__.append('{{ reg.inst_name | safe_id }}_e')
 {% endfor %}
 {% endif %}
 
@@ -203,13 +203,13 @@ def _make_enhanced_field_write(field_class):
 # Map register classes to generated flag/enum types
 _FLAG_REG_TYPES = {
 {% for reg in nodes.flag_regs %}
-    {{ reg.inst_name }}_t: {{ reg.inst_name }}_f,
+    {{ reg.inst_name | safe_id }}_t: {{ reg.inst_name | safe_id }}_f,
 {% endfor %}
 }
 
 _ENUM_REG_TYPES = {
 {% for reg in nodes.enum_regs %}
-    {{ reg.inst_name }}_t: {{ reg.inst_name }}_e,
+    {{ reg.inst_name | safe_id }}_t: {{ reg.inst_name | safe_id }}_e,
 {% endfor %}
 }
 

--- a/src/peakrdl_pybind11/templates/stubs.pyi.jinja
+++ b/src/peakrdl_pybind11/templates/stubs.pyi.jinja
@@ -80,12 +80,12 @@ class NodeBase:
 
 {% if nodes.flag_regs %}
 {% for reg in nodes.flag_regs %}
-class {{ reg.inst_name }}_f(RegisterIntFlag):
-    """Flags for {{ reg.inst_name }}."""
+class {{ reg.inst_name | safe_id }}_f(RegisterIntFlag):
+    """Flags for {{ reg.inst_name | safe_id }}."""
     {% set fields = reg.fields()|list %}
     {% if fields %}
     {% for field in fields %}
-    {{ field.inst_name }} = ...
+    {{ field.inst_name | safe_id }} = ...
     {% set alias = field.inst_name | enum_member %}
     {% if alias != field.inst_name %}
     {{ alias }} = ...
@@ -100,12 +100,12 @@ class {{ reg.inst_name }}_f(RegisterIntFlag):
 
 {% if nodes.enum_regs %}
 {% for reg in nodes.enum_regs %}
-class {{ reg.inst_name }}_e(RegisterIntEnum):
-    """Enum for {{ reg.inst_name }}."""
+class {{ reg.inst_name | safe_id }}_e(RegisterIntEnum):
+    """Enum for {{ reg.inst_name | safe_id }}."""
     {% set fields = reg.fields()|list %}
     {% if fields %}
     {% for field in fields %}
-    {{ field.inst_name }} = ...
+    {{ field.inst_name | safe_id }} = ...
     {% set alias = field.inst_name | enum_member %}
     {% if alias != field.inst_name %}
     {{ alias }} = ...
@@ -119,8 +119,8 @@ class {{ reg.inst_name }}_e(RegisterIntEnum):
 {% endif %}
 
 {% for reg in nodes.regs %}
-class {{ reg.inst_name }}_t(RegisterBase):
-    """Register: {{ reg.inst_name }}
+class {{ reg.inst_name | safe_id }}_t(RegisterBase):
+    """Register: {{ reg.inst_name | safe_id }}
     {% if reg.get_property('desc') %}
     {{ reg.get_property('desc') }}
     {% endif %}"""
@@ -128,11 +128,11 @@ class {{ reg.inst_name }}_t(RegisterBase):
     def __init__(self, base_offset: int) -> None: ...
 
     {% if reg in nodes.flag_regs %}
-    def read(self) -> {{ reg.inst_name }}_f:
+    def read(self) -> {{ reg.inst_name | safe_id }}_f:
         """Read the full register value"""
         ...
     {% elif reg in nodes.enum_regs %}
-    def read(self) -> {{ reg.inst_name }}_e:
+    def read(self) -> {{ reg.inst_name | safe_id }}_e:
         """Read the full register value"""
         ...
     {% else %}
@@ -142,8 +142,8 @@ class {{ reg.inst_name }}_t(RegisterBase):
     {% endif %}
     
     {% for field in reg.fields() %}
-    class {{ field.inst_name }}_field(FieldBase):
-        """Field: {{ field.inst_name }}
+    class {{ field.inst_name | safe_id }}_field(FieldBase):
+        """Field: {{ field.inst_name | safe_id }}
         {% if field.get_property('desc') %}
         {{ field.get_property('desc') }}
         {% endif %}"""
@@ -156,15 +156,15 @@ class {{ reg.inst_name }}_t(RegisterBase):
             """Write field value"""
             ...
     
-    {{ field.inst_name }}: {{ field.inst_name }}_field
+    {{ field.inst_name | safe_id }}: {{ field.inst_name | safe_id }}_field
     {% endfor %}
 
 {% endfor %}
 
 {% for mem in nodes.mems %}
 {%- set entry_reg = mem.children()|list|first %}
-class {{ mem.inst_name }}_t(NodeBase):
-    """Memory: {{ mem.inst_name }}
+class {{ mem.inst_name | safe_id }}_t(NodeBase):
+    """Memory: {{ mem.inst_name | safe_id }}
     {% if mem.get_property('desc') %}
     {{ mem.get_property('desc') }}
     {% endif %}
@@ -179,16 +179,16 @@ class {{ mem.inst_name }}_t(NodeBase):
         ...
     
     @overload
-    def __getitem__(self, index: int) -> {{ entry_reg.inst_name }}_t:
+    def __getitem__(self, index: int) -> {{ entry_reg.inst_name | safe_id }}_t:
         """Access memory entry by index"""
         ...
     
     @overload
-    def __getitem__(self, index: slice) -> list[{{ entry_reg.inst_name }}_t]:
+    def __getitem__(self, index: slice) -> list[{{ entry_reg.inst_name | safe_id }}_t]:
         """Access memory entries by slice"""
         ...
     
-    def __iter__(self) -> Iterator[{{ entry_reg.inst_name }}_t]:
+    def __iter__(self) -> Iterator[{{ entry_reg.inst_name | safe_id }}_t]:
         """Iterate over memory entries"""
         ...
 
@@ -205,7 +205,7 @@ class {{ soc_name }}_t(NodeBase):
     
     {% for child in top_node.children() %}
     {% if child.inst_name %}
-    {{ child.inst_name }}: {{ child.inst_name }}_t
+    {{ child.inst_name | safe_id }}: {{ child.inst_name | safe_id }}_t
     {% endif %}
     {% endfor %}
 

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -258,10 +258,6 @@ addrmap kw_soc {
 """
 
 
-@pytest.mark.xfail(
-    reason="Issue #34: identifier sanitizer does not protect Python/C++ keywords",
-    strict=True,
-)
 def test_issue_34_reserved_word_identifiers_produce_valid_python() -> None:
     out = _export(RESERVED_WORD_RDL, "kw_soc", split_bindings=0)
     try:


### PR DESCRIPTION
## Summary

`Pybind11Exporter._sanitize_identifier` now appends a trailing underscore to
any sanitized name that collides with a Python or C++ reserved word, plus
the generator's own base classes (`Master`, `RegisterBase`, `FieldBase`,
`NodeBase`, `MemoryBase`). The sanitizer is exposed as the Jinja filter
`safe_id`, and every `{{ x.inst_name }}` occurrence in the generated
templates — including the new `descriptors/` sub-templates from #27 —
now flows through the filter.

An RDL register named `class` or `template` no longer produces invalid
Python/C++; the generated identifier becomes `class_` / `template_`
consistently across descriptors, bindings, runtime module, and stub files.

Drops the corresponding xfail marker. Reimplemented (rather than
cherry-picked) on top of the post-#27 sub-template layout.

Closes #34.

## Test plan

- [x] `uv run pytest tests/` — 51 passed, 8 skipped, 1 xfailed
- [x] #34 regression test green; runs `ast.parse` on the generated
      `__init__.py` and `__init__.pyi` for an RDL whose registers are
      named `class` and `template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
