### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peakrdl-pybind11"
-version = "0.4.3"
+version = "0.5.0"
 description = "Export SystemRDL to PyBind11 modules for Python-based hardware testing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-pybind11"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Minor release rolling up the codebase-review fixes (#30-#38), the
property-test suite (#49), and the CI fixup (#50). Generated via
`uv version --bump minor` so both `pyproject.toml` and `uv.lock` are
updated together.

### Bug fixes
- #30 / #31 pybind11 class registration in single-file and split modes
- #32 nested register addresses (relative_offset model)
- #33 description strings escaped for C++ literals
- #34 reserved-word identifier sanitization (Python + C++)
- #35 multi-bit flag/enum field expansion + `flag_disable` / `flag_names` UDPs
- #36 master-backend cleanup (MockMaster width, OpenOCD/SSH error paths)
- #37 explicit codegen-time runtime enhancement tables
- #38 in-place `set_offset`; pybind11 references survive relocation

### Public API additions
- `Pybind11Exporter.register_udps(rdlc)` — programmatic UDP registration
- Two new field-level UDPs: `flag_disable`, `flag_names`

### Breaking C++ API (generated descriptors)
- `RegisterBase(name, base_offset, relative_offset, width)` — was 3 args
- `FieldBase(name, parent_register*, lsb, width, R, W)` — was offset
- `NodeBase(name, base_offset, relative_offset = 0)` — was 2 args
- `MemoryBase(name, base, relative, num_entries, entry_size)` — was 4 args
- All five base classes now expose `virtual set_offset(uint64_t base_offset)`

## Test plan
- [x] `uv run pytest tests/` — 75 passed, 7 skipped
- [x] `uvx ruff check . && uvx ruff format --check .` — clean
- [x] CI green on main as of #50
