### PR TITLE
docs: README overhaul to match API sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,54 +3,100 @@
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue)](https://github.com/arnavsacheti/PeakRDL-pybind11/blob/main/LICENSE)
 [![Documentation Status](https://readthedocs.org/projects/peakrdl-pybind11/badge/?version=latest)](https://peakrdl-pybind11.readthedocs.io/en/latest/?badge=latest)
 
-PeakRDL-pybind11 is an exporter for the PeakRDL toolchain that generates PyBind11 modules from SystemRDL register descriptions. This enables Python-based hardware testing and interaction with register maps through a clean, type-safe Python API.
+PeakRDL-pybind11 generates Python bindings from SystemRDL register descriptions so a Python-fluent person — bring-up engineer, test author, FW dev, lab automator, debugger — can drive a chip from a REPL or a Jupyter notebook with `dir(soc)` and a docstring as the only documentation needed.
+
+> **Status:** the API documented in this README is the **design target**. The current release ships the foundation (exporter, generated bindings, pluggable masters, the context-manager pattern) and is converging on the surface described here. The full design lives in [`docs/IDEAL_API_SKETCH.md`](docs/IDEAL_API_SKETCH.md). Sections marked aspirational are roadmap items; please file an issue if you hit a gap.
+
+## Mental model
+
+A generated module is a **typed tree of nodes** that mirrors the RDL hierarchy. Every node knows its path, its absolute address, its kind (`AddrMap`, `RegFile`, `Reg`, `Field`, `Mem`, `InterruptGroup`, `Alias`, `Signal`), its metadata, and which master serves its address range.
+
+```
+SoC
+├── AddrMap          (peripherals)
+│   ├── RegFile      (uart[0..3])
+│   │   ├── Reg      (control)
+│   │   │   └── Field (enable, baudrate, parity)
+│   │   ├── Reg      (status)            ← side-effecting reads (rclr) are flagged
+│   │   └── InterruptGroup               ← auto-detected from intr_state/enable/test
+│   └── Mem          (sram)              ← buffer-protocol, ndarray, slice
+└── Master           (the bus, pluggable)
+```
+
+Nodes are *descriptors*, not values. They produce values by reading. Values produced by reads are typed wrappers (`RegisterValue`, `FieldValue`) that behave like ints, decode enums, and round-trip cleanly back into writes.
+
+There are exactly **four primitive operations**:
+
+```python
+reg.read()              # → RegisterValue   (1 bus read)
+reg.write(value)        # raw write         (1 bus write, no read)
+reg.modify(**fields)    # RMW               (1 read + 1 write)
+reg.poke(value)         # explicit "I know what I'm doing", same as .write()
+```
+
+`field.read()` reads the parent register and slices. `field.write(v)` is shorthand for `reg.modify(field=v)` — one read, one write. The names are chosen so the bus cost is the obvious reading.
+
+For non-clearing inspection of registers with read-side effects, use `peek()`. Side-effect-only operations are first-class: `clear()`, `set()`, `pulse()`, `acknowledge()`.
 
 ## Features
 
-- **PyBind11 Module Generation**: Automatically generates C++ descriptors and Python bindings from SystemRDL
-- **SoC Hierarchy Exposure**: Import generated modules to access the complete SoC register hierarchy
-- **Pluggable Master Backends**: Support for multiple communication backends:
-  - Mock Master (for testing without hardware)
-  - OpenOCD Master (for JTAG/SWD debugging)
-  - SSH Master (for remote access)
-  - Custom Master backends (extensible interface)
-- **Comprehensive API**: 
-  - `attach_master()`: Connect to hardware or simulator
-  - `read()`: Read register values
-  - `write()`: Write register values
-  - `modify()`: Read-modify-write operations
-  - **Context Manager Support**: Batch field modifications for efficient register updates
-- **Type Safety**: Generated `.pyi` stub files for full IDE support and type checking
-- **Python-Based Testing**: Enable hardware testing with callbacks and custom logic
+- **Hierarchy & discovery** — typed tree mirroring RDL. Navigate by attribute, by index, or by path string. `soc.find(0x4000_1004)`, `soc.walk(kind=Reg)`, `soc.find_by_name("control", glob=True)`.
+- **Atomic multi-field updates** — `modify(**fields)` is the canonical RMW; kwargs map to fields by name and are type-checked against generated `.pyi` stubs.
+- **Interrupts as a first-class group** — `INTR_STATE`/`INTR_ENABLE`/`INTR_TEST` trios are auto-detected and exposed as `InterruptGroup` nodes with `wait()`, `clear()`, `pending()`, `enable_all()`, ISR-friendly iteration, and an asyncio variant.
+- **Memory as numpy-aware `MemView`** — `mem[10:20]` is a live view; `.copy()` / `.read()` snapshots into a one-burst `ndarray`. Buffer-protocol and `__array__` interop everywhere.
+- **Snapshots & diff** — `soc.snapshot()` for whole-SoC golden-state captures, JSON/pickle round-trip, `snap2.diff(snap1)` for change tables, `soc.restore(snap)` for replay.
+- **Jupyter widgets** — `_repr_html_` on every node renders a field table with side-effect badges, color-coded access modes, and click-to-expand source location. `node.watch(period=0.1)` produces a refreshing live monitor.
+- **Pluggable masters with tracing & replay** — Mock, OpenOCD, SSH, simulator, and a `RecordingMaster`/`ReplayMaster` pair. Transactions are reified objects you can script.
+- **Type-safe stubs** — generated `.pyi` declares enum types, field literals, and `Unpack[TypedDict]` for `modify(...)`. IDE completion is the spec; mypy/pyright catch unknown field names and out-of-range values.
+- **Typed values** — `RegisterValue`/`FieldValue` are immutable, hashable, picklable, JSON-serializable. Mutation goes through `.replace(**fields)` and never through assignment.
+- **Side effects loud, not silent** — `repr` shows `⚠ rclr`, `↻ singlepulse`, `✱ sticky`, `⚡ volatile`. `with soc.no_side_effects():` blocks destructive reads. `--strict-fields=false` opt-out exists for C-driver porting and emits a `DeprecationWarning` on every loose assignment.
 
-## Context Manager Support
+## Quick example
 
-The context manager feature allows you to batch multiple field modifications into a single bus transaction, significantly improving performance when updating multiple fields in the same register:
+The first three vignettes from [`docs/IDEAL_API_SKETCH.md`](docs/IDEAL_API_SKETCH.md) §24:
+
+### Bring-up
 
 ```python
-# Traditional approach: Each field write is a separate read-modify-write cycle (6 bus transactions)
-soc.uart.control.enable.write(1)      # Read + Write
-soc.uart.control.baudrate.write(2)    # Read + Write
-soc.uart.control.parity.write(1)      # Read + Write
+from MyChip import MyChip
+from MyChip.uart import BaudRate
+from peakrdl_pybind11.masters import OpenOCDMaster
 
-# Context manager approach: All modifications batched into one transaction (2 bus transactions)
-with soc.uart.control as reg:
-    reg.enable.write(1)       # Cached
-    reg.baudrate.write(2)     # Cached
-    reg.parity.write(1)       # Cached
-    # All changes written atomically when exiting context
-
-# You can also read and manipulate field values within the context
-with soc.uart.control as reg:
-    current_mode = reg.mode.read()
-    reg.enable.write(current_mode & 0x1)
-    reg.baudrate.write(2)
+soc = MyChip.create(master=OpenOCDMaster())
+print(soc.uart.control)
+soc.uart.control.modify(enable=1, baudrate=BaudRate.BAUD_115200)
+soc.uart.data.write(ord('A'))
+soc.uart.interrupts.tx_done.wait(timeout=1.0)
+soc.uart.interrupts.tx_done.clear()
 ```
 
-Benefits:
-- **Performance**: Reduces bus transactions from N read + N write to 1 read + 1 write
-- **Atomicity**: All field changes are committed together
-- **Readability**: Cleaner code for complex field manipulations
+### Test
+
+```python
+def test_uart_loopback(soc):
+    with soc.uart.control as r:
+        r.enable    = 1
+        r.loopback  = 1
+        r.baudrate  = BaudRate.BAUD_115200
+
+    soc.uart.data.write(0xA5)
+    soc.uart.status.rx_ready.wait_for(True, timeout=0.1)
+    assert soc.uart.data.read() == 0xA5
+
+    soc.uart.interrupts.clear_all()
+```
+
+### Bulk memory init
+
+```python
+import numpy as np
+
+soc.ram[:] = 0
+soc.ram[0:64] = np.arange(64, dtype=np.uint32) * 4
+checksum = np.bitwise_xor.reduce(np.asarray(soc.ram)[0:1024])
+```
+
+`modify(**fields)` is the canonical multi-field update; the `with soc.uart.control as r:` block is the secondary form for staging many writes (and for cases where one staged value is read back to compute another).
 
 ## Installation
 
@@ -60,41 +106,21 @@ pip install peakrdl-pybind11
 
 ## Usage
 
-### Command Line
+### Command line
 
 ```bash
 peakrdl pybind11 input.rdl -o output_dir --soc-name MySoC --top top_addrmap --gen-pyi
 ```
 
-#### CLI Options
+#### CLI options
 
-- `--soc-name`: Name of the generated SoC module (default: derived from input file)
-- `--top`: Top-level address map node to export (default: top-level node)
-- `--gen-pyi`: Generate `.pyi` stub files for type hints (enabled by default)
-- `--split-bindings COUNT`: Split bindings into multiple files for parallel compilation when register count exceeds COUNT. This significantly speeds up compilation for large register maps (default: 100, set to 0 to disable). Ignored when `--split-by-hierarchy` is used.
-- `--split-by-hierarchy`: Split bindings by addrmap/regfile hierarchy instead of by register count. This keeps related registers together and provides more logical grouping. Recommended for designs with clear hierarchical structure.
+- `--soc-name` — name of the generated SoC module (default: derived from input file)
+- `--top` — top-level address map node to export (default: top-level node)
+- `--gen-pyi` — generate `.pyi` stub files for type hints (enabled by default)
+- `--split-bindings COUNT` — split bindings into multiple files for parallel compilation when register count exceeds COUNT. Default: 100. Set to 0 to disable. Ignored when `--split-by-hierarchy` is used.
+- `--split-by-hierarchy` — split bindings by addrmap/regfile hierarchy instead of by register count. Keeps related registers together; recommended for designs with clear hierarchical structure.
 
-#### Compilation Performance Optimization
-
-For large register maps, compilation can be very slow. PeakRDL-pybind11 includes several optimizations:
-
-1. **Hierarchical binding splitting** (recommended): Use `--split-by-hierarchy` to split bindings by addrmap/regfile boundaries. This keeps related registers together in the same compilation unit, providing better organization and cache locality.
-2. **Register count binding splitting**: When register count exceeds `--split-bindings` threshold (default: 100), bindings are automatically split into multiple `.cpp` files that can be compiled in parallel
-3. **Optimized compiler flags**: The generated CMakeLists.txt uses `-O1` optimization even for debug builds, which significantly reduces compilation time for template-heavy code
-4. **Parallel compilation**: CMake will automatically compile split files in parallel when using `make -j` or `ninja`
-
-Examples for large register maps:
-```bash
-# Split by hierarchy (recommended for well-structured designs)
-peakrdl pybind11 large_design.rdl -o output --split-by-hierarchy
-
-# Split bindings every 50 registers for faster compilation
-peakrdl pybind11 large_design.rdl -o output --split-bindings 50
-
-# Build with parallel compilation (4 cores)
-cd output
-pip install . -- -DCMAKE_BUILD_PARALLEL_LEVEL=4
-```
+For large register maps, compilation can be slow. PeakRDL-pybind11 emits CMake projects that compile split files in parallel and uses `-O1` even for debug builds to reduce template-heavy build times — see [`COMPILATION_OPTIMIZATIONS.md`](COMPILATION_OPTIMIZATIONS.md) for the full breakdown.
 
 ### Python API
 
@@ -111,64 +137,58 @@ root = rdl.elaborate()
 exporter = Pybind11Exporter()
 exporter.export(root, "output_dir", soc_name="MySoC")
 
-# For large designs, enable binding splitting by hierarchy (recommended)
+# For large designs, enable hierarchical binding splitting (recommended)
 exporter.export(root, "output_dir", soc_name="MySoC", split_by_hierarchy=True)
-
-# Or split by register count
-exporter.export(root, "output_dir", soc_name="MySoC", split_bindings=50)
 ```
 
-### Using Generated Modules
+### Using generated modules
 
 ```python
 import MySoC
+from MySoC.uart import BaudRate, Parity
 from peakrdl_pybind11.masters import MockMaster
 
-# Create and attach a master
-soc = MySoC.create()
-mock = MockMaster()
-master = MySoC.wrap_master(mock)
-soc.attach_master(master)
+soc = MySoC.create(master=MockMaster())
 
-# Read/write registers
-value = soc.peripherals.uart.control.read()
-soc.peripherals.uart.control.write(0x1234)
+# Read a register — typed value with decoded fields in repr
+v = soc.uart.control.read()
+print(v)
 
-# Access individual fields
-soc.peripherals.uart.control.enable.write(1)
-enable_value = soc.peripherals.uart.control.enable.read()
+# Atomic multi-field update — one read, one write, type-checked from .pyi
+soc.uart.control.modify(enable=1, baudrate=BaudRate.BAUD_115200, parity=Parity.NONE)
 
-# Modify specific fields (traditional approach - each field modification is a separate bus transaction)
-soc.peripherals.uart.control.enable.write(1)
-soc.peripherals.uart.control.baudrate.write(2)
-soc.peripherals.uart.control.parity.write(1)
+# Wait for an interrupt
+soc.uart.interrupts.tx_done.wait(timeout=1.0)
+soc.uart.interrupts.tx_done.clear()
 
-# Use context manager for batched field modifications (recommended)
-# Only 1 read + 1 write transaction to the bus
-with soc.peripherals.uart.control as reg:
-    reg.enable.write(1)
-    reg.baudrate.write(2)
-    reg.parity.write(1)
-    # All changes are cached and written atomically when exiting the context
+# Stage many writes with the secondary context-manager form
+with soc.uart.control as r:
+    r.enable    = 1
+    r.baudrate  = BaudRate.BAUD_115200
+    if r.parity.read() == Parity.NONE:
+        r.parity = Parity.EVEN
+# 1 read + 1 write hits the bus on exit
 
-# Copy and modify field values within a context
-with soc.peripherals.uart.control as reg:
-    current_baudrate = reg.baudrate.read()
-    reg.enable.write(current_baudrate & 0x1)  # Use one field value to set another
+# Snapshot & diff
+snap1 = soc.snapshot()
+do_thing()
+snap2 = soc.snapshot()
+print(snap2.diff(snap1))
 ```
 
 ## Requirements
 
 - Python >= 3.10
-- systemrdl-compiler >= 1.30.1
-- jinja2
+- [systemrdl-compiler](https://pypi.org/project/systemrdl-compiler/) >= 1.30.1
+- [NumPy](https://numpy.org/) — hard runtime dependency (bursts, bulk reads, buffer protocol, snapshot frames)
+- [Jinja2](https://palletsprojects.com/p/jinja/)
 - CMake >= 3.15 (for building generated modules)
 - C++11 compatible compiler (for building generated modules)
-- pybind11 (runtime dependency for generated code)
+- [pybind11](https://pybind11.readthedocs.io/) (runtime dependency for generated code)
 
 ## Benchmarks
 
-Performance benchmarks are available to measure export and build times:
+Performance benchmarks measure export and build times across realistic register maps:
 
 ```bash
 # Run fast export benchmarks
@@ -182,9 +202,10 @@ python benchmarks/run_benchmarks.py
 ```
 
 See [benchmarks/README.md](benchmarks/README.md) for detailed documentation.
+
 ## Documentation
 
-Full documentation is available at [ReadTheDocs](https://peakrdl-pybind11.readthedocs.io/).
+Full documentation is available at [ReadTheDocs](https://peakrdl-pybind11.readthedocs.io/). The full design sketch lives in [`docs/IDEAL_API_SKETCH.md`](docs/IDEAL_API_SKETCH.md).
 
 To build the documentation locally:
 
@@ -198,4 +219,4 @@ The built documentation will be in `docs/_build/html/`.
 
 ## License
 
-This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GPL-3.0 License — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Rewrite the root `README.md` so a GitHub visitor immediately sees the new API:

- **Mental model** section leads — typed tree of nodes, four primitive ops (`read` / `write` / `modify(**fields)` / `poke`).
- **Features** list now leads with hierarchy & discovery, `modify(**fields)` atomic updates, interrupts as a first-class group, memory as numpy-aware `MemView`, snapshots & diff, Jupyter widgets (`_repr_html_`, `watch()`), pluggable masters with tracing & replay, and type-safe stubs.
- **Quick example** block pulls the first three vignettes verbatim from sketch §24 (bring-up + test + bulk memory init).
- **Using generated modules** example replaced with sketch idioms: `soc.uart.control.modify(enable=1, baudrate=BaudRate.BAUD_115200)` and `soc.uart.interrupts.tx_done.wait(timeout=1.0)`.
- The dedicated context-manager-as-headline section is dropped; the `with soc.uart.control as r:` form now appears as the secondary pattern after `modify(...)`.
- The long Compilation Performance Optimization subsection is collapsed to a one-paragraph link to `COMPILATION_OPTIMIZATIONS.md`.
- **Requirements** now lists NumPy as a hard runtime dependency.
- A short status banner near the top clarifies that the README documents the design target while the current release ships the foundation, and links to `docs/IDEAL_API_SKETCH.md`.

References sketch sections §0 (audience), §1 (principles), §2 (mental model), §3 (read/write surface incl. §3.3 multi-field modify), §9 (interrupts), §15 (snapshots), §24 (gallery).

> Note: the link to `docs/IDEAL_API_SKETCH.md` will 404 on GitHub until that file lands on `main` via its own unit PR — the docs overhaul is intentionally a parallel rollout.

## Test plan

- [x] `python -c "t=open('README.md').read(); assert t.count('\`\`\`') % 2 == 0"` — fences balanced (22 markers, 11 code blocks).
- [x] Mental model section appears before any read/write example.
- [x] `modify(**fields)` example appears before any context-manager example.
- [x] Interrupts and snapshots both present in the Features list.
- [ ] Eyeball the rendered Markdown on the GitHub PR page (reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)