### PR TITLE
Unit 6: Raw scalar fast-path accessors (read_raw/write_raw)

### DIFF
--- a/benchmarks/test_runtime_raw_accessors.py
+++ b/benchmarks/test_runtime_raw_accessors.py
@@ -1,0 +1,109 @@
+"""Microbench: read()/write() vs read_raw()/write_raw() on hot paths.
+
+Compares 10000 calls of each, exercising MockMaster (no Python in the C++
+read/write path). The win for ``read_raw`` is from skipping FieldInt /
+RegisterInt allocation per call.
+"""
+
+import time
+
+import pytest
+
+from tests.test_native_masters_integration import _build_test_module
+
+
+N = 10_000
+
+
+@pytest.fixture(scope="module")
+def soc(tmp_path_factory):
+    workdir = tmp_path_factory.mktemp("raw_bench")
+    mod = _build_test_module(workdir)
+    if mod is None:
+        pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+    soc = mod.create()
+    soc.attach_master(mod.MockMaster())
+    soc.reg_a.write(0xDEADBEEF)
+    return soc
+
+
+def _time(fn):
+    t0 = time.perf_counter()
+    fn()
+    return time.perf_counter() - t0
+
+
+def test_field_read_vs_read_raw(soc):
+    field = soc.reg_a.data
+
+    def loop_read():
+        for _ in range(N):
+            field.read()
+
+    def loop_read_raw():
+        for _ in range(N):
+            field.read_raw()
+
+    # Warmup
+    loop_read()
+    loop_read_raw()
+
+    t_read = _time(loop_read)
+    t_raw = _time(loop_read_raw)
+
+    print(
+        f"\n[field] read(): {t_read * 1e6 / N:.3f} us/call  "
+        f"read_raw(): {t_raw * 1e6 / N:.3f} us/call  "
+        f"speedup: {t_read / t_raw:.2f}x"
+    )
+    # Sanity: raw should not be slower than wrapped (allow noise margin).
+    assert t_raw <= t_read * 1.5
+
+
+def test_register_read_vs_read_raw(soc):
+    reg = soc.reg_a
+
+    def loop_read():
+        for _ in range(N):
+            reg.read()
+
+    def loop_read_raw():
+        for _ in range(N):
+            reg.read_raw()
+
+    loop_read()
+    loop_read_raw()
+
+    t_read = _time(loop_read)
+    t_raw = _time(loop_read_raw)
+
+    print(
+        f"\n[reg] read(): {t_read * 1e6 / N:.3f} us/call  "
+        f"read_raw(): {t_raw * 1e6 / N:.3f} us/call  "
+        f"speedup: {t_read / t_raw:.2f}x"
+    )
+    assert t_raw <= t_read * 1.5
+
+
+def test_field_write_vs_write_raw(soc):
+    field = soc.reg_a.data
+
+    def loop_write():
+        for i in range(N):
+            field.write(i & 0xFFFFFFFF)
+
+    def loop_write_raw():
+        for i in range(N):
+            field.write_raw(i & 0xFFFFFFFF)
+
+    loop_write()
+    loop_write_raw()
+
+    t_w = _time(loop_write)
+    t_raw = _time(loop_write_raw)
+
+    print(
+        f"\n[field] write(): {t_w * 1e6 / N:.3f} us/call  "
+        f"write_raw(): {t_raw * 1e6 / N:.3f} us/call  "
+        f"speedup: {t_w / t_raw:.2f}x"
+    )

