### PR TITLE
Add virtual set_offset; stop reassigning memory entries (#38)

### DIFF
--- a/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
@@ -4,7 +4,7 @@
 class {{ addrmap.inst_name | safe_id }}_t : public NodeBase {
 public:
     {{ addrmap.inst_name | safe_id }}_t(uint64_t base_offset)
-        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(addrmap.address_offset) }}) {
+        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset, 0x{{ "%x" | format(addrmap.address_offset) }}) {
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
         {{ child.inst_name | safe_id }}.set_master(master_);
@@ -21,8 +21,15 @@ public:
         {% endfor %}
     }
 
-    void set_offset(uint64_t base_offset) {
-        offset_ = base_offset;
+    void set_offset(uint64_t base_offset) override {
+        NodeBase::set_offset(base_offset);
+        // Each child receives this addrmap's new absolute offset; the child
+        // then re-applies its own relative offset internally.
+        {% for child in addrmap.children() %}
+        {% if child.inst_name %}
+        {{ child.inst_name | safe_id }}.set_offset(offset_);
+        {% endif %}
+        {% endfor %}
     }
 
     {% for child in addrmap.children() %}

--- a/src/peakrdl_pybind11/templates/descriptors/base_classes.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/base_classes.hpp.jinja
@@ -24,56 +24,20 @@ public:
 };
 
 /**
- * Base class for register fields
- */
-class FieldBase {
-public:
-    FieldBase(const std::string& name, uint64_t offset,
-              uint8_t lsb, uint8_t width, bool readable, bool writable)
-        : name_(name), offset_(offset), lsb_(lsb),
-          width_(width), readable_(readable), writable_(writable) {}
-
-    virtual ~FieldBase() = default;
-
-    const std::string& name() const { return name_; }
-    uint64_t offset() const { return offset_; }
-    uint8_t lsb() const { return lsb_; }
-    uint8_t msb() const { return lsb_ + width_ - 1; }
-    uint8_t width() const { return width_; }
-    bool is_readable() const { return readable_; }
-    bool is_writable() const { return writable_; }
-
-    uint64_t mask() const {
-        return ((1ULL << width_) - 1) << lsb_;
-    }
-
-    /**
-     * String representation
-     */
-    std::string __repr__() const {
-        std::ostringstream oss;
-        oss << "<Field '" << name_ << "' @ 0x" << std::hex << offset_
-            << " [" << std::dec << static_cast<int>(msb()) << ":" << static_cast<int>(lsb()) << "]"
-            << (readable_ ? " R" : "") << (writable_ ? "W" : "") << ">";
-        return oss.str();
-    }
-
-protected:
-    std::string name_;
-    uint64_t offset_;
-    uint8_t lsb_;
-    uint8_t width_;
-    bool readable_;
-    bool writable_;
-};
-
-/**
  * Base class for registers
+ *
+ * The constructor takes ``base_offset`` (the parent's absolute offset) and
+ * ``relative_offset`` (this register's offset relative to the parent). The
+ * absolute offset is recomputed every time ``set_offset()`` is called, so
+ * a parent can relocate the whole subtree by walking its children. Using
+ * ``set_offset()`` preserves object identity -- pybind11 references handed
+ * out via ``reference_internal`` remain valid.
  */
 class RegisterBase {
 public:
-    RegisterBase(const std::string& name, uint64_t offset, size_t width)
-        : name_(name), offset_(offset), width_(width), master_(nullptr),
+    RegisterBase(const std::string& name, uint64_t base_offset, uint64_t relative_offset, size_t width)
+        : name_(name), offset_(base_offset + relative_offset),
+          relative_offset_(relative_offset), width_(width), master_(nullptr),
           in_context_(false), cached_value_(0) {}
 
     virtual ~RegisterBase() = default;
@@ -83,6 +47,16 @@ public:
     size_t width() const { return width_; }
 
     void set_master(Master* master) { master_ = master; }
+
+    /**
+     * Update the absolute offset given a new parent base. This rewrites
+     * ``offset_`` in place and is safe to call while pybind11 holds
+     * references into the register; cached state (master, in_context,
+     * cached_value) is preserved.
+     */
+    virtual void set_offset(uint64_t base_offset) {
+        offset_ = base_offset + relative_offset_;
+    }
 
     /**
      * Read the full register value
@@ -165,6 +139,7 @@ public:
 protected:
     std::string name_;
     uint64_t offset_;
+    uint64_t relative_offset_;
     size_t width_;
     Master* master_;
     bool in_context_;
@@ -172,12 +147,65 @@ protected:
 };
 
 /**
+ * Base class for register fields
+ *
+ * Fields read their offset dynamically from their parent register, so a
+ * parent's ``set_offset()`` propagates to every field without explicit
+ * fan-out. Per-field metadata (lsb/width/access) is constant.
+ */
+class FieldBase {
+public:
+    FieldBase(const std::string& name, RegisterBase* parent_register,
+              uint8_t lsb, uint8_t width, bool readable, bool writable)
+        : name_(name), parent_register_(parent_register), lsb_(lsb),
+          width_(width), readable_(readable), writable_(writable) {}
+
+    virtual ~FieldBase() = default;
+
+    const std::string& name() const { return name_; }
+    uint64_t offset() const { return parent_register_->offset(); }
+    uint8_t lsb() const { return lsb_; }
+    uint8_t msb() const { return lsb_ + width_ - 1; }
+    uint8_t width() const { return width_; }
+    bool is_readable() const { return readable_; }
+    bool is_writable() const { return writable_; }
+
+    uint64_t mask() const {
+        return ((1ULL << width_) - 1) << lsb_;
+    }
+
+    /**
+     * String representation
+     */
+    std::string __repr__() const {
+        std::ostringstream oss;
+        oss << "<Field '" << name_ << "' @ 0x" << std::hex << offset()
+            << " [" << std::dec << static_cast<int>(msb()) << ":" << static_cast<int>(lsb()) << "]"
+            << (readable_ ? " R" : "") << (writable_ ? "W" : "") << ">";
+        return oss.str();
+    }
+
+protected:
+    std::string name_;
+    RegisterBase* parent_register_;
+    uint8_t lsb_;
+    uint8_t width_;
+    bool readable_;
+    bool writable_;
+};
+
+/**
  * Base class for address maps and register files
+ *
+ * Same construction model as RegisterBase: parent passes ``base_offset``,
+ * the node stores its own ``relative_offset`` and recomputes ``offset_``
+ * on every ``set_offset()``.
  */
 class NodeBase {
 public:
-    NodeBase(const std::string& name, uint64_t offset)
-        : name_(name), offset_(offset), master_(nullptr) {}
+    NodeBase(const std::string& name, uint64_t base_offset, uint64_t relative_offset = 0)
+        : name_(name), offset_(base_offset + relative_offset),
+          relative_offset_(relative_offset), master_(nullptr) {}
 
     virtual ~NodeBase() = default;
 
@@ -186,6 +214,14 @@ public:
 
     virtual void set_master(Master* master) {
         master_ = master;
+    }
+
+    /**
+     * Update the absolute offset given a new parent base. Subclasses
+     * override this to also propagate the new base to their children.
+     */
+    virtual void set_offset(uint64_t base_offset) {
+        offset_ = base_offset + relative_offset_;
     }
 
     /**
@@ -201,22 +237,30 @@ public:
 protected:
     std::string name_;
     uint64_t offset_;
+    uint64_t relative_offset_;
     Master* master_;
 };
 
 /**
  * Base class for memory arrays
  * Provides list-like interface for accessing memory entries
+ *
+ * ``set_offset()`` updates each entry **in place** via the entry's own
+ * ``set_offset()``. Entries are not destroyed/reassigned, so any pybind11
+ * reference handed out via ``reference_internal`` (and any cached state
+ * on the entry: master, in_context, cached_value) remains valid.
  */
 template<typename EntryType>
 class MemoryBase : public NodeBase {
 public:
-    MemoryBase(const std::string& name, uint64_t base_offset, size_t num_entries, size_t entry_size)
-        : NodeBase(name, base_offset), num_entries_(num_entries), entry_size_(entry_size) {
-        // Pre-allocate all entries
+    MemoryBase(const std::string& name, uint64_t base_offset, uint64_t relative_offset,
+               size_t num_entries, size_t entry_size)
+        : NodeBase(name, base_offset, relative_offset),
+          num_entries_(num_entries), entry_size_(entry_size) {
+        // Pre-allocate all entries with the correct per-slot base offset.
         entries_.reserve(num_entries);
         for (size_t i = 0; i < num_entries; ++i) {
-            entries_.emplace_back(base_offset + i * entry_size);
+            entries_.emplace_back(offset_ + i * entry_size);
         }
     }
 
@@ -226,6 +270,13 @@ public:
         NodeBase::set_master(master);
         for (auto& entry : entries_) {
             entry.set_master(master);
+        }
+    }
+
+    void set_offset(uint64_t base_offset) override {
+        NodeBase::set_offset(base_offset);
+        for (size_t i = 0; i < entries_.size(); ++i) {
+            entries_[i].set_offset(offset_ + i * entry_size_);
         }
     }
 

--- a/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/memories.hpp.jinja
@@ -5,20 +5,10 @@
 class {{ mem.inst_name | safe_id }}_t : public MemoryBase<{{ entry_reg.inst_name | safe_id }}_t> {
 public:
     {{ mem.inst_name | safe_id }}_t(uint64_t base_offset)
-        : MemoryBase<{{ entry_reg.inst_name | safe_id }}_t>("{{ mem.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(mem.address_offset) }}, {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
-
-    void set_offset(uint64_t base_offset) {
-        offset_ = base_offset;
-        // Update all entry offsets
-        size_t entry_size = {{ entry_reg.size }};
-        for (size_t i = 0; i < entries_.size(); ++i) {
-            entries_[i] = {{ entry_reg.inst_name | safe_id }}_t(base_offset + i * entry_size);
-        }
-        // Re-apply master if set
-        if (master_) {
-            set_master(master_);
-        }
-    }
+        : MemoryBase<{{ entry_reg.inst_name | safe_id }}_t>(
+              "{{ mem.inst_name | safe_id }}", base_offset,
+              0x{{ "%x" | format(mem.address_offset) }},
+              {{ mem.get_property('mementries') }}, {{ entry_reg.size }}) {}
 };
 
 {% endfor %}

--- a/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/regfiles.hpp.jinja
@@ -3,7 +3,7 @@
 class {{ regfile.inst_name | safe_id }}_t : public NodeBase {
 public:
     {{ regfile.inst_name | safe_id }}_t(uint64_t base_offset)
-        : NodeBase("{{ regfile.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(regfile.address_offset) }}) {
+        : NodeBase("{{ regfile.inst_name | safe_id }}", base_offset, 0x{{ "%x" | format(regfile.address_offset) }}) {
         {% for child in regfile.children() %}
         {% if child.inst_name %}
         {{ child.inst_name | safe_id }}.set_master(master_);
@@ -20,8 +20,15 @@ public:
         {% endfor %}
     }
 
-    void set_offset(uint64_t base_offset) {
-        offset_ = base_offset;
+    void set_offset(uint64_t base_offset) override {
+        NodeBase::set_offset(base_offset);
+        // Each child receives this regfile's new absolute offset; the child
+        // then re-applies its own relative offset internally.
+        {% for child in regfile.children() %}
+        {% if child.inst_name %}
+        {{ child.inst_name | safe_id }}.set_offset(offset_);
+        {% endif %}
+        {% endfor %}
     }
 
     {% for child in regfile.children() %}

--- a/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
@@ -3,14 +3,14 @@
 class {{ reg.inst_name | safe_id }}_t : public RegisterBase {
 public:
     {{ reg.inst_name | safe_id }}_t(uint64_t base_offset)
-        : RegisterBase("{{ reg.inst_name | safe_id }}", base_offset + 0x{{ "%x" | format(reg.address_offset) }}, {{ reg.size }}) {}
+        : RegisterBase("{{ reg.inst_name | safe_id }}", base_offset, 0x{{ "%x" | format(reg.address_offset) }}, {{ reg.size }}) {}
 
     {% for field in reg.fields() %}
     // Field: {{ field.inst_name | safe_id }}
     class {{ field.inst_name | safe_id }}_field : public FieldBase {
     public:
         {{ field.inst_name | safe_id }}_field({{ reg.inst_name | safe_id }}_t* parent)
-            : FieldBase("{{ field.inst_name | safe_id }}", parent->offset(),
+            : FieldBase("{{ field.inst_name | safe_id }}", parent,
                        {{ field.low }}, {{ field.width }},
                        {{ 'true' if field.is_hw_readable or field.is_sw_readable else 'false' }},
                        {{ 'true' if field.is_hw_writable or field.is_sw_writable else 'false' }}),

--- a/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/top_node.hpp.jinja
@@ -16,10 +16,24 @@ public:
         {% endfor %}
     }
 
-    // Each child contributes its own address_offset on top of the base passed
-    // here, so the SoC always passes its own offset (0). Containers'
-    // set_offset() does not propagate to children -- treat the address layout
-    // as fixed at construction time.
+    /**
+     * Move the entire register map to a new base address. Each top-level
+     * child receives this new base; their set_offset overrides recurse
+     * through any nested regfiles, addrmaps, memories, and registers.
+     * Existing pybind11 references into the SoC remain valid -- nothing
+     * is destroyed or reassigned.
+     */
+    void set_offset(uint64_t base_offset) override {
+        NodeBase::set_offset(base_offset);
+        {% for child in top_node.children() %}
+        {% if child.inst_name %}
+        {{ child.inst_name | safe_id }}.set_offset(offset_);
+        {% endif %}
+        {% endfor %}
+    }
+
+    // Each child contributes its own address_offset on top of the base
+    // passed here, so the SoC always passes its own offset (initially 0).
     {% for child in top_node.children() %}
     {% if child.inst_name %}
     {{ child.inst_name | safe_id }}_t {{ child.inst_name | safe_id }}{offset_};

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -14,6 +14,8 @@ Tracked issues (https://github.com/arnavsacheti/PeakRDL-pybind11/issues):
   #34 Identifier sanitization does not handle reserved words / collisions
   #35 Generated IntFlag/IntEnum values use bit positions, not encodings
   #36 MockMaster.read ignores width
+  #37 Runtime enhancement layer was heuristic
+  #38 Memory set_offset reassigned entries, breaking pybind11 references
 """
 
 from __future__ import annotations
@@ -537,3 +539,93 @@ def test_issue_36_mock_master_read_honours_width() -> None:
     assert master.read(0x100, 1) == 0xEF
     assert master.read(0x100, 2) == 0xBEEF
     assert master.read(0x100, 4) == 0xDEADBEEF
+
+
+# ---------------------------------------------------------------------------
+# Issue #38: memory set_offset must update entries in place, not reassign
+# ---------------------------------------------------------------------------
+MEMORY_RELOCATE_RDL = """
+addrmap relocate_soc {
+    external mem {
+        mementries = 4;
+        memwidth   = 32;
+        reg {
+            field { sw = rw; hw = r; } data[7:0];
+        } entry;
+    } ctrl_mem @ 0x1000;
+};
+"""
+
+
+def test_issue_38_memory_set_offset_preserves_entry_identity() -> None:
+    """Compile a g++ probe that:
+
+      1. holds a pointer to a memory entry,
+      2. calls ``mem.set_offset(...)`` to relocate the array,
+      3. confirms the *same* entry pointer reflects the new absolute
+         address (i.e. the entry was updated in place, not reassigned).
+    """
+    cxx = shutil.which("g++") or shutil.which("clang++")
+    if cxx is None:
+        pytest.skip("No C++ compiler available")
+
+    out = _export(MEMORY_RELOCATE_RDL, "relocate_soc", split_bindings=0)
+    try:
+        driver = os.path.join(out, "_probe.cpp")
+        with open(driver, "w") as f:
+            f.write(r"""
+#include <cstdio>
+#include "relocate_soc_descriptors.hpp"
+
+int main() {
+    relocate_soc::relocate_soc_t soc;
+
+    // Initial layout: ctrl_mem at 0x1000 with 32-bit (4-byte) entries.
+    auto* entry2_before = &soc.ctrl_mem[2];
+    auto offset_before  = entry2_before->offset();
+    if (offset_before != 0x1000ull + 2 * 4) {
+        std::fprintf(stderr, "entry[2] initial offset = 0x%llx, expected 0x1008\n",
+                     (unsigned long long)offset_before);
+        return 1;
+    }
+
+    // Relocate the whole SoC.
+    soc.set_offset(0x80000000ull);
+
+    // Pointer must still be valid AND must reflect the new layout.
+    auto* entry2_after = &soc.ctrl_mem[2];
+    if (entry2_after != entry2_before) {
+        std::fprintf(stderr, "entry[2] address changed across set_offset\n");
+        return 2;
+    }
+    auto offset_after = entry2_before->offset();
+    if (offset_after != 0x80001000ull + 2 * 4) {
+        std::fprintf(stderr, "entry[2] post-relocate offset = 0x%llx, expected 0x80001008\n",
+                     (unsigned long long)offset_after);
+        return 3;
+    }
+    return 0;
+}
+""")
+
+        binary = os.path.join(out, "_probe")
+        compile_result = subprocess.run(
+            [cxx, "-std=c++17", "-I", out, driver, "-o", binary],
+            capture_output=True,
+            timeout=30,
+        )
+        if compile_result.returncode != 0:
+            pytest.fail(
+                "Memory-relocation probe failed to compile:\n"
+                + compile_result.stdout.decode(errors="ignore")
+                + compile_result.stderr.decode(errors="ignore")
+            )
+
+        run_result = subprocess.run([binary], capture_output=True, timeout=10)
+        if run_result.returncode != 0:
+            print(run_result.stderr.decode(errors="ignore"))
+        assert run_result.returncode == 0, (
+            f"memory-relocation probe exited with {run_result.returncode}"
+        )
+    finally:
+        shutil.rmtree(out, ignore_errors=True)

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -92,13 +92,13 @@ class TestMemoryIntegration:
             assert 'class ctrl_mem_t' in descriptor_content
             assert 'MemoryBase<entry_t>' in descriptor_content
             
-            # Verify entry register constructor adds its own (relative)
-            # address_offset on top of the base offset passed by the parent.
-            # The mem entry's address_offset is 0 -- the memory itself
-            # contributes the +0x1000 in its own constructor.
+            # Verify entry register constructor passes (base, relative, width)
+            # to RegisterBase. The entry's relative address is 0 -- the
+            # memory contributes the +0x1000 via MemoryBase's relative_offset.
             assert 'entry_t(uint64_t base_offset)' in descriptor_content
-            assert 'RegisterBase("entry", base_offset + 0x0, 4)' in descriptor_content
-            assert 'MemoryBase<entry_t>("ctrl_mem", base_offset + 0x1000, 64, 4)' in descriptor_content
+            assert 'RegisterBase("entry", base_offset, 0x0, 4)' in descriptor_content
+            assert '"ctrl_mem", base_offset' in descriptor_content
+            assert '0x1000,' in descriptor_content
             
             # Verify bindings content has memory interface
             with open(os.path.join(tmpdir, 'integration_test_bindings.cpp')) as f:

--- a/tests/test_repr_integration.py
+++ b/tests/test_repr_integration.py
@@ -83,15 +83,15 @@ def test_repr_integration_build_and_use():
 
 int main() {
     // Just verify the code compiles
-    repr_test::FieldBase field("test", 0x1000, 0, 8, true, true);
-    std::string repr = field.__repr__();
-    
-    repr_test::RegisterBase reg("control", 0x0, 32);
-    repr = reg.__repr__();
-    
+    repr_test::RegisterBase reg("control", 0x0, 0x0, 32);
+    std::string repr = reg.__repr__();
+
+    repr_test::FieldBase field("test", &reg, 0, 8, true, true);
+    repr = field.__repr__();
+
     repr_test::NodeBase node("node", 0x1000);
     repr = node.__repr__();
-    
+
     return 0;
 }
 """)


### PR DESCRIPTION
## Summary

Memory's `set_offset` previously rebuilt every entry register in place via
copy-assignment. pybind11 hands out memory entries through
`reference_internal` and external code may hold those references;
reassigning the entry destroyed cached state (`master`, `in_context`,
`cached_value`) and invalidated the conceptual identity that pybind11's
reference policy implies.

Construction model is now uniform across the hierarchy. Every base
class (`RegisterBase`, `NodeBase`, `MemoryBase`) takes `(base_offset,
relative_offset)` at construction, stores the relative offset, and
exposes a **virtual `set_offset(uint64_t base_offset)`** that recomputes
its absolute offset in place. Container subclasses (regfile, addrmap,
SoC) override `set_offset` to also propagate to their children, so
moving a parent walks the whole subtree without any destruction or
reassignment.

`MemoryBase::set_offset` now calls each entry's `set_offset` rather
than reassigning. Entry pointers, master state, and in-context state
all survive a relocate.

`FieldBase` no longer caches the parent register's offset at
construction; it stores a `RegisterBase*` and reads `offset()`
dynamically, so a register's `set_offset` propagates to every field
without a fan-out walk.

Closes #38.

## Test plan

- [x] `uv run pytest tests/` — 62 passed, 7 skipped, 0 xfailed
- [x] New regression test compiles a g++/clang++ probe that:
  1. takes a pointer to `mem[2]`,
  2. calls `soc.set_offset(0x80000000)`,
  3. asserts the *same* pointer now reports offset `0x80001008`
- [x] `tests/test_repr_integration.py` updated for the new
      `RegisterBase` / `FieldBase` constructor signatures
- [x] `tests/test_memory_integration.py` updated for the new
      `MemoryBase` init shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
