### PR TITLE
Land Hypothesis property tests; fix sanitizer false positive on '_'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,11 @@ docs = [
     "sphinx-autodoc-typehints >= 2.0",
 ]
 benchmark = ["pytest >= 7.4.4", "pytest-benchmark >= 5.1.0", "build >= 1.0.0"]
-test = ["pytest >= 7.4.4", "pytest-cov >= 4.1.0"]
+test = [
+    "hypothesis>=6.151.9",
+    "pytest >= 7.4.4",
+    "pytest-cov >= 4.1.0",
+]
 tools = ["ty >= 0.0.15", "ruff >= 0.14.0"]
 
 [project.urls]

--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -10,9 +10,15 @@ from pathlib import Path
 from typing import TypedDict
 
 # Words that cannot be used as identifiers in either Python or C++.
+#
+# We deliberately use only ``keyword.kwlist`` (hard Python keywords) and skip
+# ``keyword.softkwlist`` -- soft keywords like ``_``, ``match``, ``case``,
+# ``type`` are only reserved in specific syntactic contexts (e.g. match-case
+# patterns) and remain valid identifiers everywhere else. Mangling them
+# would, for example, turn the bare ``_`` field into ``__``, which is more
+# disruptive than helpful.
 _RESERVED_WORDS: frozenset[str] = frozenset(
     set(keyword.kwlist)
-    | set(keyword.softkwlist)
     | {
         # C++ keywords / reserved identifiers that could collide with an RDL
         # inst_name. Not exhaustive -- focused on commonly-used names.

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,288 @@
+"""
+Property-based tests using Hypothesis for PeakRDL-pybind11.
+"""
+
+import re
+import string
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from peakrdl_pybind11 import FieldInt, RegisterInt
+from peakrdl_pybind11.masters import MockMaster
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Hardware registers are typically 8-64 bits wide, but FieldInt is a plain int
+# subclass with no documented upper bound on lsb/width. We keep values realistic
+# (up to 64-bit registers) while still exercising edge cases.
+field_lsb = st.integers(min_value=0, max_value=63)
+field_width = st.integers(min_value=1, max_value=64)
+
+# Register widths used in practice (bytes): 1, 2, 4, 8
+register_width_bytes = st.sampled_from([1, 2, 4, 8])
+
+
+@st.composite
+def non_overlapping_fields(draw: st.DrawFn) -> tuple[int, int, dict[str, tuple[int, int]]]:
+    """Generate a register value, register width in bytes, and a dict of non-overlapping fields.
+
+    Returns (value, width_bytes, fields) where fields maps name -> (lsb, bit_width).
+    The fields are guaranteed not to overlap and to fit within the register width.
+    """
+    width_bytes = draw(register_width_bytes)
+    total_bits = width_bytes * 8
+
+    # Generate a value that fits in the register
+    value = draw(st.integers(min_value=0, max_value=(1 << total_bits) - 1))
+
+    # Partition the register into non-overlapping fields by choosing split points
+    # We generate between 1 and min(6, total_bits) fields.
+    max_fields = min(6, total_bits)
+    num_fields = draw(st.integers(min_value=1, max_value=max_fields))
+
+    # Choose (num_fields - 1) unique split points in [1, total_bits - 1]
+    if total_bits == 1:
+        # Only one possible field: bit 0 with width 1
+        boundaries = [0, 1]
+    else:
+        splits = sorted(draw(st.lists(
+            st.integers(min_value=1, max_value=total_bits - 1),
+            min_size=num_fields - 1,
+            max_size=num_fields - 1,
+            unique=True,
+        )))
+        boundaries = [0] + splits + [total_bits]
+
+    fields: dict[str, tuple[int, int]] = {}
+    for i in range(len(boundaries) - 1):
+        lsb = boundaries[i]
+        w = boundaries[i + 1] - boundaries[i]
+        fields[f"f{i}"] = (lsb, w)
+
+    return value, width_bytes, fields
+
+
+# ---------------------------------------------------------------------------
+# FieldInt mask and msb mathematical invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFieldIntProperties:
+    """Property-based tests for FieldInt metadata calculations."""
+
+    @given(
+        value=st.integers(min_value=0, max_value=(1 << 64) - 1),
+        lsb=st.integers(min_value=0, max_value=63),
+        width=st.integers(min_value=1, max_value=64),
+        offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
+    )
+    def test_mask_has_correct_popcount(
+        self, value: int, lsb: int, width: int, offset: int
+    ) -> None:
+        """The mask should have exactly `width` bits set."""
+        field = FieldInt(value, lsb=lsb, width=width, offset=offset)
+        assert bin(field.mask).count("1") == width
+
+    @given(
+        value=st.integers(min_value=0, max_value=(1 << 64) - 1),
+        lsb=st.integers(min_value=0, max_value=63),
+        width=st.integers(min_value=1, max_value=64),
+        offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
+    )
+    def test_mask_starts_at_lsb(
+        self, value: int, lsb: int, width: int, offset: int
+    ) -> None:
+        """Shifting the mask right by `lsb` should give a contiguous run of `width` ones."""
+        field = FieldInt(value, lsb=lsb, width=width, offset=offset)
+        assert field.mask >> lsb == (1 << width) - 1
+
+    @given(
+        value=st.integers(min_value=0, max_value=(1 << 64) - 1),
+        lsb=st.integers(min_value=0, max_value=63),
+        width=st.integers(min_value=1, max_value=64),
+        offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
+    )
+    def test_msb_equals_lsb_plus_width_minus_one(
+        self, value: int, lsb: int, width: int, offset: int
+    ) -> None:
+        """msb should always equal lsb + width - 1."""
+        field = FieldInt(value, lsb=lsb, width=width, offset=offset)
+        assert field.msb == lsb + width - 1
+
+    @given(
+        value=st.integers(min_value=0, max_value=(1 << 64) - 1),
+        lsb=st.integers(min_value=0, max_value=63),
+        width=st.integers(min_value=1, max_value=64),
+        offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
+    )
+    def test_mask_no_bits_below_lsb(
+        self, value: int, lsb: int, width: int, offset: int
+    ) -> None:
+        """No bits below position `lsb` should be set in the mask."""
+        field = FieldInt(value, lsb=lsb, width=width, offset=offset)
+        if lsb > 0:
+            assert field.mask & ((1 << lsb) - 1) == 0
+
+
+# ---------------------------------------------------------------------------
+# RegisterInt field extraction round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterIntFieldExtraction:
+    """Property-based tests for RegisterInt field value extraction."""
+
+    @given(data=non_overlapping_fields())
+    def test_field_values_match_bitwise_extraction(
+        self, data: tuple[int, int, dict[str, tuple[int, int]]]
+    ) -> None:
+        """Each field's integer value should equal the bits extracted from the register value."""
+        value, width_bytes, fields = data
+        reg = RegisterInt(value, offset=0, width=width_bytes, fields=fields)
+
+        for name, (lsb, field_width) in fields.items():
+            expected = (value >> lsb) & ((1 << field_width) - 1)
+            actual = int(getattr(reg, name))
+            assert actual == expected, (
+                f"Field {name}: expected {expected:#x}, got {actual:#x} "
+                f"(value={value:#x}, lsb={lsb}, width={field_width})"
+            )
+
+    @given(data=non_overlapping_fields())
+    def test_fields_reconstruct_register_value(
+        self, data: tuple[int, int, dict[str, tuple[int, int]]]
+    ) -> None:
+        """Non-overlapping fields that cover all bits should reconstruct the original value."""
+        value, width_bytes, fields = data
+        reg = RegisterInt(value, offset=0, width=width_bytes, fields=fields)
+
+        reconstructed = 0
+        for name, (lsb, _field_width) in fields.items():
+            field_val = int(getattr(reg, name))
+            reconstructed |= field_val << lsb
+
+        # Our strategy generates fields covering all bits of the register
+        total_bits = width_bytes * 8
+        mask = (1 << total_bits) - 1
+        assert reconstructed == (value & mask)
+
+    @given(data=non_overlapping_fields())
+    def test_field_metadata_preserved(
+        self, data: tuple[int, int, dict[str, tuple[int, int]]]
+    ) -> None:
+        """Field metadata (lsb, width, offset) should be faithfully preserved."""
+        value, width_bytes, fields = data
+        offset = 0x4000
+        reg = RegisterInt(value, offset=offset, width=width_bytes, fields=fields)
+
+        for name, (lsb, field_width) in fields.items():
+            field = getattr(reg, name)
+            assert field.lsb == lsb
+            assert field.width == field_width
+            assert field.offset == offset
+
+
+# ---------------------------------------------------------------------------
+# MockMaster write/read round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMockMasterRoundTrip:
+    """Property-based tests for MockMaster write/read round-trip."""
+
+    @given(
+        address=st.integers(min_value=0, max_value=(1 << 32) - 1),
+        value=st.integers(min_value=0, max_value=(1 << 64) - 1),
+        width=register_width_bytes,
+    )
+    def test_write_read_roundtrip(self, address: int, value: int, width: int) -> None:
+        """Reading back a written value returns the value masked to the register width."""
+        master = MockMaster()
+        master.write(address, value, width)
+        result = master.read(address, width)
+
+        mask = (1 << (width * 8)) - 1
+        assert result == value & mask
+
+    @given(
+        address=st.integers(min_value=0, max_value=(1 << 32) - 1),
+        width=register_width_bytes,
+    )
+    def test_read_unwritten_returns_zero(self, address: int, width: int) -> None:
+        """Reading an address that was never written returns 0."""
+        master = MockMaster()
+        assert master.read(address, width) == 0
+
+    @given(
+        addr1=st.integers(min_value=0, max_value=(1 << 16) - 1),
+        addr2=st.integers(min_value=0, max_value=(1 << 16) - 1),
+        val1=st.integers(min_value=0, max_value=(1 << 32) - 1),
+        val2=st.integers(min_value=0, max_value=(1 << 32) - 1),
+        width=register_width_bytes,
+    )
+    def test_writes_to_different_addresses_are_independent(
+        self, addr1: int, addr2: int, val1: int, val2: int, width: int
+    ) -> None:
+        """Writing to one address does not affect the value at a different address."""
+        from hypothesis import assume
+
+        assume(addr1 != addr2)
+        master = MockMaster()
+        master.write(addr1, val1, width)
+        master.write(addr2, val2, width)
+
+        mask = (1 << (width * 8)) - 1
+        assert master.read(addr1, width) == val1 & mask
+        assert master.read(addr2, width) == val2 & mask
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_identifier: valid output and idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeIdentifier:
+    """Property-based tests for the identifier sanitization logic."""
+
+    VALID_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+    @staticmethod
+    def _sanitize(name: str) -> str:
+        """Standalone reimplementation of _sanitize_identifier for testing.
+
+        Matches the logic in Pybind11Exporter._sanitize_identifier exactly.
+        """
+        from peakrdl_pybind11 import Pybind11Exporter
+
+        exporter = Pybind11Exporter()
+        return exporter._sanitize_identifier(name)
+
+    @settings(deadline=None)
+    @given(name=st.text(min_size=0, max_size=200))
+    def test_output_is_always_valid_identifier(self, name: str) -> None:
+        """Sanitized output must always be a valid Python/C++ identifier."""
+        result = self._sanitize(name)
+        assert self.VALID_IDENTIFIER_RE.match(result), (
+            f"Sanitize({name!r}) produced invalid identifier: {result!r}"
+        )
+
+    @given(name=st.text(min_size=0, max_size=200))
+    def test_sanitize_is_idempotent(self, name: str) -> None:
+        """Applying sanitize twice should give the same result as applying it once."""
+        once = self._sanitize(name)
+        twice = self._sanitize(once)
+        assert once == twice
+
+    @given(
+        name=st.from_regex(r"[a-zA-Z_][a-zA-Z0-9_]*", fullmatch=True).filter(
+            lambda s: 1 <= len(s) <= 100
+        )
+    )
+    def test_valid_identifiers_are_unchanged(self, name: str) -> None:
+        """Strings that are already valid identifiers should pass through unchanged."""
+        result = self._sanitize(name)
+        assert result == name

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -3,14 +3,12 @@ Property-based tests using Hypothesis for PeakRDL-pybind11.
 """
 
 import re
-import string
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from peakrdl_pybind11 import FieldInt, RegisterInt
 from peakrdl_pybind11.masters import MockMaster
-
 
 # ---------------------------------------------------------------------------
 # Strategies
@@ -49,13 +47,17 @@ def non_overlapping_fields(draw: st.DrawFn) -> tuple[int, int, dict[str, tuple[i
         # Only one possible field: bit 0 with width 1
         boundaries = [0, 1]
     else:
-        splits = sorted(draw(st.lists(
-            st.integers(min_value=1, max_value=total_bits - 1),
-            min_size=num_fields - 1,
-            max_size=num_fields - 1,
-            unique=True,
-        )))
-        boundaries = [0] + splits + [total_bits]
+        splits = sorted(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=total_bits - 1),
+                    min_size=num_fields - 1,
+                    max_size=num_fields - 1,
+                    unique=True,
+                )
+            )
+        )
+        boundaries = [0, *splits, total_bits]
 
     fields: dict[str, tuple[int, int]] = {}
     for i in range(len(boundaries) - 1):
@@ -80,9 +82,7 @@ class TestFieldIntProperties:
         width=st.integers(min_value=1, max_value=64),
         offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
     )
-    def test_mask_has_correct_popcount(
-        self, value: int, lsb: int, width: int, offset: int
-    ) -> None:
+    def test_mask_has_correct_popcount(self, value: int, lsb: int, width: int, offset: int) -> None:
         """The mask should have exactly `width` bits set."""
         field = FieldInt(value, lsb=lsb, width=width, offset=offset)
         assert bin(field.mask).count("1") == width
@@ -93,9 +93,7 @@ class TestFieldIntProperties:
         width=st.integers(min_value=1, max_value=64),
         offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
     )
-    def test_mask_starts_at_lsb(
-        self, value: int, lsb: int, width: int, offset: int
-    ) -> None:
+    def test_mask_starts_at_lsb(self, value: int, lsb: int, width: int, offset: int) -> None:
         """Shifting the mask right by `lsb` should give a contiguous run of `width` ones."""
         field = FieldInt(value, lsb=lsb, width=width, offset=offset)
         assert field.mask >> lsb == (1 << width) - 1
@@ -106,9 +104,7 @@ class TestFieldIntProperties:
         width=st.integers(min_value=1, max_value=64),
         offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
     )
-    def test_msb_equals_lsb_plus_width_minus_one(
-        self, value: int, lsb: int, width: int, offset: int
-    ) -> None:
+    def test_msb_equals_lsb_plus_width_minus_one(self, value: int, lsb: int, width: int, offset: int) -> None:
         """msb should always equal lsb + width - 1."""
         field = FieldInt(value, lsb=lsb, width=width, offset=offset)
         assert field.msb == lsb + width - 1
@@ -119,9 +115,7 @@ class TestFieldIntProperties:
         width=st.integers(min_value=1, max_value=64),
         offset=st.integers(min_value=0, max_value=(1 << 32) - 1),
     )
-    def test_mask_no_bits_below_lsb(
-        self, value: int, lsb: int, width: int, offset: int
-    ) -> None:
+    def test_mask_no_bits_below_lsb(self, value: int, lsb: int, width: int, offset: int) -> None:
         """No bits below position `lsb` should be set in the mask."""
         field = FieldInt(value, lsb=lsb, width=width, offset=offset)
         if lsb > 0:
@@ -171,9 +165,7 @@ class TestRegisterIntFieldExtraction:
         assert reconstructed == (value & mask)
 
     @given(data=non_overlapping_fields())
-    def test_field_metadata_preserved(
-        self, data: tuple[int, int, dict[str, tuple[int, int]]]
-    ) -> None:
+    def test_field_metadata_preserved(self, data: tuple[int, int, dict[str, tuple[int, int]]]) -> None:
         """Field metadata (lsb, width, offset) should be faithfully preserved."""
         value, width_bytes, fields = data
         offset = 0x4000
@@ -277,11 +269,7 @@ class TestSanitizeIdentifier:
         twice = self._sanitize(once)
         assert once == twice
 
-    @given(
-        name=st.from_regex(r"[a-zA-Z_][a-zA-Z0-9_]*", fullmatch=True).filter(
-            lambda s: 1 <= len(s) <= 100
-        )
-    )
+    @given(name=st.from_regex(r"[a-zA-Z_][a-zA-Z0-9_]*", fullmatch=True).filter(lambda s: 1 <= len(s) <= 100))
     def test_valid_identifiers_are_unchanged(self, name: str) -> None:
         """Strings that are already valid identifiers should pass through unchanged."""
         result = self._sanitize(name)

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -8,6 +8,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from peakrdl_pybind11 import FieldInt, RegisterInt
+from peakrdl_pybind11.exporter import _RESERVED_WORDS
 from peakrdl_pybind11.masters import MockMaster
 
 # ---------------------------------------------------------------------------
@@ -269,8 +270,17 @@ class TestSanitizeIdentifier:
         twice = self._sanitize(once)
         assert once == twice
 
-    @given(name=st.from_regex(r"[a-zA-Z_][a-zA-Z0-9_]*", fullmatch=True).filter(lambda s: 1 <= len(s) <= 100))
+    @given(
+        name=st.from_regex(r"[a-zA-Z_][a-zA-Z0-9_]*", fullmatch=True)
+        .filter(lambda s: 1 <= len(s) <= 100)
+        # The sanitizer deliberately appends `_` to Python/C++ reserved words
+        # (e.g. `class`, `do`, `template`) so the generated code parses in
+        # both languages. Filter those out -- this test covers the
+        # non-reserved case; the reserved case is covered by
+        # test_known_bugs.test_issue_34_*.
+        .filter(lambda s: s not in _RESERVED_WORDS)
+    )
     def test_valid_identifiers_are_unchanged(self, name: str) -> None:
-        """Strings that are already valid identifiers should pass through unchanged."""
+        """Non-reserved valid identifiers should pass through unchanged."""
         result = self._sanitize(name)
         assert result == name

--- a/uv.lock
+++ b/uv.lock
@@ -316,11 +316,24 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
 ]
 
 [[package]]
@@ -346,7 +359,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -520,6 +533,7 @@ docs = [
     { name = "sphinx-book-theme" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -548,6 +562,7 @@ docs = [
     { name = "sphinx-book-theme", specifier = ">=1.0" },
 ]
 test = [
+    { name = "hypothesis", specifier = ">=6.151.9" },
     { name = "pytest", specifier = ">=7.4.4" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
 ]
@@ -715,6 +730,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts the property-based test suite from #28 and resolves the one
test it left failing on current main. Replaces #28.

PR #28 added 13 Hypothesis tests covering core invariants:

- **FieldInt mask/msb math** (4 tests): popcount, lsb alignment,
  msb formula, no bits below lsb.
- **RegisterInt field extraction** (3 tests): field values match
  bitwise extraction, non-overlapping fields reconstruct the
  register value, metadata preserved.
- **MockMaster round-trips** (3 tests): write/read consistency,
  unwritten reads return 0, address isolation.
- **Identifier sanitization** (3 tests): output is always a valid
  identifier, idempotent, valid identifiers pass through unchanged.

12 of 13 passed on current main as-is. The lone failure
(`test_valid_identifiers_are_unchanged`) found a real bug in our
sanitizer plus a too-narrow assertion in the test.

### Changes on top of #28

1. **Drop `keyword.softkwlist` from `_RESERVED_WORDS`**
   (`src/peakrdl_pybind11/exporter.py`). Soft keywords (`_`, `case`,
   `match`, `type`) are only reserved in specific syntactic positions
   (e.g. match-case patterns) and remain valid identifiers
   everywhere else. Mangling them was overzealous — a bare `_` field
   would become `__`, which is more disruptive than helpful. Hard
   Python keywords (`if`, `def`, `class`, ...) and the C++ keyword
   list still get sanitized.

2. **Filter `_RESERVED_WORDS` from the
   `test_valid_identifiers_are_unchanged` strategy**
   (`tests/test_hypothesis.py`). The sanitizer deliberately appends
   `_` to reserved words like `class` and `do` so the generated code
   parses in both languages; that's the intended behavior covered by
   `tests/test_known_bugs.py::test_issue_34_*`. This Hypothesis test
   now covers only the non-reserved case, which is the
   pass-through invariant it actually wants to assert.

## Test plan

- [x] `uv run pytest tests/` — 75 passed, 7 skipped, 0 xfailed
  (was 62 passed; +13 from this PR)
- [x] `uv run pytest tests/test_hypothesis.py` — 13 passed
- [x] `tests/test_known_bugs.py::test_issue_34_*` still passes
      (reserved-word sanitization unchanged for hard keywords +
      curated C++ list + generator base classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
