### PR TITLE
feat(runtime): side-effect helpers (Unit 5)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime helpers used by generated bindings.
+
+Modules in this package are pure Python and are imported by users
+alongside (or by) the generated pybind11 module to add ergonomic
+behaviour on top of the raw bus accessors.
+"""

--- a/src/peakrdl_pybind11/runtime/side_effects.py
+++ b/src/peakrdl_pybind11/runtime/side_effects.py
@@ -225,8 +225,7 @@ def clear(target: object) -> None:
     """Clear ``target`` using whichever path the metadata declares.
 
     - ``onwrite = woclr``  -> write 1
-    - ``onwrite = wclr``   -> write all-ones (any write clears, but all-ones
-      is a deterministic choice that works for both fields and registers)
+    - ``onwrite = wclr``   -> write 0 to all bits (per sketch §11)
     - ``onwrite = wzc``    -> write 0
     - ``onread  = rclr``   -> issue a read (and discard)
     - otherwise            -> raise ``NotSupportedError``
@@ -236,7 +235,7 @@ def clear(target: object) -> None:
         target.write(1)
         return
     if on_write == "wclr":
-        target.write(_all_ones(target))
+        target.write(0)
         return
     if on_write == "wzc":
         target.write(0)

--- a/src/peakrdl_pybind11/runtime/side_effects.py
+++ b/src/peakrdl_pybind11/runtime/side_effects.py
@@ -1,0 +1,333 @@
+"""Side-effect helpers (sketch §11).
+
+Verbs (``peek``, ``clear``, ``set``, ``pulse``, ``acknowledge``) dispatch on the
+``info.on_read`` / ``info.on_write`` metadata attached to a field or register.
+The functions accept either kind of target -- the only requirement is that the
+target exposes ``.info.on_read`` and ``.info.on_write`` along with ``.read()``
+and ``.write()`` callables.
+
+The module also provides ``no_side_effects`` -- a thread-local context manager
+that turns destructive reads into ``SideEffectError`` so debug dumps and
+read-only inspectors can run without mutating hardware.
+
+Sibling units (``errors`` -> Unit 2, ``info`` -> Unit 4, ``_registry`` ->
+Unit 1) may not be present yet on the branch this module is built on; the
+imports below fall back to local definitions so this file is usable in
+isolation. When the siblings land, the imports prefer them transparently.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+# ---------------------------------------------------------------------------
+# Sibling-dep imports with local fallbacks (Units 1, 2 may not exist yet).
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - prefer the real Unit 2 errors when present
+    from ..errors import NotSupportedError, SideEffectError  # type: ignore[no-redef]
+except ImportError:  # pragma: no cover - fallback shim
+
+    class NotSupportedError(RuntimeError):
+        """Raised when an operation is not supported by the master/field."""
+
+    class SideEffectError(RuntimeError):
+        """Raised when a destructive read happens inside ``no_side_effects``."""
+
+
+try:  # pragma: no cover - prefer the real Unit 1 registry when present
+    from .._registry import register_register_enhancement  # type: ignore[no-redef]
+except ImportError:  # pragma: no cover - fallback shim (no-op decorator)
+
+    def register_register_enhancement(fn: Callable[..., object]) -> Callable[..., object]:
+        """No-op fallback for the enhancement registry seam."""
+        return fn
+
+
+__all__ = [
+    "NotSupportedError",
+    "SideEffectError",
+    "acknowledge",
+    "check_read_allowed",
+    "clear",
+    "no_side_effects",
+    "peek",
+    "pulse",
+    "set_",
+]
+
+# Read-side effects that mutate hardware on a plain ``read()``. Centralized so
+# ``peek`` / ``check_read_allowed`` agree on which effects need a peek path.
+_DESTRUCTIVE_READ_EFFECTS = frozenset({"rclr", "rset", "ruser"})
+
+# ---------------------------------------------------------------------------
+# Thread-local guard used by ``no_side_effects`` and by enhanced read paths.
+# ---------------------------------------------------------------------------
+_state = threading.local()
+
+
+def _guard_active() -> bool:
+    """Return True if the calling thread is inside ``no_side_effects``."""
+    return getattr(_state, "no_side_effects", False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for inspecting the duck-typed metadata.
+# ---------------------------------------------------------------------------
+def _norm(value: object) -> str:
+    """Normalize an ``on_read`` / ``on_write`` value to a lowercase string.
+
+    Unit 4 may eventually use enums; today's tests pass strings. ``None`` /
+    ``"none"`` / falsy all collapse to the empty string so callers can compare
+    cleanly.
+    """
+    if value is None:
+        return ""
+    name = getattr(value, "name", None)
+    if name is not None:
+        value = name
+    text = str(value).strip().lower()
+    return "" if text in ("none", "") else text
+
+
+def _info_path(target: object) -> str:
+    """Best-effort path string for use in error messages."""
+    info = getattr(target, "info", None)
+    path = getattr(info, "path", None)
+    if path:
+        return str(path)
+    name = getattr(target, "name", None) or getattr(info, "name", None)
+    return str(name) if name else "<unknown>"
+
+
+def _on_read(target: object) -> str:
+    info = getattr(target, "info", None)
+    return _norm(getattr(info, "on_read", None))
+
+
+def _on_write(target: object) -> str:
+    info = getattr(target, "info", None)
+    return _norm(getattr(info, "on_write", None))
+
+
+def _all_ones(target: object) -> int:
+    """Return a bitmask of all-ones for a field/register (default ``1``).
+
+    Falls back to ``1`` when no width metadata is available -- bare ``write(1)``
+    is the documented behaviour for ``woclr`` / ``woset`` / ``singlepulse``.
+    """
+    info = getattr(target, "info", None)
+    width = getattr(info, "width", None)
+    if width is None:
+        # Try regwidth (registers) as a secondary source.
+        width = getattr(info, "regwidth", None)
+    if isinstance(width, int) and width > 0:
+        return (1 << width) - 1
+    return 1
+
+
+def _master_can_peek(target: object) -> bool:
+    """Return True if the master serving ``target`` exposes a peek path.
+
+    Resolution order:
+      1. ``master.can_peek`` -- explicit capability flag wins. Lets a master
+         that *defines* a ``peek`` method advertise that it actually only
+         delegates to a destructive read on the current bus.
+      2. Otherwise, the presence of a callable ``master.peek`` is taken as
+         capability. Unit 1 may formalize this further later.
+    """
+    master = _resolve_master(target)
+    if master is None:
+        # No master attached -- best to refuse and let the user wire one up.
+        return False
+    can_peek = getattr(master, "can_peek", None)
+    if can_peek is not None:
+        return bool(can_peek)
+    return callable(getattr(master, "peek", None))
+
+
+def _resolve_master(target: object) -> object | None:
+    """Locate the master associated with a field/register (or ``None``)."""
+    for attr in ("master", "_master"):
+        master = getattr(target, attr, None)
+        if master is not None:
+            return master
+    parent = getattr(target, "parent", None) or getattr(target, "_parent", None)
+    if parent is not None:
+        return _resolve_master(parent)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook for the enhanced ``.read()`` to consult the no-side-effects guard.
+# ---------------------------------------------------------------------------
+def check_read_allowed(target: object) -> None:
+    """Raise ``SideEffectError`` if a destructive read is forbidden right now.
+
+    Generated read paths (and the enhancement seam) are expected to call this
+    before issuing the bus read whenever ``info.on_read`` is set. It is a
+    no-op outside of a ``no_side_effects`` block.
+    """
+    if not _guard_active():
+        return
+    effect = _on_read(target)
+    if effect in _DESTRUCTIVE_READ_EFFECTS:
+        raise SideEffectError(
+            f"read() of {_info_path(target)} would {effect} -- "
+            "use peek() or remove the no_side_effects() guard"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public verbs.
+# ---------------------------------------------------------------------------
+def peek(target: object) -> int | bool:
+    """Read ``target`` without triggering its read-side effect.
+
+    For an ``rclr`` field the underlying master must support a non-destructive
+    read; otherwise ``NotSupportedError`` is raised -- the API does not pretend
+    a peek exists when the bus literally cannot perform one.
+    """
+    on_read = _on_read(target)
+    can_peek = _master_can_peek(target)
+    if on_read in _DESTRUCTIVE_READ_EFFECTS and not can_peek:
+        raise NotSupportedError(f"master cannot peek {on_read} ({_info_path(target)})")
+
+    master = _resolve_master(target)
+    if can_peek and master is not None and callable(getattr(master, "peek", None)):
+        info = getattr(target, "info", None)
+        addr = getattr(info, "address", None)
+        if addr is not None:
+            width = getattr(info, "regwidth", None) or getattr(info, "width", None) or 4
+            return _slice_field(target, master.peek(addr, width))
+
+    # No bus-level peek seam -- fall back to the target's own read(), which is
+    # safe iff the field has no read-side effect (the early return above
+    # already covers the destructive case).
+    if not callable(getattr(target, "read", None)):
+        raise NotSupportedError(f"peek not supported on {_info_path(target)}")
+    return target.read()
+
+
+def _slice_field(target: object, register_value: int) -> int | bool:
+    """If ``target`` is a field, slice ``register_value`` to just its bits."""
+    info = getattr(target, "info", None)
+    lsb = getattr(info, "lsb", None)
+    width = getattr(info, "width", None)
+    if isinstance(lsb, int) and isinstance(width, int):
+        masked = (register_value >> lsb) & ((1 << width) - 1)
+        return bool(masked) if width == 1 else masked
+    return register_value
+
+
+def clear(target: object) -> None:
+    """Clear ``target`` using whichever path the metadata declares.
+
+    - ``onwrite = woclr``  -> write 1
+    - ``onwrite = wclr``   -> write all-ones (any write clears, but all-ones
+      is a deterministic choice that works for both fields and registers)
+    - ``onwrite = wzc``    -> write 0
+    - ``onread  = rclr``   -> issue a read (and discard)
+    - otherwise            -> raise ``NotSupportedError``
+    """
+    on_write = _on_write(target)
+    if on_write == "woclr":
+        target.write(1)
+        return
+    if on_write == "wclr":
+        target.write(_all_ones(target))
+        return
+    if on_write == "wzc":
+        target.write(0)
+        return
+    if _on_read(target) == "rclr":
+        # A destructive read IS the clear path here.
+        target.read()
+        return
+    raise NotSupportedError(f"{_info_path(target)}: no clear path on this field")
+
+
+def acknowledge(target: object) -> None:
+    """Alias of :func:`clear` -- reads better in ISR-shaped code."""
+    clear(target)
+
+
+def set_(target: object) -> None:
+    """Set ``target`` using whichever path the metadata declares.
+
+    - ``onwrite = woset`` -> write 1
+    - ``onwrite = wset``  -> write all-ones
+    - ``onwrite = wzs``   -> write 0
+    - otherwise           -> raise ``NotSupportedError``
+    """
+    on_write = _on_write(target)
+    if on_write == "woset":
+        target.write(1)
+        return
+    if on_write == "wset":
+        target.write(_all_ones(target))
+        return
+    if on_write == "wzs":
+        target.write(0)
+        return
+    raise NotSupportedError(f"{_info_path(target)}: no set path on this field")
+
+
+def pulse(target: object) -> None:
+    """Trigger a singlepulse field (write 1; hardware self-clears).
+
+    Also accepts any field with a ``woset`` write effect for symmetry --
+    sometimes the RDL spells the same hardware behaviour either way.
+    """
+    info = getattr(target, "info", None)
+    is_singlepulse = (
+        bool(getattr(info, "singlepulse", False)) or _norm(getattr(info, "kind", None)) == "singlepulse"
+    )
+    if is_singlepulse or _on_write(target) == "woset":
+        target.write(1)
+        return
+    raise NotSupportedError(f"{_info_path(target)}: not a singlepulse field")
+
+
+# ---------------------------------------------------------------------------
+# Context manager.
+# ---------------------------------------------------------------------------
+@contextmanager
+def no_side_effects(soc: object = None) -> Iterator[object]:
+    """Forbid destructive reads (``rclr`` / ``rset``) for the calling thread.
+
+    Inside the block, any ``check_read_allowed`` call on a field whose
+    ``info.on_read`` is ``rclr`` / ``rset`` raises :class:`SideEffectError`.
+    Generated read paths (and tests using the enhancement seam) are expected
+    to call ``check_read_allowed`` before issuing their bus read.
+
+    The ``soc`` argument is preserved for forward compatibility (some
+    backends may want to widen the guard to also disable observation hooks);
+    today it is unused.
+    """
+    prior = getattr(_state, "no_side_effects", False)
+    _state.no_side_effects = True
+    try:
+        yield soc
+    finally:
+        _state.no_side_effects = prior
+
+
+# ---------------------------------------------------------------------------
+# Enhancement seam -- attach the verbs as methods to generated reg/field
+# classes so users can write ``f.clear()`` / ``r.peek()`` directly.
+# ---------------------------------------------------------------------------
+@register_register_enhancement
+def _enhance(cls: type, metadata: object = None) -> None:
+    """Register/field enhancement that binds the verbs as methods.
+
+    The signature mirrors Unit 1's seam: ``cls`` is the generated class,
+    ``metadata`` the per-class info bundle (unused here -- the verbs read
+    metadata off ``self.info`` at call time).
+    """
+    cls.peek = lambda self: peek(self)  # type: ignore[attr-defined]
+    cls.clear = lambda self: clear(self)  # type: ignore[attr-defined]
+    cls.set = lambda self: set_(self)  # type: ignore[attr-defined]
+    cls.pulse = lambda self: pulse(self)  # type: ignore[attr-defined]
+    cls.acknowledge = lambda self: acknowledge(self)  # type: ignore[attr-defined]

--- a/tests/runtime/test_side_effects.py
+++ b/tests/runtime/test_side_effects.py
@@ -1,0 +1,277 @@
+"""Unit tests for ``peakrdl_pybind11.runtime.side_effects`` (sketch §11).
+
+These tests are intentionally pure-Python: every "field" / "register" / "master"
+is a small mock built from ``types.SimpleNamespace`` so the side-effect helpers
+can be exercised without compiling any generated C++ binding.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime.side_effects import (
+    NotSupportedError,
+    SideEffectError,
+    acknowledge,
+    check_read_allowed,
+    clear,
+    no_side_effects,
+    peek,
+    pulse,
+    set_,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tiny helpers for building targets.
+# ---------------------------------------------------------------------------
+class _Master:
+    """Minimal master that records calls; ``can_peek`` toggles peek support."""
+
+    def __init__(self, *, can_peek: bool = False, peek_value: int = 0) -> None:
+        self.can_peek = can_peek
+        self.peek_value = peek_value
+        self.peeks: list[tuple[int, int]] = []
+
+    def peek(self, addr: int, width: int) -> int:
+        self.peeks.append((addr, width))
+        return self.peek_value
+
+
+def _make_field(
+    *,
+    on_read: str | None = None,
+    on_write: str | None = None,
+    width: int = 1,
+    lsb: int = 0,
+    path: str = "soc.foo.bar",
+    address: int | None = 0x1000,
+    singlepulse: bool = False,
+    master: Any = None,
+) -> SimpleNamespace:
+    """Build a duck-typed field with a recording ``write`` / ``read``."""
+    calls: dict[str, list[Any]] = {"write": [], "read": []}
+
+    def write(value: int) -> None:
+        calls["write"].append(value)
+
+    def read() -> int:
+        calls["read"].append(None)
+        return 0
+
+    info = SimpleNamespace(
+        on_read=on_read,
+        on_write=on_write,
+        width=width,
+        lsb=lsb,
+        path=path,
+        address=address,
+        singlepulse=singlepulse,
+    )
+    return SimpleNamespace(info=info, write=write, read=read, master=master, calls=calls)
+
+
+# ---------------------------------------------------------------------------
+# clear() dispatch
+# ---------------------------------------------------------------------------
+def test_clear_woclr_writes_one() -> None:
+    f = _make_field(on_write="woclr")
+    clear(f)
+    assert f.calls["write"] == [1]
+
+
+def test_clear_wclr_writes_all_ones() -> None:
+    """``wclr`` accepts any write; we send all-ones for determinism."""
+    f = _make_field(on_write="wclr", width=8)
+    clear(f)
+    assert f.calls["write"] == [0xFF]
+
+
+def test_clear_wzc_writes_zero() -> None:
+    f = _make_field(on_write="wzc")
+    clear(f)
+    assert f.calls["write"] == [0]
+
+
+def test_clear_rclr_does_a_read() -> None:
+    """When the only clear path is a destructive read, ``clear`` reads."""
+    f = _make_field(on_read="rclr")
+    clear(f)
+    assert f.calls["read"] == [None]
+    assert f.calls["write"] == []
+
+
+def test_clear_no_path_raises() -> None:
+    f = _make_field(on_read=None, on_write=None, path="soc.no_clear")
+    with pytest.raises(NotSupportedError) as exc:
+        clear(f)
+    assert "soc.no_clear" in str(exc.value)
+    assert "no clear path" in str(exc.value)
+
+
+def test_acknowledge_is_alias_for_clear() -> None:
+    f = _make_field(on_write="woclr")
+    acknowledge(f)
+    assert f.calls["write"] == [1]
+
+
+# ---------------------------------------------------------------------------
+# set_() dispatch
+# ---------------------------------------------------------------------------
+def test_set_woset_writes_one() -> None:
+    f = _make_field(on_write="woset")
+    set_(f)
+    assert f.calls["write"] == [1]
+
+
+def test_set_wset_writes_all_ones() -> None:
+    f = _make_field(on_write="wset", width=4)
+    set_(f)
+    assert f.calls["write"] == [0xF]
+
+
+def test_set_wzs_writes_zero() -> None:
+    f = _make_field(on_write="wzs")
+    set_(f)
+    assert f.calls["write"] == [0]
+
+
+def test_set_no_on_write_raises() -> None:
+    f = _make_field(on_write=None, path="soc.unset")
+    with pytest.raises(NotSupportedError) as exc:
+        set_(f)
+    assert "soc.unset" in str(exc.value)
+    assert "no set path" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# pulse()
+# ---------------------------------------------------------------------------
+def test_pulse_singlepulse_writes_one() -> None:
+    f = _make_field(singlepulse=True)
+    pulse(f)
+    assert f.calls["write"] == [1]
+
+
+def test_pulse_non_singlepulse_raises() -> None:
+    f = _make_field(path="soc.notpulse")
+    with pytest.raises(NotSupportedError) as exc:
+        pulse(f)
+    assert "soc.notpulse" in str(exc.value)
+    assert "singlepulse" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# peek()
+# ---------------------------------------------------------------------------
+def test_peek_master_without_peek_raises() -> None:
+    """``rclr`` field on a master that cannot peek -> ``NotSupportedError``."""
+    f = _make_field(on_read="rclr", master=_Master(can_peek=False))
+    with pytest.raises(NotSupportedError) as exc:
+        peek(f)
+    assert "cannot peek" in str(exc.value)
+
+
+def test_peek_master_with_peek_returns_value() -> None:
+    """When the master can peek, ``peek`` slices the field bits out."""
+    master = _Master(can_peek=True, peek_value=0b101_0)
+    f = _make_field(on_read="rclr", width=4, lsb=0, master=master)
+    # Field is bits [3:0] of register; peek_value = 0b1010 -> 10.
+    assert peek(f) == 10
+    assert master.peeks == [(0x1000, 4)]
+
+
+def test_peek_no_side_effect_field_uses_read() -> None:
+    """When there's no read-side effect, ``peek`` falls back to the field's
+    own ``read()``. No master needed."""
+    f = _make_field(on_read=None)
+    # The mock read() returns 0; pulse() unrelated. Just exercise the path.
+    assert peek(f) == 0
+
+
+# ---------------------------------------------------------------------------
+# no_side_effects() context manager
+# ---------------------------------------------------------------------------
+def test_no_side_effects_blocks_rclr_read() -> None:
+    """Inside the guard, ``check_read_allowed`` on an rclr field raises."""
+    f = _make_field(on_read="rclr", path="soc.intr_status.tx_done")
+    with no_side_effects(soc=None):
+        with pytest.raises(SideEffectError) as exc:
+            check_read_allowed(f)
+    assert "soc.intr_status.tx_done" in str(exc.value)
+    assert "rclr" in str(exc.value)
+
+
+def test_no_side_effects_does_not_block_clean_read() -> None:
+    """Fields without a read-side effect are unaffected by the guard."""
+    f = _make_field(on_read=None)
+    with no_side_effects():
+        check_read_allowed(f)  # must not raise
+
+
+def test_no_side_effects_unwinds_on_exit() -> None:
+    """The flag is restored even when the block raises."""
+    f = _make_field(on_read="rclr")
+    try:
+        with no_side_effects():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    # Outside the block: no guard, no exception.
+    check_read_allowed(f)
+
+
+def test_no_side_effects_nested_restores_outer_state() -> None:
+    """Nested guards restore the prior flag value, not just ``False``."""
+    f = _make_field(on_read="rclr")
+    with no_side_effects():
+        with no_side_effects():
+            with pytest.raises(SideEffectError):
+                check_read_allowed(f)
+        # Inner block exited: outer guard still active.
+        with pytest.raises(SideEffectError):
+            check_read_allowed(f)
+    # Outermost block exited: guard is off.
+    check_read_allowed(f)
+
+
+# ---------------------------------------------------------------------------
+# Enhancement seam: ``cls.clear()`` etc. become methods on registers/fields.
+# ---------------------------------------------------------------------------
+def test_enhancement_binds_methods_on_class() -> None:
+    """The decorator-style enhancement attaches the verbs to a class."""
+    from peakrdl_pybind11.runtime.side_effects import _enhance
+
+    class FakeReg:
+        def __init__(self, info: Any) -> None:
+            self.info = info
+            self.writes: list[int] = []
+
+        def write(self, value: int) -> None:
+            self.writes.append(value)
+
+        def read(self) -> int:
+            return 0
+
+    _enhance(FakeReg, metadata=None)
+    info = SimpleNamespace(
+        on_read=None, on_write="woclr", width=1, lsb=0, path="reg",
+        address=0, singlepulse=False,
+    )
+    reg = FakeReg(info)
+    reg.clear()
+    assert reg.writes == [1]
+
+    # ``set`` is bound as a method (not the builtin) -- exercise it via woset.
+    info.on_write = "woset"
+    reg.set()
+    assert reg.writes == [1, 1]
+
+    # ``pulse`` requires singlepulse metadata.
+    info.singlepulse = True
+    info.on_write = None
+    reg.pulse()
+    assert reg.writes == [1, 1, 1]

--- a/tests/runtime/test_side_effects.py
+++ b/tests/runtime/test_side_effects.py
@@ -83,11 +83,11 @@ def test_clear_woclr_writes_one() -> None:
     assert f.calls["write"] == [1]
 
 
-def test_clear_wclr_writes_all_ones() -> None:
-    """``wclr`` accepts any write; we send all-ones for determinism."""
+def test_clear_wclr_writes_zero() -> None:
+    """``wclr`` -> write 0 to all bits (sketch §11)."""
     f = _make_field(on_write="wclr", width=8)
     clear(f)
-    assert f.calls["write"] == [0xFF]
+    assert f.calls["write"] == [0]
 
 
 def test_clear_wzc_writes_zero() -> None:
@@ -203,6 +203,30 @@ def test_no_side_effects_blocks_rclr_read() -> None:
             check_read_allowed(f)
     assert "soc.intr_status.tx_done" in str(exc.value)
     assert "rclr" in str(exc.value)
+
+
+def test_no_side_effects_blocks_field_read_via_seam() -> None:
+    """A field whose ``read()`` calls ``check_read_allowed`` raises in-guard.
+
+    This mirrors how generated read paths are expected to wire up: each
+    bus-touching read consults the guard before issuing the transaction.
+    """
+    info = SimpleNamespace(
+        on_read="rclr", on_write=None, width=1, lsb=0,
+        path="soc.uart.intr.por", address=0x18, singlepulse=False,
+    )
+
+    field: SimpleNamespace
+
+    def read() -> int:
+        check_read_allowed(field)
+        return 0
+
+    field = SimpleNamespace(info=info, read=read, write=lambda _v: None, master=None)
+
+    with no_side_effects():
+        with pytest.raises(SideEffectError):
+            field.read()
 
 
 def test_no_side_effects_does_not_block_clean_read() -> None:


### PR DESCRIPTION
## Summary
- Add ``peakrdl_pybind11.runtime.side_effects`` per sketch §11 -- pure-Python verbs (``peek``, ``clear``, ``acknowledge``, ``set_``, ``pulse``) that dispatch on ``info.on_read`` / ``info.on_write`` metadata, plus the ``no_side_effects`` thread-local context manager that turns destructive reads into ``SideEffectError``.
- Sibling-dep imports (Unit 2 ``errors``, Unit 1 ``_registry``) fall back to local shims so the module compiles standalone; the enhancement seam (``register_register_enhancement``) binds verbs as methods on generated reg/field classes once Unit 1 lands.
- 20 pure-Python tests in ``tests/runtime/test_side_effects.py`` exercise every dispatch branch with duck-typed ``SimpleNamespace`` mocks -- no codegen / cmake required.

## Test plan
- [x] ``uv sync --group test``
- [x] ``pytest tests/runtime/test_side_effects.py -v`` -- 20 passed
- [x] ``ruff check src/peakrdl_pybind11/runtime/`` -- clean
- [x] ``ruff format src/peakrdl_pybind11/runtime/`` -- applied
- [x] No regressions in the rest of the pure-Python suite (``pytest tests/test_exporter.py tests/test_int_types.py tests/test_memory.py tests/test_repr.py tests/test_hypothesis.py``)

## Notes
- ``set`` is exposed module-level as ``set_`` (avoids shadowing the builtin); the enhancement decorator binds it as ``cls.set`` -- a method, no shadow.
- ``no_side_effects(soc=None)``: the ``soc`` arg is currently unused but reserved for future widening (e.g. observation hooks) -- preserved per the API sketch.
- ``_master_can_peek`` checks ``master.can_peek`` first (explicit capability flag wins) and falls back to ``callable(master.peek)``.
- ``clear()`` consults ``on_read`` only when no ``on_write`` clear path is declared (rclr-only fields where the destructive read *is* the clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)