### PR TITLE
feat(runtime): error taxonomy (Unit 2)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,4 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+"""

--- a/src/peakrdl_pybind11/runtime/errors.py
+++ b/src/peakrdl_pybind11/runtime/errors.py
@@ -1,0 +1,212 @@
+"""Error taxonomy for the PeakRDL-pybind11 runtime.
+
+Implements the model described in ``docs/IDEAL_API_SKETCH.md`` §19, plus the
+:class:`BusError` detail from §13.5. Every exception carries enough context
+(node path and, where meaningful, the absolute address) to triage failures in
+CI without re-running the test under a debugger.
+
+Stack traces stay short by setting ``__tracebackhide__`` in internal helper
+frames; pytest honors this convention to skip framework code when rendering
+tracebacks.
+"""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "AccessError",
+    "BusError",
+    "NotSupportedError",
+    "RoutingError",
+    "SideEffectError",
+    "StaleHandleError",
+    "WaitTimeoutError",
+    "did_you_mean",
+]
+
+
+class AccessError(Exception):
+    """Raised when a software access violates the field's access mode.
+
+    Examples include writing to a read-only field or reading from a
+    write-only field. The default message follows the sketch §19 form
+    ``"<node_path> is sw=<access_mode>"`` (e.g. ``"uart.status.tx_ready is
+    sw=r"``); callers may override with a custom ``message``.
+    """
+
+    def __init__(
+        self,
+        node_path: str,
+        access_mode: str,
+        message: str | None = None,
+    ) -> None:
+        self.node_path = node_path
+        self.access_mode = access_mode
+        if message is None:
+            message = f"{node_path} is sw={access_mode}"
+        self.message = message
+        super().__init__(message)
+
+
+class SideEffectError(Exception):
+    """Raised when an access would trigger a side-effect inside a
+    ``no_side_effects()`` block.
+
+    The canonical case is reading an ``rclr`` field while side-effects are
+    suppressed (the read would clear the field, which the caller has
+    explicitly opted out of).
+    """
+
+    def __init__(self, node_path: str, message: str | None = None) -> None:
+        self.node_path = node_path
+        if message is None:
+            message = (
+                f"{node_path} would trigger a side-effect inside no_side_effects()"
+            )
+        self.message = message
+        super().__init__(message)
+
+
+class NotSupportedError(Exception):
+    """Raised when a feature is not implemented by the active master/transport.
+
+    For example, calling ``peek()`` on a master that cannot do non-destructive
+    reads, or requesting interrupt subscription on a polling-only backend.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class BusError(Exception):
+    """Raised when a bus transaction fails after all retries are exhausted.
+
+    Carries the failed transaction, the master that issued it, the retry
+    count, and the underlying exception — enough for a CI run to triage why
+    it died (sketch §13.5).
+    """
+
+    def __init__(
+        self,
+        address: int,
+        op: str,
+        master: object,
+        retries: int = 0,
+        underlying: BaseException | None = None,
+    ) -> None:
+        self.address = address
+        self.op = op
+        self.master = master
+        self.retries = retries
+        self.underlying = underlying
+        retry_word = "retry" if retries == 1 else "retries"
+        parts = [
+            f"bus {op} @ 0x{address:08x}",
+            f"master={_master_name(master)}",
+            f"{retries} {retry_word}",
+        ]
+        underlying_summary = _summarise_exception(underlying)
+        if underlying_summary:
+            parts.append(f"underlying={underlying_summary}")
+        self.message = ", ".join(parts)
+        super().__init__(self.message)
+
+
+class RoutingError(Exception):
+    """Raised when an absolute address has no master attached to serve it.
+
+    The default message follows the sketch §19 form
+    ``"no master attached for 0x<address>"``; callers may override.
+    """
+
+    def __init__(self, address: int, message: str | None = None) -> None:
+        self.address = address
+        if message is None:
+            message = f"no master attached for 0x{address:08x}"
+        self.message = message
+        super().__init__(message)
+
+
+class StaleHandleError(Exception):
+    """Raised when a :class:`RegisterValue` or :class:`Snapshot` is used after
+    the underlying SoC has been reloaded (``soc.reload()``)."""
+
+    def __init__(self, node_path: str, message: str | None = None) -> None:
+        self.node_path = node_path
+        if message is None:
+            message = f"handle for {node_path} is stale; SoC was reloaded"
+        self.message = message
+        super().__init__(message)
+
+
+class WaitTimeoutError(TimeoutError):
+    """Raised when ``wait_until``/``poll`` exceeds its timeout.
+
+    Subclasses :class:`TimeoutError` so existing ``except TimeoutError``
+    handlers still catch it. Optionally records a sample trail of the
+    intermediate values seen while polling, useful for glitch debugging.
+    """
+
+    def __init__(
+        self,
+        node_path: str,
+        expected: object,
+        last_seen: object,
+        samples: Sequence[object] | None = None,
+    ) -> None:
+        self.node_path = node_path
+        self.expected = expected
+        self.last_seen = last_seen
+        self.samples = tuple(samples) if samples is not None else None
+        message = (
+            f"timeout waiting for {node_path} == {expected!r}; "
+            f"last_seen={last_seen!r}"
+        )
+        if self.samples is not None:
+            message += f"; samples={list(self.samples)!r}"
+        self.message = message
+        super().__init__(message)
+
+
+def did_you_mean(name: str, candidates: Iterable[str]) -> str:
+    """Return the closest match from ``candidates`` for ``name``.
+
+    Returns the empty string when nothing is close enough. Used to power the
+    "did you mean ...?" hint shown alongside :class:`AttributeError` for
+    misspelled field/register names.
+    """
+
+    # pytest skips frames whose locals contain __tracebackhide__ = True, so
+    # user-facing tracebacks stay focused on the caller's code rather than
+    # this helper.
+    __tracebackhide__ = True
+
+    matches = difflib.get_close_matches(name, candidates, n=1)
+    return matches[0] if matches else ""
+
+
+def _master_name(master: object) -> str:
+    """Best-effort name extraction for a master object."""
+
+    __tracebackhide__ = True
+    if master is None:
+        return "<no-master>"
+    name = getattr(master, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    return type(master).__name__
+
+
+def _summarise_exception(exc: BaseException | None) -> str:
+    """One-line summary of an underlying exception for :class:`BusError`."""
+
+    __tracebackhide__ = True
+    if exc is None:
+        return ""
+    text = str(exc).strip()
+    if not text:
+        return type(exc).__name__
+    return f"{type(exc).__name__}: {text}"

--- a/tests/runtime/test_errors.py
+++ b/tests/runtime/test_errors.py
@@ -1,0 +1,253 @@
+"""Tests for ``peakrdl_pybind11.runtime.errors`` (sketch §19, §13.5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from peakrdl_pybind11.runtime.errors import (
+    AccessError,
+    BusError,
+    NotSupportedError,
+    RoutingError,
+    SideEffectError,
+    StaleHandleError,
+    WaitTimeoutError,
+    did_you_mean,
+)
+
+
+# ---------------------------------------------------------------------------
+# AccessError
+# ---------------------------------------------------------------------------
+
+
+class TestAccessError:
+    def test_default_message_format(self) -> None:
+        err = AccessError("uart.status.tx_ready", "r")
+        assert err.node_path == "uart.status.tx_ready"
+        assert err.access_mode == "r"
+        # Sketch §19 example.
+        assert str(err) == "uart.status.tx_ready is sw=r"
+
+    def test_custom_message_overrides_default(self) -> None:
+        err = AccessError("uart.status.tx_ready", "r", message="custom")
+        assert str(err) == "custom"
+
+    def test_is_exception(self) -> None:
+        with pytest.raises(AccessError):
+            raise AccessError("foo.bar", "w")
+
+
+# ---------------------------------------------------------------------------
+# SideEffectError
+# ---------------------------------------------------------------------------
+
+
+class TestSideEffectError:
+    def test_instantiable_with_path(self) -> None:
+        err = SideEffectError("uart.status.rx_overrun")
+        assert err.node_path == "uart.status.rx_overrun"
+        assert "uart.status.rx_overrun" in str(err)
+        assert "no_side_effects" in str(err)
+
+    def test_custom_message(self) -> None:
+        err = SideEffectError("foo.bar", message="rclr inside no_side_effects()")
+        assert str(err) == "rclr inside no_side_effects()"
+
+
+# ---------------------------------------------------------------------------
+# NotSupportedError
+# ---------------------------------------------------------------------------
+
+
+class TestNotSupportedError:
+    def test_message_round_trip(self) -> None:
+        err = NotSupportedError("master cannot peek rclr")
+        assert err.message == "master cannot peek rclr"
+        assert str(err) == "master cannot peek rclr"
+
+
+# ---------------------------------------------------------------------------
+# BusError
+# ---------------------------------------------------------------------------
+
+
+class _FakeMaster:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class TestBusError:
+    def test_minimal_construction(self) -> None:
+        err = BusError(0x4000_1000, "wr", _FakeMaster("ahb0"))
+        assert err.address == 0x4000_1000
+        assert err.op == "wr"
+        assert err.retries == 0
+        assert err.underlying is None
+
+    def test_str_contains_address_in_hex(self) -> None:
+        err = BusError(0xDEAD_BEEF, "rd", _FakeMaster("jtag"))
+        # The contract: address rendered as 0x{:08x}.
+        assert "0xdeadbeef" in str(err)
+
+    def test_str_zero_pads_short_addresses(self) -> None:
+        err = BusError(0x42, "wr", _FakeMaster("ahb0"))
+        assert "0x00000042" in str(err)
+
+    def test_str_includes_op_master_and_retries(self) -> None:
+        err = BusError(0x100, "wr", _FakeMaster("ahb0"), retries=3)
+        text = str(err)
+        assert "wr" in text
+        assert "ahb0" in text
+        assert "3 retries" in text
+
+    def test_retry_word_is_singular_for_one(self) -> None:
+        err = BusError(0x100, "wr", _FakeMaster("ahb0"), retries=1)
+        assert "1 retry" in str(err)
+
+    def test_underlying_summary(self) -> None:
+        underlying = TimeoutError("ack timed out")
+        err = BusError(
+            0x4000_1000,
+            "rd",
+            _FakeMaster("ahb0"),
+            retries=2,
+            underlying=underlying,
+        )
+        text = str(err)
+        assert "TimeoutError" in text
+        assert "ack timed out" in text
+
+    def test_master_without_name_falls_back_to_type(self) -> None:
+        class Anon:
+            pass
+
+        err = BusError(0x4000_1000, "wr", Anon())
+        assert "Anon" in str(err)
+
+    def test_master_none_renders_placeholder(self) -> None:
+        err = BusError(0x4000_1000, "wr", None)
+        assert "<no-master>" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# RoutingError
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingError:
+    def test_default_message_includes_phrase_and_address(self) -> None:
+        err = RoutingError(0xDEAD_BEEF)
+        text = str(err)
+        assert "no master attached" in text
+        assert "0xdeadbeef" in text
+
+    def test_custom_message_overrides_default(self) -> None:
+        err = RoutingError(0xDEAD_BEEF, message="explicitly unmapped")
+        assert str(err) == "explicitly unmapped"
+        # Address still recoverable from the attribute.
+        assert err.address == 0xDEAD_BEEF
+
+
+# ---------------------------------------------------------------------------
+# StaleHandleError
+# ---------------------------------------------------------------------------
+
+
+class TestStaleHandleError:
+    def test_default_message(self) -> None:
+        err = StaleHandleError("uart.control")
+        text = str(err)
+        assert "uart.control" in text
+        assert "stale" in text
+
+    def test_custom_message(self) -> None:
+        err = StaleHandleError("uart.control", message="snapshot invalidated")
+        assert str(err) == "snapshot invalidated"
+
+
+# ---------------------------------------------------------------------------
+# WaitTimeoutError
+# ---------------------------------------------------------------------------
+
+
+class TestWaitTimeoutError:
+    def test_subclass_of_timeout_error(self) -> None:
+        err = WaitTimeoutError("uart.status.tx_ready", expected=1, last_seen=0)
+        assert isinstance(err, TimeoutError)
+
+    def test_message_includes_expected_and_last_seen(self) -> None:
+        err = WaitTimeoutError("uart.status.tx_ready", expected=1, last_seen=0)
+        text = str(err)
+        assert "uart.status.tx_ready" in text
+        assert "1" in text
+        assert "last_seen=0" in text
+
+    def test_samples_are_recorded_when_provided(self) -> None:
+        err = WaitTimeoutError(
+            "uart.status.tx_ready",
+            expected=1,
+            last_seen=0,
+            samples=[0, 0, 1, 0],
+        )
+        assert err.samples == (0, 0, 1, 0)
+        assert "samples=" in str(err)
+
+    def test_samples_default_none(self) -> None:
+        err = WaitTimeoutError("uart.status.tx_ready", expected=1, last_seen=0)
+        assert err.samples is None
+
+
+# ---------------------------------------------------------------------------
+# did_you_mean
+# ---------------------------------------------------------------------------
+
+
+class TestDidYouMean:
+    def test_documented_example(self) -> None:
+        # Pulled from the unit's spec.
+        assert did_you_mean("enbale", ["enable", "baudrate", "parity"]) == "enable"
+
+    def test_returns_empty_string_when_no_match(self) -> None:
+        assert did_you_mean("xyzzy", ["enable", "baudrate", "parity"]) == ""
+
+    def test_exact_match_returned(self) -> None:
+        assert did_you_mean("enable", ["enable", "baudrate"]) == "enable"
+
+    def test_empty_candidates_returns_empty_string(self) -> None:
+        assert did_you_mean("enable", []) == ""
+
+    def test_accepts_iterable_not_only_list(self) -> None:
+        # difflib needs to materialise the candidates; the helper should
+        # cope with one-shot iterables (e.g. dict_keys, generators).
+        assert did_you_mean("enbale", iter(["enable", "baudrate"])) == "enable"
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_all_exports_listed() -> None:
+    from peakrdl_pybind11.runtime import errors
+
+    expected = {
+        "AccessError",
+        "BusError",
+        "NotSupportedError",
+        "RoutingError",
+        "SideEffectError",
+        "StaleHandleError",
+        "WaitTimeoutError",
+        "did_you_mean",
+    }
+    assert set(errors.__all__) == expected
+    for name in expected:
+        assert hasattr(errors, name)
+
+
+def test_module_docstring_references_section_19() -> None:
+    from peakrdl_pybind11.runtime import errors
+
+    assert errors.__doc__ is not None
+    assert "§19" in errors.__doc__


### PR DESCRIPTION
## Summary
- Adds `peakrdl_pybind11.runtime.errors` implementing the error model from `docs/IDEAL_API_SKETCH.md` §19 plus the `BusError` detail from §13.5.
- Defines `AccessError`, `SideEffectError`, `NotSupportedError`, `BusError`, `RoutingError`, `StaleHandleError`, `WaitTimeoutError` (subclass of `TimeoutError`), and a `did_you_mean` helper backed by `difflib.get_close_matches`.
- Standalone module: only stdlib imports, no dependency on Unit 1's seam, so tests can run pre-scaffolding. Internal helpers set `__tracebackhide__` so pytest collapses them in user tracebacks.

## Test plan
- [x] `uv run pytest tests/runtime/test_errors.py -v` (29 passing)
- [x] `uv run pytest tests/ --no-header -q` (105 passing, 27 skipped, no regressions)
- [x] `uv run python -c "from peakrdl_pybind11.runtime.errors import BusError, RoutingError, did_you_mean; print(did_you_mean('enbale', ['enable']))"` prints `enable`
- [x] `ruff check src/peakrdl_pybind11/runtime/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)