### PR TITLE
Unit 4: Per-register multi-field write (reg.write_fields(...))

### DIFF
--- a/benchmarks/test_runtime_write_fields.py
+++ b/benchmarks/test_runtime_write_fields.py
@@ -1,0 +1,117 @@
+"""Microbenchmark: per-field write loop vs single ``write_fields`` call.
+
+Compares the cost of writing 5 fields on the same register via 5 individual
+``reg.<field>.write(...)`` calls (5 RMW = 10 master ops, 5 C++ entries) vs a
+single ``reg.write_fields(...)`` (1 RMW = 2 master ops, 1 C++ entry plus a
+small Python boundary).
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from systemrdl import RDLCompiler
+
+from peakrdl_pybind11 import Pybind11Exporter
+
+BENCH_RDL = """
+addrmap wfb_soc {
+    reg {
+        field { sw = rw; hw = r; } f0[3:0]   = 0;
+        field { sw = rw; hw = r; } f1[7:4]   = 0;
+        field { sw = rw; hw = r; } f2[11:8]  = 0;
+        field { sw = rw; hw = r; } f3[15:12] = 0;
+        field { sw = rw; hw = r; } f4[19:16] = 0;
+    } reg_multi @ 0x0;
+};
+"""
+
+
+def _build(workdir, soc_name="wfb_soc"):
+    rdl_path = Path(workdir) / "wfb.rdl"
+    rdl_path.write_text(BENCH_RDL)
+    rdl = RDLCompiler()
+    rdl.compile_file(str(rdl_path))
+    root = rdl.elaborate()
+
+    output_dir = Path(workdir) / "out"
+    output_dir.mkdir()
+    Pybind11Exporter().export(root.top, str(output_dir), soc_name=soc_name)
+
+    build_dir = output_dir / "build"
+    build_dir.mkdir()
+    if subprocess.run(["cmake", ".."], cwd=build_dir,
+                      capture_output=True, text=True).returncode != 0:
+        return None
+    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
+                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+        return None
+
+    so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
+    if not so_files:
+        return None
+    pkg_dir = output_dir / soc_name
+    pkg_dir.mkdir(exist_ok=True)
+    shutil.copy(so_files[0], pkg_dir)
+    sys.path.insert(0, str(output_dir))
+    spec = importlib.util.spec_from_file_location(
+        soc_name, str(pkg_dir / "__init__.py")
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[soc_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_fields_microbench(tmpdir):
+    soc_module = _build(tmpdir)
+    if soc_module is None:
+        pytest.skip("Could not build benchmark module (cmake/pybind11 unavailable)")
+
+    soc = soc_module.create()
+    soc.attach_master(soc_module.MockMaster())
+    reg = soc.reg_multi
+
+    iters = 20_000
+
+    # Warm-up.
+    for _ in range(1000):
+        reg.f0.write(1); reg.f1.write(2); reg.f2.write(3); reg.f3.write(4); reg.f4.write(5)
+        reg.write_fields(f0=1, f1=2, f2=3, f3=4, f4=5)
+
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        reg.f0.write(1)
+        reg.f1.write(2)
+        reg.f2.write(3)
+        reg.f3.write(4)
+        reg.f4.write(5)
+    t_field = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        reg.write_fields(f0=1, f1=2, f2=3, f3=4, f4=5)
+    t_combined = time.perf_counter() - t0
+
+    speedup = t_field / t_combined if t_combined > 0 else float("inf")
+    print(
+        f"\n[write_fields microbench] iters={iters}\n"
+        f"  per-field x5:        {t_field*1e6/iters:8.2f} us/op  ({t_field:.3f}s total)\n"
+        f"  write_fields(...):   {t_combined*1e6/iters:8.2f} us/op  ({t_combined:.3f}s total)\n"
+        f"  speedup:             {speedup:.2f}x"
+    )
+
+    # Sanity: combined call should not be slower than per-field loop.
+    assert t_combined < t_field, (
+        f"write_fields should be faster: {t_combined:.3f}s vs {t_field:.3f}s"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/benchmarks/test_runtime_write_fields.py
+++ b/benchmarks/test_runtime_write_fields.py
@@ -12,7 +12,9 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import ModuleType
 
+import py
 import pytest
 from systemrdl import RDLCompiler
 
@@ -31,7 +33,7 @@ addrmap wfb_soc {
 """
 
 
-def _build(workdir, soc_name="wfb_soc"):
+def _build(workdir: py.path.local, soc_name: str = "wfb_soc") -> ModuleType | None:
     rdl_path = Path(workdir) / "wfb.rdl"
     rdl_path.write_text(BENCH_RDL)
     rdl = RDLCompiler()
