### PR TITLE
Bump g++ probe subprocess timeouts to dodge Windows AV cold-start flakes

### DIFF
--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -171,10 +171,14 @@ int main() {{
 """)
 
     binary = os.path.join(out, "_probe")
+    # 120 s instead of 30 s: Windows mingw runners spend a lot of the wall
+    # time on antivirus scanning the freshly written binary, so the old
+    # 30 s budget intermittently hit TimeoutExpired even on a healthy
+    # toolchain. The actual compile is sub-second.
     compile_result = subprocess.run(
         [cxx, "-std=c++17", "-I", out, driver, "-o", binary],
         capture_output=True,
-        timeout=30,
+        timeout=120,
     )
     if compile_result.returncode != 0:
         pytest.fail(
@@ -183,7 +187,9 @@ int main() {{
             + compile_result.stderr.decode(errors="ignore")
         )
 
-    run_result = subprocess.run([binary], capture_output=True, timeout=10)
+    # 60 s instead of 10 s: same antivirus-on-first-run effect as the
+    # compile call above — actual probe execution is sub-second.
+    run_result = subprocess.run([binary], capture_output=True, timeout=60)
     if run_result.returncode != 0:
         # Surface the failure text so the regression is readable when triaging.
         print(run_result.stderr.decode(errors="ignore"))
@@ -611,10 +617,12 @@ int main() {
 """)
 
         binary = os.path.join(out, "_probe")
+        # 120 s instead of 30 s: see _build_address_probe for the same
+        # Windows-AV rationale.
         compile_result = subprocess.run(
             [cxx, "-std=c++17", "-I", out, driver, "-o", binary],
             capture_output=True,
-            timeout=30,
+            timeout=120,
         )
         if compile_result.returncode != 0:
             pytest.fail(
@@ -623,7 +631,8 @@ int main() {
                 + compile_result.stderr.decode(errors="ignore")
             )
 
-        run_result = subprocess.run([binary], capture_output=True, timeout=10)
+        # 60 s instead of 10 s: same antivirus-on-first-run effect.
+        run_result = subprocess.run([binary], capture_output=True, timeout=60)
         if run_result.returncode != 0:
             print(run_result.stderr.decode(errors="ignore"))
         assert run_result.returncode == 0, (


### PR DESCRIPTION
## Summary

`test_known_bugs.py` compiles a small C++ probe binary in two places (issue #32 register-address probe, issue #38 memory-relocation probe). On Windows mingw runners the compile itself is sub-second, but Windows Security scans the freshly written `.exe` synchronously on first invocation, intermittently pushing wall time past the old 30 s compile budget / 10 s execution budget.

Concrete failure: [main run 24964716884](https://github.com/arnavsacheti/PeakRDL-pybind11/actions/runs/24964716884), `test_issue_32_top_level_register_address` on `windows-latest, 3.12`. A vanilla GitHub Actions re-run cleared it, confirming the toolchain is fine — the timeouts are just too tight.

This bumps:

- compile timeout: 30 s → 120 s
- execution timeout: 10 s → 60 s

Both probe helpers updated. Real wall time on a healthy Windows runner stays well under either limit; the extra slack just absorbs AV-scan jitter so we stop flaking.

## Test plan

- [x] `pytest tests/test_known_bugs.py` (16 passed locally)
- [x] No behaviour change on success path — only the timeout window grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)