### PR TITLE
docs: NumPy as hard dep, ipywidgets/watchdog/pandas as optional extras

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,12 +4,21 @@ Installation
 Requirements
 ------------
 
+Runtime requirements (always installed):
+
 - Python >= 3.10
 - systemrdl-compiler >= 1.30.1
 - jinja2
+- **NumPy** — hard dependency
 - CMake >= 3.15 (for building generated modules)
 - C++11 compatible compiler (for building generated modules)
 - pybind11 (runtime dependency for generated code)
+
+NumPy is a **hard runtime dependency**, not optional. Bursts, bulk reads, and
+the buffer protocol return ``ndarray`` from arrays, memory regions, and
+snapshot frames; pretending NumPy were optional would just push the same
+import into user code. There is no list-fallback shim and no apology — if
+``peakrdl-pybind11`` is installed, ``numpy`` is installed.
 
 Using pip
 ---------
@@ -19,6 +28,32 @@ The easiest way to install PeakRDL-pybind11 is using pip:
 .. code-block:: bash
 
    pip install peakrdl-pybind11
+
+Optional extras
+---------------
+
+Several features have *soft* dependencies. They are not required to import or
+use the core API, but they unlock additional functionality when present:
+
+- **ipywidgets** — powers ``watch()`` live monitor widgets in Jupyter
+  notebooks. Without it, ``watch()`` falls back to a plain text refresh loop.
+- **watchdog** — required by the ``--watch`` CLI flag, which rebuilds and
+  hot-reloads the bound module when the source RDL changes.
+- **pandas** — enables ``Snapshot.to_dataframe()`` for tabular introspection
+  of all readable fields in a snapshot.
+
+These can be installed individually, or grouped via the ``notebook`` extras
+bundle (recommended for interactive workflows):
+
+.. code-block:: bash
+
+   pip install peakrdl-pybind11[notebook]
+
+.. note::
+
+   The ``[notebook]`` extras group is the intended UX for grouping the
+   notebook/interactive soft dependencies. The exact set of extras groups
+   may evolve as the API stabilizes.
 
 From Source
 -----------


### PR DESCRIPTION
## Summary

- Promote **NumPy** to a hard runtime dependency in ``docs/installation.rst`` per ``IDEAL_API_SKETCH.md`` §22.2 — public surface returns ``ndarray`` from arrays, memory, and snapshots.
- Add an **Optional extras** section listing ``ipywidgets`` (Jupyter ``watch()`` widgets — §5.5), ``watchdog`` (``--watch`` hot reload — §21), and ``pandas`` (``Snapshot.to_dataframe()`` — §16.1) as soft dependencies.
- Mention the intended ``pip install peakrdl-pybind11[notebook]`` extras-group UX (a future PR will wire up the actual extras group in ``pyproject.toml``).

This is part of the docs overhaul that brings user-facing pages in line with the aspirational API sketch; runtime code catches up later.

## Test plan

- [x] ``sphinx-build`` of ``docs/`` succeeds with no fatal errors
- [x] ``_build/html/installation.html`` renders the "NumPy ... hard runtime dependency" copy
- [x] Existing sections (Using pip, From Source, Development Installation, Verifying Installation) preserved verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)