@@ -44,11 +46,14 @@ def _build(workdir, soc_name="wfb_soc"):
 
     build_dir = output_dir / "build"
     build_dir.mkdir()
-    if subprocess.run(["cmake", ".."], cwd=build_dir,
-                      capture_output=True, text=True).returncode != 0:
+    if subprocess.run(["cmake", ".."], cwd=build_dir, capture_output=True, text=True).returncode != 0:
         return None
-    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
-                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+    if (
+        subprocess.run(
+            ["cmake", "--build", ".", "--config", "Release"], cwd=build_dir, capture_output=True, text=True
+        ).returncode
+        != 0
+    ):
         return None
 
     so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
@@ -58,9 +63,7 @@ def _build(workdir, soc_name="wfb_soc"):
     pkg_dir.mkdir(exist_ok=True)
     shutil.copy(so_files[0], pkg_dir)
     sys.path.insert(0, str(output_dir))
-    spec = importlib.util.spec_from_file_location(
-        soc_name, str(pkg_dir / "__init__.py")
-    )
+    spec = importlib.util.spec_from_file_location(soc_name, str(pkg_dir / "__init__.py"))
     if spec is None or spec.loader is None:
         return None
     module = importlib.util.module_from_spec(spec)
@@ -69,7 +72,7 @@ def _build(workdir, soc_name="wfb_soc"):
     return module
 
 
-def test_write_fields_microbench(tmpdir):
+def test_write_fields_microbench(tmpdir: py.path.local) -> None:
     soc_module = _build(tmpdir)
     if soc_module is None:
         pytest.skip("Could not build benchmark module (cmake/pybind11 unavailable)")
@@ -82,7 +85,11 @@ def test_write_fields_microbench(tmpdir):
 
     # Warm-up.
     for _ in range(1000):
-        reg.f0.write(1); reg.f1.write(2); reg.f2.write(3); reg.f3.write(4); reg.f4.write(5)
+        reg.f0.write(1)
+        reg.f1.write(2)
+        reg.f2.write(3)
+        reg.f3.write(4)
+        reg.f4.write(5)
         reg.write_fields(f0=1, f1=2, f2=3, f3=4, f4=5)
 
     t0 = time.perf_counter()
@@ -102,15 +109,13 @@ def test_write_fields_microbench(tmpdir):
     speedup = t_field / t_combined if t_combined > 0 else float("inf")
     print(
         f"\n[write_fields microbench] iters={iters}\n"
-        f"  per-field x5:        {t_field*1e6/iters:8.2f} us/op  ({t_field:.3f}s total)\n"
-        f"  write_fields(...):   {t_combined*1e6/iters:8.2f} us/op  ({t_combined:.3f}s total)\n"
+        f"  per-field x5:        {t_field * 1e6 / iters:8.2f} us/op  ({t_field:.3f}s total)\n"
+        f"  write_fields(...):   {t_combined * 1e6 / iters:8.2f} us/op  ({t_combined:.3f}s total)\n"
         f"  speedup:             {speedup:.2f}x"
     )
 
     # Sanity: combined call should not be slower than per-field loop.
-    assert t_combined < t_field, (
-        f"write_fields should be faster: {t_combined:.3f}s vs {t_field:.3f}s"
-    )
+    assert t_combined < t_field, f"write_fields should be faster: {t_combined:.3f}s vs {t_field:.3f}s"
 
 
 if __name__ == "__main__":

--- a/src/peakrdl_pybind11/templates/bindings.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings.cpp.jinja
@@ -157,6 +157,9 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     // Register class: {{ reg.get_path() }}
     py::class_<{{ reg | pybind_name }}_t, RegisterBase>(m, "{{ reg | pybind_name }}_t"{% if reg.get_property('desc') %}, "{{ reg.get_html_desc() | cpp_string }}"{% endif %})
         .def(py::init<uint64_t>())
+        .def("write_fields", &{{ reg | pybind_name }}_t::write_fields,
+             py::arg("mask"), py::arg("value"),
+             "Combined multi-field RMW: single read+write on the master")
         {% for field in reg.fields() %}
         .def_readonly("{{ field.inst_name | safe_id }}", &{{ reg | pybind_name }}_t::{{ field.inst_name | safe_id }})
         {% endfor %}

--- a/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/registers.hpp.jinja
@@ -38,6 +38,17 @@ public:
 
     {{ field.inst_name | safe_id }}_field {{ field.inst_name | safe_id }}{this};
     {% endfor %}
+
+    /**
+     * Multi-field write: single read-modify-write for all fields combined.
+     *
+     * Callers (typically the Python wrapper) precompute ``mask`` and
+     * ``value`` from the per-field metadata and invoke this once,
+     * collapsing N field writes into 1 read + 1 write on the master.
+     */
+    void write_fields(uint64_t mask, uint64_t value) {
+        modify(value, mask);
+    }
 };
 
 {% endfor %}

