### PR TITLE
Use relative address_offset in nested register descriptors (#32)

### DIFF
--- a/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
@@ -4,7 +4,7 @@
 class {{ addrmap.inst_name | safe_id }}_t : public NodeBase {
 public:
     {{ addrmap.inst_name | safe_id }}_t(uint64_t base_offset)
-        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset) {
+        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(addrmap.address_offset) }}) {
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
         {{ child.inst_name | safe_id }}.set_master(master_);

--- a/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
@@ -5,7 +5,7 @@
 class {{ mem.inst_name | safe_id }}_t : public MemoryBase<{{ entry_reg.inst_name | safe_id }}_t> {
 public:
     {{ mem.inst_name | safe_id }}_t(uint64_t base_offset)
-        : MemoryBase<{{ entry_reg.inst_name | safe_id }}_t>("{{ mem.inst_name | safe_id }}", base_offset, {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
+        : MemoryBase<{{ entry_reg.inst_name | safe_id }}_t>("{{ mem.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(mem.address_offset) }}, {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
 
     void set_offset(uint64_t base_offset) {
         offset_ = base_offset;

--- a/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
@@ -3,7 +3,7 @@
 class {{ regfile.inst_name | safe_id }}_t : public NodeBase {
 public:
     {{ regfile.inst_name | safe_id }}_t(uint64_t base_offset)
-        : NodeBase("{{ regfile.inst_name | safe_id }}", base_offset) {
+        : NodeBase("{{ regfile.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(regfile.address_offset) }}) {
         {% for child in regfile.children() %}
         {% if child.inst_name %}
         {{ child.inst_name | safe_id }}.set_master(master_);

--- a/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
@@ -3,7 +3,7 @@
 class {{ reg.inst_name | safe_id }}_t : public RegisterBase {
 public:
     {{ reg.inst_name | safe_id }}_t(uint64_t base_offset)
-        : RegisterBase("{{ reg.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(reg.absolute_address) }}, {{ reg.size }}) {}
+        : RegisterBase("{{ reg.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(reg.address_offset) }}, {{ reg.size }}) {}
 
     {% for field in reg.fields() %}
     // Field: {{ field.inst_name | safe_id }}

--- a/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
@@ -1,26 +1,11 @@
 // Top-level SoC class
 class {{ soc_name }}_t : public NodeBase {
 public:
-    {{ soc_name }}_t() : NodeBase("{{ soc_name }}", 0) {
-        {% for child in top_node.children() %}
-        {% if child.inst_name and not child.__class__.__name__ == 'RegNode' %}
-        {{ child.inst_name | safe_id }}.set_offset(offset_);
-        {% endif %}
-        {% endfor %}
-    }
+    {{ soc_name }}_t() : NodeBase("{{ soc_name }}", 0) {}
 
     void attach_master(Master* master) {
         set_master(master);
         propagate_master(master);
-    }
-
-    void set_offset(uint64_t offset) {
-        offset_ = offset;
-        {% for child in top_node.children() %}
-        {% if child.inst_name and not child.__class__.__name__ == 'RegNode' %}
-        {{ child.inst_name | safe_id }}.set_offset(offset_);
-        {% endif %}
-        {% endfor %}
     }
 
     void propagate_master(Master* master) {
@@ -31,9 +16,13 @@ public:
         {% endfor %}
     }
 
+    // Each child contributes its own address_offset on top of the base passed
+    // here, so the SoC always passes its own offset (0). Containers'
+    // set_offset() does not propagate to children -- treat the address layout
+    // as fixed at construction time.
     {% for child in top_node.children() %}
     {% if child.inst_name %}
-    {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{0x{{ "%x" | format(child.absolute_address if child.absolute_address else 0) }}};
+    {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{offset_};
     {% endif %}
     {% endfor %}
 };

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -186,10 +186,6 @@ int main() {{
     return run_result.returncode
 
 
-@pytest.mark.xfail(
-    reason="Issue #32: top-level register absolute_address is double-counted",
-    strict=True,
-)
 def test_issue_32_top_level_register_address() -> None:
     out = _export(ADDR_RDL, "addr_soc", split_bindings=0)
     try:

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -92,10 +92,13 @@ class TestMemoryIntegration:
             assert 'class ctrl_mem_t' in descriptor_content
             assert 'MemoryBase<entry_t>' in descriptor_content
             
-            # Verify all entry registers have correct offsets
-            # The memory starts at 0x1000 with 64 entries of 4 bytes each
+            # Verify entry register constructor adds its own (relative)
+            # address_offset on top of the base offset passed by the parent.
+            # The mem entry's address_offset is 0 -- the memory itself
+            # contributes the +0x1000 in its own constructor.
             assert 'entry_t(uint64_t base_offset)' in descriptor_content
-            assert 'RegisterBase("entry", base_offset + 0x1000, 4)' in descriptor_content
+            assert 'RegisterBase("entry", base_offset + 0x0, 4)' in descriptor_content
+            assert 'MemoryBase<entry_t>("ctrl_mem", base_offset + 0x1000, 64, 4)' in descriptor_content
             
             # Verify bindings content has memory interface
             with open(os.path.join(tmpdir, 'integration_test_bindings.cpp')) as f:


### PR DESCRIPTION
## Summary

Each level of the descriptor hierarchy now adds only its own
`address_offset` on top of the base passed by its parent, rather than
always adding the *absolute* address from the top of the RDL. This fixes
two related correctness problems:

- Top-level RegNode children were double-counting their own absolute
  address (SoC passed it in, RegNode added it again).
- Registers and regfiles inside another regfile/addrmap saw the parent's
  offset added on top of their already-absolute address, pushing all
  nested registers to wrong locations.

Construction model:
- `RegisterBase` init: `base_offset + reg.address_offset`
- `regfile/addrmap NodeBase` init: `base_offset + own.address_offset`
- `MemoryBase` init: `base_offset + mem.address_offset`
- SoC top member init: passes `offset_` (= 0) to every child

Removed the SoC's `set_offset()` method and the constructor body that
called `set_offset()` on children. Under the new model these would
*overwrite* a child's correctly-computed offset with the SoC's. The
container `set_offset()` methods on regfile/addrmap remain as no-ops that
update the parent's own `offset_` but do not propagate to children —
runtime offset mutation is intentionally out of scope here (tracked
separately under #38).

Updated `tests/test_memory_integration.py:98-99` for the new
construction shape: the entry register adds its own `address_offset` (0)
and the memory class itself contributes the `+0x1000`.

Reimplemented on top of the post-#27 sub-template layout (registers,
regfiles, addrmaps, memories, top_node sub-files).

Closes #32.

## Test plan

- [x] `uv run pytest tests/` — 52 passed, 8 skipped, 0 xfailed
- [x] #32 regression test compiles a g++ probe that asserts
      `soc.top_reg.offset() == 0x40` and
      `soc.block.nested_reg.offset() == 0x210`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
