### PR TITLE
Unit 5: Skip-readback (write-only) context manager

### DIFF
--- a/benchmarks/test_runtime_write_only.py
+++ b/benchmarks/test_runtime_write_only.py
@@ -1,0 +1,156 @@
+"""
+Microbench: regular context manager vs ``reg.write_only()``.
+
+Each iteration performs 100 "enable" sequences on a single register --
+once with the regular ``with reg as r:`` context (one read + one write
+per iteration) and once with ``with reg.write_only() as r:`` (one write
+per iteration). The bench reports the per-iteration master op counts to
+make the ~2x reduction obvious.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+from systemrdl import RDLCompiler
+
+from peakrdl_pybind11 import Pybind11Exporter
+
+WO_BENCH_RDL = """
+addrmap wo_bench_soc {
+    reg {
+        field { sw = rw; hw = r; } enable[0:0] = 0;
+        field { sw = rw; hw = r; } start[1:1] = 0;
+        field { sw = rw; hw = r; } mode[7:4] = 0;
+    } cmd @ 0x0;
+};
+"""
+
+
+class _CountingMaster:
+    def __init__(self):
+        self.store = {}
+        self.reads = 0
+        self.writes = 0
+
+    def read(self, addr, width):
+        self.reads += 1
+        return self.store.get(addr, 0)
+
+    def write(self, addr, value, width):
+        self.writes += 1
+        self.store[addr] = value
+
+
+def _build_module():
+    workdir = Path(tempfile.mkdtemp(prefix="wo_bench_"))
+    rdl_path = workdir / "wo.rdl"
+    rdl_path.write_text(WO_BENCH_RDL)
+
+    rdl = RDLCompiler()
+    rdl.compile_file(str(rdl_path))
+    root = rdl.elaborate()
+
+    output_dir = workdir / "out"
+    output_dir.mkdir()
+    Pybind11Exporter().export(root.top, str(output_dir), soc_name="wo_bench_soc")
+
+    build_dir = output_dir / "build"
+    build_dir.mkdir()
+
+    if subprocess.run(["cmake", ".."], cwd=build_dir,
+                      capture_output=True, text=True).returncode != 0:
+        return None
+    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
+                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+        return None
+
+    so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
+    if not so_files:
+        return None
+    pkg_dir = output_dir / "wo_bench_soc"
+    pkg_dir.mkdir(exist_ok=True)
+    shutil.copy(so_files[0], pkg_dir)
+
+    sys.path.insert(0, str(output_dir))
+    spec = importlib.util.spec_from_file_location(
+        "wo_bench_soc", str(pkg_dir / "__init__.py")
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["wo_bench_soc"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def soc_module():
+    mod = _build_module()
+    if mod is None:
+        pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+    return mod
+
+
+class TestRuntimeWriteOnly:
+    """Compare master-op counts for regular context vs write_only."""
+
+    def test_regular_context_100_enables(self, benchmark: BenchmarkFixture, soc_module):
+        soc = soc_module.create()
+        cm = _CountingMaster()
+        soc.attach_master(soc_module.wrap_master(cm))
+
+        def run():
+            for _ in range(100):
+                with soc.cmd as reg:
+                    reg.enable.write(1)
+                    reg.mode.write(0xA)
+
+        # Warm + measure ops on a single iteration so the count is stable.
+        cm.reads = 0
+        cm.writes = 0
+        run()
+        regular_reads, regular_writes = cm.reads, cm.writes
+        print(f"\n[regular  ] 100 enables -> reads={regular_reads} writes={regular_writes}")
+
+        benchmark(run)
+
+        # Stash for the comparison test; cheap and avoids cross-test deps.
+        TestRuntimeWriteOnly.regular_ops = (regular_reads, regular_writes)
+
+    def test_write_only_context_100_enables(self, benchmark: BenchmarkFixture, soc_module):
+        soc = soc_module.create()
+        cm = _CountingMaster()
+        soc.attach_master(soc_module.wrap_master(cm))
+
+        def run():
+            for _ in range(100):
+                with soc.cmd.write_only() as reg:
+                    reg.enable.write(1)
+                    reg.mode.write(0xA)
+
+        cm.reads = 0
+        cm.writes = 0
+        run()
+        wo_reads, wo_writes = cm.reads, cm.writes
+        print(f"\n[write_only] 100 enables -> reads={wo_reads} writes={wo_writes}")
+
+        benchmark(run)
+
+        # Sanity: write_only halves the master ops.
+        regular = getattr(TestRuntimeWriteOnly, "regular_ops", None)
+        if regular is not None:
+            regular_reads, regular_writes = regular
+            total_regular = regular_reads + regular_writes
+            total_wo = wo_reads + wo_writes
+            print(f"[summary   ] total master ops: regular={total_regular} "
+                  f"write_only={total_wo} (ratio={total_regular / max(total_wo, 1):.2f}x)")
+            assert wo_reads == 0
+            assert wo_writes == 100
+            assert regular_reads == 100
+            assert regular_writes == 100

--- a/benchmarks/test_runtime_write_only.py
+++ b/benchmarks/test_runtime_write_only.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
@@ -33,21 +34,21 @@ addrmap wo_bench_soc {
 
 
 class _CountingMaster:
-    def __init__(self):
+    def __init__(self) -> None:
         self.store = {}
         self.reads = 0
         self.writes = 0
 
-    def read(self, addr, width):
+    def read(self, addr: int, width: int) -> int:
         self.reads += 1
         return self.store.get(addr, 0)
 
-    def write(self, addr, value, width):
+    def write(self, addr: int, value: int, width: int) -> None:
         self.writes += 1
         self.store[addr] = value
 
 
-def _build_module():
+def _build_module() -> Any:  # noqa: ANN401
     workdir = Path(tempfile.mkdtemp(prefix="wo_bench_"))
     rdl_path = workdir / "wo.rdl"
     rdl_path.write_text(WO_BENCH_RDL)
@@ -63,11 +64,14 @@ def _build_module():
     build_dir = output_dir / "build"
     build_dir.mkdir()
 
-    if subprocess.run(["cmake", ".."], cwd=build_dir,
-                      capture_output=True, text=True).returncode != 0:
+    if subprocess.run(["cmake", ".."], cwd=build_dir, capture_output=True, text=True).returncode != 0:
         return None
-    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
-                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+    if (
+        subprocess.run(
+            ["cmake", "--build", ".", "--config", "Release"], cwd=build_dir, capture_output=True, text=True
+        ).returncode
+        != 0
+    ):
         return None
 
     so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
@@ -78,9 +82,7 @@ def _build_module():
     shutil.copy(so_files[0], pkg_dir)
 
     sys.path.insert(0, str(output_dir))
-    spec = importlib.util.spec_from_file_location(
-        "wo_bench_soc", str(pkg_dir / "__init__.py")
-    )
+    spec = importlib.util.spec_from_file_location("wo_bench_soc", str(pkg_dir / "__init__.py"))
     if spec is None or spec.loader is None:
         return None
     module = importlib.util.module_from_spec(spec)
@@ -90,7 +92,7 @@ def _build_module():
 
 
 @pytest.fixture(scope="module")
-def soc_module():
+def soc_module() -> Any:  # noqa: ANN401
     mod = _build_module()
     if mod is None:
         pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
@@ -100,12 +102,12 @@ def soc_module():
 class TestRuntimeWriteOnly:
     """Compare master-op counts for regular context vs write_only."""
 
-    def test_regular_context_100_enables(self, benchmark: BenchmarkFixture, soc_module):
+    def test_regular_context_100_enables(self, benchmark: BenchmarkFixture, soc_module: Any) -> None:  # noqa: ANN401
         soc = soc_module.create()
         cm = _CountingMaster()
         soc.attach_master(soc_module.wrap_master(cm))
 
-        def run():
+        def run() -> None:
             for _ in range(100):
                 with soc.cmd as reg:
                     reg.enable.write(1)
@@ -123,12 +125,12 @@ class TestRuntimeWriteOnly:
         # Stash for the comparison test; cheap and avoids cross-test deps.
         TestRuntimeWriteOnly.regular_ops = (regular_reads, regular_writes)
 
-    def test_write_only_context_100_enables(self, benchmark: BenchmarkFixture, soc_module):
+    def test_write_only_context_100_enables(self, benchmark: BenchmarkFixture, soc_module: Any) -> None:  # noqa: ANN401
         soc = soc_module.create()
         cm = _CountingMaster()
         soc.attach_master(soc_module.wrap_master(cm))
 
-        def run():
+        def run() -> None:
             for _ in range(100):
                 with soc.cmd.write_only() as reg:
                     reg.enable.write(1)
@@ -148,8 +150,10 @@ class TestRuntimeWriteOnly:
             regular_reads, regular_writes = regular
             total_regular = regular_reads + regular_writes
             total_wo = wo_reads + wo_writes
-            print(f"[summary   ] total master ops: regular={total_regular} "
-                  f"write_only={total_wo} (ratio={total_regular / max(total_wo, 1):.2f}x)")
+            print(
+                f"[summary   ] total master ops: regular={total_regular} "
+                f"write_only={total_wo} (ratio={total_regular / max(total_wo, 1):.2f}x)"
+            )
             assert wo_reads == 0
             assert wo_writes == 100
             assert regular_reads == 100

--- a/src/peakrdl_pybind11/templates/bindings.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings.cpp.jinja
@@ -143,8 +143,26 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
         .def("__exit__", [](RegisterBase& self, py::object exc_type, py::object exc_value, py::object traceback) {
             self.exit_context();
         }, "Exit context manager")
+        .def("write_only", &RegisterBase::write_only,
+             "Return a write-only context-manager handle. On entry the "
+             "register's cache is seeded to 0 (no master read); field "
+             "writes accumulate; on exit a single master write flushes "
+             "the value. Unspecified bits become 0 -- use only on true "
+             "write-only registers.")
         .def("__repr__", &RegisterBase::__repr__)
         .def("__str__", &RegisterBase::__repr__);
+
+    // Write-only context-manager handle returned by RegisterBase::write_only().
+    py::class_<RegisterWriteOnlyContext>(m, "RegisterWriteOnlyContext")
+        .def("__enter__", &RegisterWriteOnlyContext::__enter__,
+             py::return_value_policy::reference,
+             "Enter write-only context (skip the initial master read)")
+        .def("__exit__",
+             [](RegisterWriteOnlyContext& self, py::object exc_type,
+                py::object exc_value, py::object traceback) {
+                 self.exit_context();
+             },
+             "Exit write-only context (single master write of the cached value)");
 
     // NodeBase
     py::class_<NodeBase>(m, "NodeBase")

--- a/src/peakrdl_pybind11/templates/descriptors/base_classes.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/base_classes.hpp.jinja
@@ -267,6 +267,32 @@ public:
     }
 
     /**
+     * Enter write-only context manager - skip the initial master read.
+     *
+     * Sets in_context_ = true and seeds cached_value_ = 0 *without*
+     * issuing a read on the master. Field writes inside the context
+     * accumulate into cached_value_ exactly like __enter__. On exit, a
+     * single master write flushes the accumulated value.
+     *
+     * NOTE: Any bit not explicitly written inside the context will be 0
+     * in the resulting master write. Use this only on registers where
+     * unspecified bits should be cleared on each operation (true
+     * write-only registers: DMA enable/start, IRQ ack, command FIFOs,
+     * etc.).
+     */
+    RegisterBase* enter_write_only() {
+        if (in_context_) {
+            throw std::runtime_error("Register " + name_ + " is already in a context");
+        }
+        if (!master_) {
+            throw std::runtime_error("No master attached to register: " + name_);
+        }
+        cached_value_ = 0;
+        in_context_ = true;
+        return this;
+    }
+
+    /**
      * Exit context manager - write cached value back to register
      */
     void exit_context() {
@@ -279,6 +305,12 @@ public:
         }
         in_context_ = false;
     }
+
+    /**
+     * Return a write-only context-manager handle for this register.
+     * See ``enter_write_only()`` for semantics.
+     */
+    class RegisterWriteOnlyContext write_only();
 
     /**
      * String representation
@@ -299,6 +331,28 @@ protected:
     bool in_context_;
     uint64_t cached_value_;
 };
+
+/**
+ * Lightweight context-manager handle returned by ``RegisterBase::write_only()``.
+ *
+ * Holding a separate handle type lets us bind ``__enter__`` to the
+ * skip-readback path without colliding with the regular
+ * ``RegisterBase::__enter__`` (which always reads the master first).
+ */
+class RegisterWriteOnlyContext {
+public:
+    explicit RegisterWriteOnlyContext(RegisterBase* reg) : reg_(reg) {}
+
+    RegisterBase* __enter__() { return reg_->enter_write_only(); }
+    void exit_context() { reg_->exit_context(); }
+
+private:
+    RegisterBase* reg_;
+};
+
+inline RegisterWriteOnlyContext RegisterBase::write_only() {
+    return RegisterWriteOnlyContext(this);
+}
 
 /**
  * Base class for register fields

--- a/src/peakrdl_pybind11/templates/stubs.pyi.jinja
+++ b/src/peakrdl_pybind11/templates/stubs.pyi.jinja
@@ -118,6 +118,18 @@ class FieldBase:
         """Write field value from a plain int (skips wrapping)."""
         ...
 
+class RegisterWriteOnlyContext:
+    """Context-manager handle returned by :meth:`RegisterBase.write_only`.
+
+    On entry the register's cache is seeded to 0 (no master read); field
+    writes accumulate; on exit a single master write flushes the value.
+    Bits not explicitly written inside the context become 0 -- use only on
+    true write-only registers (DMA enable/start, IRQ ack, command FIFOs).
+    """
+
+    def __enter__(self) -> RegisterBase: ...
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None: ...
+
 class RegisterBase:
     """Base class for registers"""
 
@@ -148,6 +160,19 @@ class RegisterBase:
 
     def write_raw(self, value: int) -> None:
         """Write full register value from a plain int (skips wrapping)."""
+        ...
+
+    def __enter__(self) -> RegisterBase:
+        """Enter context manager (reads current value, accumulates writes, flushes on exit)"""
+        ...
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None: ...
+
+    def write_only(self) -> RegisterWriteOnlyContext:
+        """Return a write-only context-manager handle that skips the initial master read.
+
+        Bits not explicitly written inside the context are flushed as 0.
+        """
         ...
 
 class NodeBase:

--- a/tests/test_write_only_context.py
+++ b/tests/test_write_only_context.py
@@ -1,0 +1,159 @@
+"""
+Tests for the skip-readback (write-only) context manager.
+
+Verifies that ``reg.write_only()``:
+  (a) does NOT trigger a master read on enter,
+  (b) accumulates field writes inside the context,
+  (c) flushes a single master write on exit with the accumulated value,
+  (d) leaves unspecified bits as 0,
+  (e) is mutually exclusive with the regular ``__enter__`` (nested -> error).
+
+Uses the same export/build harness as test_native_masters_integration.py.
+Skips automatically if cmake / pybind11 isn't available.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from systemrdl import RDLCompiler
+
+from peakrdl_pybind11 import Pybind11Exporter
+
+WO_RDL = """
+addrmap wo_soc {
+    name = "Write-only context test SoC";
+    reg {
+        field { sw = rw; hw = r; } enable[0:0] = 0;
+        field { sw = rw; hw = r; } start[1:1] = 0;
+        field { sw = rw; hw = r; } mode[7:4] = 0;
+    } cmd @ 0x0;
+};
+"""
+
+
+def _build(workdir, soc_name="wo_soc"):
+    rdl_path = Path(workdir) / "wo.rdl"
+    rdl_path.write_text(WO_RDL)
+
+    rdl = RDLCompiler()
+    rdl.compile_file(str(rdl_path))
+    root = rdl.elaborate()
+
+    output_dir = Path(workdir) / "out"
+    output_dir.mkdir()
+    Pybind11Exporter().export(root.top, str(output_dir), soc_name=soc_name)
+
+    build_dir = output_dir / "build"
+    build_dir.mkdir()
+
+    if subprocess.run(["cmake", ".."], cwd=build_dir,
+                      capture_output=True, text=True).returncode != 0:
+        return None
+    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
+                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+        return None
+
+    so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
+    if not so_files:
+        return None
+    pkg_dir = output_dir / soc_name
+    pkg_dir.mkdir(exist_ok=True)
+    shutil.copy(so_files[0], pkg_dir)
+
+    sys.path.insert(0, str(output_dir))
+    spec = importlib.util.spec_from_file_location(
+        soc_name, str(pkg_dir / "__init__.py")
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[soc_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        return None
+    return module
+
+
+class _CountingMaster:
+    """Pure-Python master that counts read/write calls (via wrap_master)."""
+
+    def __init__(self):
+        self.store = {}
+        self.reads = 0
+        self.writes = 0
+
+    def read(self, addr, width):
+        self.reads += 1
+        return self.store.get(addr, 0)
+
+    def write(self, addr, value, width):
+        self.writes += 1
+        self.store[addr] = value
+
+
+class TestWriteOnlyContext:
+    def test_skip_readback_and_accumulate(self, tmpdir):
+        mod = _build(tmpdir)
+        if mod is None:
+            pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+
+        soc = mod.create()
+        cm = _CountingMaster()
+        soc.attach_master(mod.wrap_master(cm))
+
+        # Pre-populate "hardware" with garbage. write_only() must NOT read it.
+        cm.store[soc.cmd.offset] = 0xDEADBEEF
+
+        # Reset counters after attach (no traffic should have happened, but
+        # be defensive).
+        cm.reads = 0
+        cm.writes = 0
+
+        with soc.cmd.write_only() as reg:
+            # (a) no master read on enter
+            assert cm.reads == 0
+            # (b) field writes accumulate in the cache; no master writes yet
+            reg.enable.write(1)
+            reg.mode.write(0xA)
+            assert cm.writes == 0
+            assert cm.reads == 0
+
+        # (c) exactly one master write on exit
+        assert cm.writes == 1
+        assert cm.reads == 0
+
+        # (d) accumulated value: enable=1 (bit 0), mode=0xA (bits 7:4) ->
+        # 0xA1. Unspecified bits (start, upper bits) are 0.
+        assert cm.store[soc.cmd.offset] == 0xA1
+
+    def test_nested_with_regular_context_errors(self, tmpdir):
+        mod = _build(tmpdir)
+        if mod is None:
+            pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+
+        soc = mod.create()
+        cm = _CountingMaster()
+        soc.attach_master(mod.wrap_master(cm))
+
+        # write_only inside regular context -> error.
+        with pytest.raises(RuntimeError, match="already in a context"):
+            with soc.cmd as _reg:
+                with soc.cmd.write_only() as _reg2:
+                    pass
+
+        # Regular context inside write_only -> error.
+        with pytest.raises(RuntimeError, match="already in a context"):
+            with soc.cmd.write_only() as _reg:
+                with soc.cmd as _reg2:
+                    pass
+
+        # Nested write_only -> error.
+        with pytest.raises(RuntimeError, match="already in a context"):
+            with soc.cmd.write_only() as _reg:
+                with soc.cmd.write_only() as _reg2:
+                    pass


### PR DESCRIPTION
## Summary

- Add `reg.write_only()` returning a `RegisterWriteOnlyContext` handle. On enter the cache is seeded to 0 *without* issuing a master read; field writes accumulate in-cache; on exit a single master write flushes the value.
- Halves master-bus traffic on true write-only registers (DMA enable/start, IRQ ack, command FIFOs) where the readback was always discarded.
- Bits not explicitly written inside the context are flushed as 0 -- documented on the API. Mutually exclusive with the regular `__enter__` (nested usage raises).

## Implementation

- New `RegisterBase::enter_write_only()` mirrors `__enter__` but skips the master read. `exit_context()` is reused unchanged.
- New tiny `RegisterWriteOnlyContext` handle returned by `RegisterBase::write_only()`. Separate type so its `__enter__` can route to the skip-readback path without colliding with the default `RegisterBase::__enter__` (which always reads).
- Bindings + .pyi stubs updated.

## Microbench (100 enables of a 32-bit register)

```
[regular   ] 100 enables -> reads=100 writes=100  (200 master ops)
[write_only] 100 enables -> reads=0   writes=100  (100 master ops)
[summary   ] ratio = 2.00x reduction in master ops
```

Wall-time of the bench harness is similar because the in-process Python `_CountingMaster` is essentially free; the relevant figure for real hardware is the master-op count, which drops 2x as expected.

## Test plan

- [x] `pytest tests/ -x -k 'not benchmarks'` -- 74 passed (existing context-manager tests still pass)
- [x] New `tests/test_write_only_context.py` covers: no master read on enter, field accumulation, single master write on exit, unspecified bits = 0, nested-with-regular-context error, nested write_only error.
- [x] `python examples/run_example.py` succeeds end-to-end.
- [x] `benchmarks/test_runtime_write_only.py` runs and confirms 2.00x master-op reduction.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>