--- a/src/peakrdl_pybind11/templates/runtime.py.jinja
+++ b/src/peakrdl_pybind11/templates/runtime.py.jinja
@@ -110,6 +110,17 @@ _REGISTER_FIELDS: dict[type, dict[str, tuple[int, int]]] = {
 {% endfor %}
 }
 
+# Per-register field writability metadata used by ``write_fields``.
+_REGISTER_FIELD_WRITABLE: dict[type, dict[str, bool]] = {
+{% for reg in nodes.regs %}
+    {{ reg | pybind_name }}_t: {
+        {% for field in reg.fields() %}
+        "{{ field.inst_name | safe_id }}": {{ 'True' if field.is_hw_writable or field.is_sw_writable else 'False' }},
+        {% endfor %}
+    },
+{% endfor %}
+}
+
 _FLAG_REG_TYPES: dict[type, type] = {
 {% for reg in nodes.flag_regs %}
     {{ reg | pybind_name }}_t: {{ reg | pybind_name }}_f,
@@ -168,6 +179,36 @@ def _enhanced_field_write(original_write):
     return write
 
 
+def _make_write_fields(fields_spec, writable_spec):
+    """Build a ``write_fields(**kwargs)`` shim for a generated register class.
+
+    Collapses N per-field writes into a single C++ ``write_fields(mask, value)``
+    call (1 read + 1 write on the master, regardless of N). Validates field
+    names and writability at the Python boundary so the C++ side stays minimal.
+    """
+    def write_fields(self, **kwargs):
+        combined_mask = 0
+        combined_value = 0
+        for name, raw_value in kwargs.items():
+            spec = fields_spec.get(name)
+            if spec is None:
+                raise KeyError(
+                    f"Unknown field '{name}' on register '{self.name}'. "
+                    f"Known fields: {sorted(fields_spec)}"
+                )
+            if not writable_spec.get(name, False):
+                raise PermissionError(
+                    f"Field '{name}' on register '{self.name}' is not writable"
+                )
+            lsb, width = spec
+            field_mask = ((1 << width) - 1) << lsb
+            combined_mask |= field_mask
+            combined_value |= (int(raw_value) << lsb) & field_mask
+        # Single C++ entry: native RMW under the hood.
+        self._native_write_fields(combined_mask, combined_value)
+    return write_fields
+
+
 def _enhance_register_class(cls, fields_spec):
     if getattr(cls.read, "__peakrdl_enhanced__", False):
         return
@@ -185,6 +226,12 @@ def _enhance_register_class(cls, fields_spec):
     # a plain ``int`` and writes it directly via the underlying C++ method.
     cls.read_raw = raw_read
     cls.write_raw = raw_write
+    # Preserve native binding under a private name; expose Python shim with
+    # validation under the public name.
+    cls._native_write_fields = cls.write_fields
+    cls.write_fields = _make_write_fields(
+        fields_spec, _REGISTER_FIELD_WRITABLE.get(cls, {})
+    )
 
 
 def _enhance_field_class(cls):

--- a/src/peakrdl_pybind11/templates/stubs.pyi.jinja
+++ b/src/peakrdl_pybind11/templates/stubs.pyi.jinja
@@ -150,6 +150,14 @@ class RegisterBase:
         """Write full register value from a plain int (skips wrapping)."""
         ...
 
+    def write_fields(self, **kwargs: int) -> None:
+        """Atomically write multiple fields in a single read-modify-write.
+
+        Accepts ``field_name=value`` keyword arguments. Unknown field names
+        raise ``KeyError``; read-only fields raise ``PermissionError``.
+        """
+        ...
+
 class NodeBase:
     """Base class for address maps and register files"""
 

--- a/tests/test_write_fields.py
+++ b/tests/test_write_fields.py
@@ -1,0 +1,133 @@
+"""End-to-end tests for the per-register ``write_fields`` multi-field write.
+
+Verifies that ``reg.write_fields(field_a=..., field_b=...)`` collapses N
+field writes into exactly 1 master read + 1 master write, regardless of N,
+and that field-name / writability validation happens at the Python boundary.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from systemrdl import RDLCompiler
+
+from peakrdl_pybind11 import Pybind11Exporter
+
+WRITE_FIELDS_RDL = """
+addrmap wf_soc {
+    name = "write_fields integration test";
+    reg {
+        field { sw = rw; hw = r; } field_a[3:0] = 0;
+        field { sw = rw; hw = r; } field_b[7:4] = 0;
+        field { sw = rw; hw = r; } field_c[15:8] = 0;
+        field { sw = r;  hw = r; } ro_field[23:16] = 0;
+    } reg_multi @ 0x0;
+};
+"""
+
+
+def _build_module(workdir, soc_name="wf_soc"):
+    rdl_path = Path(workdir) / "wf.rdl"
+    rdl_path.write_text(WRITE_FIELDS_RDL)
+
+    rdl = RDLCompiler()
+    rdl.compile_file(str(rdl_path))
+    root = rdl.elaborate()
+
+    output_dir = Path(workdir) / "out"
+    output_dir.mkdir()
+    Pybind11Exporter().export(root.top, str(output_dir), soc_name=soc_name)
+
+    build_dir = output_dir / "build"
+    build_dir.mkdir()
+    if subprocess.run(["cmake", ".."], cwd=build_dir,
+                      capture_output=True, text=True).returncode != 0:
+        return None
+    if subprocess.run(["cmake", "--build", ".", "--config", "Release"],
+                      cwd=build_dir, capture_output=True, text=True).returncode != 0:
+        return None
+
+    so_files = list(build_dir.glob("**/*.so")) + list(build_dir.glob("**/*.pyd"))
+    if not so_files:
+        return None
+    pkg_dir = output_dir / soc_name
+    pkg_dir.mkdir(exist_ok=True)
+    shutil.copy(so_files[0], pkg_dir)
+
+    sys.path.insert(0, str(output_dir))
+    spec = importlib.util.spec_from_file_location(
+        soc_name, str(pkg_dir / "__init__.py")
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[soc_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        print(f"Failed to import generated module: {e}")
+        return None
+    return module
+
+
+class TestWriteFields:
+    def test_single_rmw_for_multi_field_write(self, tmpdir):
+        soc_module = _build_module(tmpdir)
+        if soc_module is None:
+            pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+
+        soc = soc_module.create()
+
+        store = {}
+        reads = [0]
+        writes = [0]
+
+        def _read(addr, width):
+            reads[0] += 1
+            return store.get(addr, 0)
+
+        def _write(addr, value, width):
+            writes[0] += 1
+            store[addr] = value
+
+        cb = soc_module.CallbackMaster(_read, _write)
+        soc.attach_master(cb)
+
+        # Multi-field write: exactly 1 read + 1 write on the master.
+        soc.reg_multi.write_fields(field_a=0x5, field_b=0x3, field_c=0xAB)
+        assert reads[0] == 1, f"expected 1 read, got {reads[0]}"
+        assert writes[0] == 1, f"expected 1 write, got {writes[0]}"
+
+        # Resulting register value: each field placed at its lsb.
+        expected = (0x5 << 0) | (0x3 << 4) | (0xAB << 8)
+        # +1 read for verification.
+        assert int(soc.reg_multi.read()) == expected
+
+    def test_unknown_field_raises_key_error(self, tmpdir):
+        soc_module = _build_module(tmpdir)
+        if soc_module is None:
+            pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+
+        soc = soc_module.create()
+        soc.attach_master(soc_module.MockMaster())
+
+        with pytest.raises(KeyError):
+            soc.reg_multi.write_fields(field_a=1, nonexistent=2)
+
+    def test_read_only_field_raises_permission_error(self, tmpdir):
+        soc_module = _build_module(tmpdir)
+        if soc_module is None:
+            pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+
+        soc = soc_module.create()
+        soc.attach_master(soc_module.MockMaster())
+
+        with pytest.raises(PermissionError):
+            soc.reg_multi.write_fields(ro_field=1)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- Generate ``write_fields(uint64_t mask, uint64_t value)`` on every register class (delegates to existing ``RegisterBase::modify``).
- Add Python ``write_fields(**kwargs)`` shim that derives the combined mask/value from per-field metadata, then makes a single C++ entry. Validates unknown field names (``KeyError``) and read-only fields (``PermissionError``) at the Python boundary.
- N field writes on the same register now collapse to 1 read + 1 write on the master.

## Microbench (5-field write, 20k iters, MockMaster)
| variant | us/op | total |
| --- | --- | --- |
| ``reg.f0.write(); reg.f1.write(); ... reg.f4.write()`` | 2.42 | 0.048 s |
| ``reg.write_fields(f0=, f1=, ..., f4=)`` | 0.86 | 0.017 s |

Speedup: **2.83x**.

## Test plan
- [x] ``pytest tests/ -x -k 'not benchmarks'`` (88 passed, 0 failed)
- [x] New ``tests/test_write_fields.py``: verifies 1 read + 1 write on CallbackMaster, register value correctness, ``KeyError`` on unknown field, ``PermissionError`` on RO field
- [x] ``examples/run_example.py`` runs end-to-end
- [x] New ``benchmarks/test_runtime_write_fields.py`` microbench (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)