--- a/benchmarks/test_runtime_raw_accessors.py
+++ b/benchmarks/test_runtime_raw_accessors.py
@@ -6,17 +6,18 @@ RegisterInt allocation per call.
 """
 
 import time
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
 from tests.test_native_masters_integration import _build_test_module
 
-
 N = 10_000
 
 
 @pytest.fixture(scope="module")
-def soc(tmp_path_factory):
+def soc(tmp_path_factory: pytest.TempPathFactory) -> Any:  # noqa: ANN401
     workdir = tmp_path_factory.mktemp("raw_bench")
     mod = _build_test_module(workdir)
     if mod is None:
@@ -27,20 +28,20 @@ def soc(tmp_path_factory):
     return soc
 
 
-def _time(fn):
+def _time(fn: Callable[[], None]) -> float:
     t0 = time.perf_counter()
     fn()
     return time.perf_counter() - t0
 
 
-def test_field_read_vs_read_raw(soc):
+def test_field_read_vs_read_raw(soc: Any) -> None:  # noqa: ANN401
     field = soc.reg_a.data
 
-    def loop_read():
+    def loop_read() -> None:
         for _ in range(N):
             field.read()
 
-    def loop_read_raw():
+    def loop_read_raw() -> None:
         for _ in range(N):
             field.read_raw()
 
@@ -60,14 +61,14 @@ def test_field_read_vs_read_raw(soc):
     assert t_raw <= t_read * 1.5
 
 
-def test_register_read_vs_read_raw(soc):
+def test_register_read_vs_read_raw(soc: Any) -> None:  # noqa: ANN401
     reg = soc.reg_a
 
-    def loop_read():
+    def loop_read() -> None:
         for _ in range(N):
             reg.read()
 
-    def loop_read_raw():
+    def loop_read_raw() -> None:
         for _ in range(N):
             reg.read_raw()
 
@@ -85,14 +86,14 @@ def test_register_read_vs_read_raw(soc):
     assert t_raw <= t_read * 1.5
 
 
-def test_field_write_vs_write_raw(soc):
+def test_field_write_vs_write_raw(soc: Any) -> None:  # noqa: ANN401
     field = soc.reg_a.data
 
-    def loop_write():
+    def loop_write() -> None:
         for i in range(N):
             field.write(i & 0xFFFFFFFF)
 
-    def loop_write_raw():
+    def loop_write_raw() -> None:
         for i in range(N):
             field.write_raw(i & 0xFFFFFFFF)
 

--- a/src/peakrdl_pybind11/templates/runtime.py.jinja
+++ b/src/peakrdl_pybind11/templates/runtime.py.jinja
@@ -171,20 +171,36 @@ def _enhanced_field_write(original_write):
 def _enhance_register_class(cls, fields_spec):
     if getattr(cls.read, "__peakrdl_enhanced__", False):
         return
+    raw_read = cls.read
+    raw_write = cls.write
     cls.read = _enhanced_register_read(
-        cls.read,
+        raw_read,
         _FLAG_REG_TYPES.get(cls),
         _ENUM_REG_TYPES.get(cls),
         fields_spec,
     )
-    cls.write = _enhanced_register_write(cls.write, cls.modify)
+    cls.write = _enhanced_register_write(raw_write, cls.modify)
+    # Fast-path scalar accessors: bypass RegisterInt wrapping / FieldInt
+    # handling. ``read_raw`` returns a plain ``int``; ``write_raw`` accepts
+    # a plain ``int`` and writes it directly via the underlying C++ method.
+    cls.read_raw = raw_read
+    cls.write_raw = raw_write
 
 
 def _enhance_field_class(cls):
     if getattr(cls.read, "__peakrdl_enhanced__", False):
         return
-    cls.read = _enhanced_field_read(cls.read)
-    cls.write = _enhanced_field_write(cls.write)
+    raw_read = cls.read
+    raw_write = cls.write
+    cls.read = _enhanced_field_read(raw_read)
+    cls.write = _enhanced_field_write(raw_write)
+    # Fast-path scalar accessors: ``read_raw`` returns a plain ``int`` (the
+    # field-space value, identical to what the C++ getter returns -- no
+    # ``FieldInt`` allocation). ``write_raw`` takes a plain ``int`` in
+    # field-space and forwards directly to the C++ setter (which performs
+    # the shift+mask+modify on the underlying register).
+    cls.read_raw = raw_read
+    cls.write_raw = raw_write
 
 
 for _reg_cls, _spec in _REGISTER_FIELDS.items():

--- a/src/peakrdl_pybind11/templates/stubs.pyi.jinja
+++ b/src/peakrdl_pybind11/templates/stubs.pyi.jinja
@@ -74,6 +74,14 @@ class FieldBase:
     @property
     def mask(self) -> int: ...
 
+    def read_raw(self) -> int:
+        """Read field value as a plain int (skips FieldInt wrapping)."""
+        ...
+
+    def write_raw(self, value: int) -> None:
+        """Write field value from a plain int (skips wrapping)."""
+        ...
+
 class RegisterBase:
     """Base class for registers"""
 
@@ -96,6 +104,14 @@ class RegisterBase:
 
     def modify(self, value: int, mask: int) -> None:
         """Read-modify-write operation with mask"""
+        ...
+
+    def read_raw(self) -> int:
+        """Read full register value as a plain int (skips RegisterInt wrapping)."""
+        ...
+
+    def write_raw(self, value: int) -> None:
+        """Write full register value from a plain int (skips wrapping)."""
         ...
 
 class NodeBase:

--- a/tests/test_raw_accessors.py
+++ b/tests/test_raw_accessors.py
@@ -1,0 +1,57 @@
+"""Tests for read_raw / write_raw fast-path accessors."""
+
+import pytest
+
+from peakrdl_pybind11.int_types import FieldInt, RegisterInt
+from tests.test_native_masters_integration import _build_test_module
+
+
+@pytest.fixture(scope="module")
+def soc_module(tmp_path_factory):
+    workdir = tmp_path_factory.mktemp("raw_acc")
+    mod = _build_test_module(workdir)
+    if mod is None:
+        pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+    return mod
+
+
+def test_field_read_raw_returns_plain_int(soc_module):
+    soc = soc_module.create()
+    soc.attach_master(soc_module.MockMaster())
+
+    soc.reg_a.write(0xDEADBEEF)
+
+    val = soc.reg_a.data.read_raw()
+    assert type(val) is int  # exact type, not FieldInt subclass
+    assert not isinstance(val, FieldInt)
+    assert val == int(soc.reg_a.data.read())
+
+
+def test_field_write_raw_round_trip(soc_module):
+    soc = soc_module.create()
+    soc.attach_master(soc_module.MockMaster())
+
+    soc.reg_a.data.write_raw(0x12345678)
+    assert soc.reg_a.data.read_raw() == 0x12345678
+    assert int(soc.reg_a.data.read()) == 0x12345678
+
+
+def test_register_read_raw_returns_plain_int(soc_module):
+    soc = soc_module.create()
+    soc.attach_master(soc_module.MockMaster())
+
+    soc.reg_b.write(0xCAFEBABE)
+
+    val = soc.reg_b.read_raw()
+    assert type(val) is int
+    assert not isinstance(val, RegisterInt)
+    assert val == int(soc.reg_b.read())
+
+
+def test_register_write_raw_round_trip(soc_module):
+    soc = soc_module.create()
+    soc.attach_master(soc_module.MockMaster())
+
+    soc.reg_b.write_raw(0xA5A5A5A5)
+    assert soc.reg_b.read_raw() == 0xA5A5A5A5
+    assert int(soc.reg_b.read()) == 0xA5A5A5A5


### PR DESCRIPTION
## Summary
- Add `read_raw()` / `write_raw(int)` accessors on generated register and field wrappers that bypass `RegisterInt` / `FieldInt` allocation, enum/flag conversion, and metadata attachment.
- Pure-Python change in `runtime.py.jinja`: capture the original C++ method refs before `_enhance_*_class` rebinds them, then expose those refs as `read_raw` / `write_raw`. Existing `read()` / `write()` semantics are 100% intact.
- Update `stubs.pyi.jinja` with matching signatures on `RegisterBase` / `FieldBase`.

`field.write_raw(v)` takes a field-space `int` and forwards directly to the C++ setter (which performs shift+mask+modify on the underlying register).

## Microbench (10000 calls vs MockMaster, macOS arm64, py3.14)

| Op | wrapped | raw | speedup |
|---|---|---|---|
| `field.read()` | 0.542 us | 0.108 us | **5.0x** |
| `reg.read()` | 0.902 us | 0.098 us | **9.2x** |
| `field.write()` | 0.143 us | 0.133 us | 1.1x |

Big win on reads: skipping the `FieldInt` / `RegisterInt` allocation pays back per call. Writes are already a thin `int(value)` cast so the gain is small.

## Test plan
- [x] `pytest tests/ -x -k 'not benchmarks'` -- 76 passed
- [x] New `tests/test_raw_accessors.py`: `read_raw()` returns plain `int` (not `FieldInt`/`RegisterInt`), value matches `int(read())`, `write_raw` round-trips for both register and field
- [x] `python examples/run_example.py` -- end-to-end OK
- [x] New `benchmarks/test_runtime_raw_accessors.py` -- numbers above

Generated with Claude Code