### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peakrdl-pybind11"
-version = "0.5.0"
+version = "0.6.0"
 description = "Export SystemRDL to PyBind11 modules for Python-based hardware testing"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts release v0.6.0. Highlights since 0.5.0 (#52, #53):

**Exporter fixes**
- Class names now path-derived (`top_earlgrey__uart0__INTR_STATE_t`) so reusing register names like `INTR_STATE` across IPs no longer redefines the same class at link time.
- Generated wheels ship as a real `<soc>/` Python package — `import <soc>` works after a vanilla `pip install .` with no manual reshuffling.
- `attach_master` uses `py::keep_alive<1, 2>` so passing inline temporaries no longer leaves the C++ raw pointer dangling.
- All generated files written as UTF-8 (Windows / cp1252 fix).

**Build / install performance**
- Generated CMakeLists passes `NO_EXTRAS` to `pybind11_add_module()` and uses a precompiled header for the giant descriptors header. Top_earlgrey-scale install: **21 m → 2 m 45 s** on M1.
- Strip-symbols guard rewritten with a generator expression so multi-config generators (Xcode / VS / Ninja Multi-Config) do the right thing.
- `install()` now sets `LIBRARY` + `RUNTIME` + `ARCHIVE` destinations so wheels work on Windows.
- Opt-in/out knobs: `PEAKRDL_PYBIND_O3`, `PEAKRDL_PYBIND_PCH`.

**Native masters**
- Every generated module now ships C++ `MockMaster` / `CallbackMaster` classes inheriting directly from `Master`. No pybind11 trampoline on the read/write hot path — ~25–40% faster than wrapping a Python master via `wrap_master`, depending on workload.

**Tests / CI**
- `test_native_masters_emitted` (text-level) and `test_native_masters_integration` (build-and-import) cover the new masters.
- Bumped g++ probe subprocess timeouts so Windows AV cold-start jitter stops flaking the known-bug tests.

**OpenTitan integration test**
- New `test_ot/` directory: shallow-clones lowRISC/opentitan, walks `top_earlgrey.gen.hjson` via OpenTitan's `reggen`, emits a single composite RDL, exports + builds + round-trip-tests all 44 IPs. Ships bench scripts and a measured comparison with PeakRDL-PyRAL.

## Test plan

- [x] `pytest tests/` 62 passed locally
- [x] `ruff check`, `ruff format --check`, `pyrefly check` clean
- [x] PR #52 CI fully green across format / lint / typecheck / build / benchmark + ubuntu 3.10–3.14 + windows 3.10–3.14
- [x] PR #53 CI green
- [ ] CI green here, then tag `v0.6.0` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)