### PR TITLE
feat(masters): MockMasterEx with hooks (Unit 21)

### DIFF
--- a/src/peakrdl_pybind11/masters/__init__.py
+++ b/src/peakrdl_pybind11/masters/__init__.py
@@ -5,6 +5,7 @@ Master interfaces for register access
 from .base import AccessOp, MasterBase
 from .callback import CallbackMaster
 from .mock import MockMaster
+from .mock_extensions import MockMasterEx
 from .openocd import OpenOCDMaster
 from .ssh import SSHMaster
 
@@ -13,6 +14,7 @@ __all__ = [
     "CallbackMaster",
     "MasterBase",
     "MockMaster",
+    "MockMasterEx",
     "OpenOCDMaster",
     "SSHMaster",
 ]

--- a/src/peakrdl_pybind11/masters/mock_extensions.py
+++ b/src/peakrdl_pybind11/masters/mock_extensions.py
@@ -1,0 +1,222 @@
+"""Mock master with hooks and side-effect semantics (per IDEAL_API_SKETCH §13.7).
+
+:class:`MockMasterEx` extends :class:`MockMaster` with three primitives a
+test author actually needs:
+
+* ``on_read(reg_or_addr, fn)``  — install a callback that synthesizes the
+  value returned for a read at the given address.
+* ``on_write(reg_or_addr, fn)`` — install a callback that observes (and
+  optionally records) writes to the given address.
+* ``preload(mem_or_addr, ndarray)`` — bulk-seed a memory region with an
+  iterable / numpy array of word values.
+
+In addition, the class understands the two RDL side-effects most tests
+need to exercise:
+
+* ``info.on_read == "rclr"``   — after a successful read, the underlying
+  storage is cleared, so a second read returns 0.
+* ``info.on_write == "woclr"`` — bits set in the written value clear the
+  corresponding bits in the stored state (write-1-to-clear).
+
+These semantics are inferred automatically when ``on_read`` / ``on_write``
+is called with a register handle whose ``.info`` carries the metadata,
+and they can also be requested explicitly via :meth:`mark_rclr` /
+:meth:`mark_woclr` when the caller only has a raw integer address.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeAlias
+
+from .base import AccessOp
+from .mock import MockMaster
+
+ReadHook: TypeAlias = Callable[[int], int]
+WriteHook: TypeAlias = Callable[[int, int], None]
+# Anything we can extract an address from: a plain int, or a register/memory
+# handle that exposes ``info.address`` (or, legacy, ``.address``).
+AddressLike: TypeAlias = "int | object"
+
+
+def _resolve_address(reg_or_addr: AddressLike) -> int:
+    """Coerce a register handle or raw int into an absolute address.
+
+    Accepts (in order):
+      * a plain :class:`int` (returned as-is);
+      * an object with ``info.address`` (preferred — matches the modern
+        ``reg.info.address`` surface from §11);
+      * an object with ``address`` (covers older / generated handles that
+        expose the attribute directly).
+    """
+    if isinstance(reg_or_addr, int):
+        return reg_or_addr
+    info = getattr(reg_or_addr, "info", None)
+    if info is not None:
+        addr = getattr(info, "address", None)
+        if isinstance(addr, int):
+            return addr
+    addr = getattr(reg_or_addr, "address", None)
+    if isinstance(addr, int):
+        return addr
+    raise TypeError(
+        f"cannot derive an address from {reg_or_addr!r}; pass an int or "
+        f"a register handle exposing .info.address"
+    )
+
+
+def _info_value(info: object, name: str) -> str | None:
+    """Return the side-effect tag (``"rclr"``/``"woclr"``) on ``info`` or
+    ``None`` if absent.  Tolerant of both string-valued metadata (as in the
+    current sketch) and enum-valued metadata (the eventual long-term form
+    from §11.2 — ``ReadEffect.RCLR`` etc.).
+    """
+    if info is None:
+        return None
+    raw = getattr(info, name, None)
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw.lower()
+    # enum-like: take the trailing token of the repr/name and lowercase it.
+    token = getattr(raw, "name", None) or str(raw).rsplit(".", 1)[-1]
+    return token.lower()
+
+
+class MockMasterEx(MockMaster):
+    """A :class:`MockMaster` with read/write hooks and rclr/woclr semantics.
+
+    Existing :class:`MockMaster` semantics (``read`` / ``write`` from the
+    backing dict) are preserved as the fallback path — addresses without a
+    registered hook still hit the in-memory store.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._read_hooks: dict[int, ReadHook] = {}
+        self._write_hooks: dict[int, WriteHook] = {}
+        self._rclr: set[int] = set()
+        self._woclr: set[int] = set()
+
+    # -- hook registration -------------------------------------------------
+
+    def on_read(self, reg_or_addr: AddressLike, fn: ReadHook) -> None:
+        """Register a read callback.
+
+        ``fn(address) -> int`` is invoked whenever this address is read;
+        the returned value is masked to the access width and returned to
+        the caller.  If ``reg_or_addr`` is a register handle and its
+        ``info.on_read`` is ``"rclr"``, the address is auto-marked for
+        rclr so the underlying value clears after every read.
+        """
+        addr = _resolve_address(reg_or_addr)
+        self._read_hooks[addr] = fn
+        if _info_value(getattr(reg_or_addr, "info", None), "on_read") == "rclr":
+            self._rclr.add(addr)
+
+    def on_write(self, reg_or_addr: AddressLike, fn: WriteHook) -> None:
+        """Register a write callback.
+
+        ``fn(address, value) -> None`` is invoked for every write at this
+        address.  The write also propagates to the in-memory store (so a
+        subsequent read returns the latest value) unless the address is
+        marked woclr, in which case write-1-to-clear semantics apply.
+        """
+        addr = _resolve_address(reg_or_addr)
+        self._write_hooks[addr] = fn
+        if _info_value(getattr(reg_or_addr, "info", None), "on_write") == "woclr":
+            self._woclr.add(addr)
+
+    def mark_rclr(self, reg_or_addr: AddressLike) -> None:
+        """Mark an address (or register) as read-clear-on-read."""
+        self._rclr.add(_resolve_address(reg_or_addr))
+
+    def mark_woclr(self, reg_or_addr: AddressLike) -> None:
+        """Mark an address (or register) as write-1-to-clear."""
+        self._woclr.add(_resolve_address(reg_or_addr))
+
+    # -- bulk preload ------------------------------------------------------
+
+    def preload(
+        self,
+        mem_or_addr: AddressLike,
+        values: Iterable[int],
+        *,
+        word_size: int = 4,
+    ) -> None:
+        """Seed a memory region with an iterable / ndarray of word values.
+
+        ``mem_or_addr`` may be a memory handle (``info.address`` is used
+        as the base) or a raw int base address.  Each element of ``values``
+        is stored at ``base + i * word_size``.  The default ``word_size``
+        of 4 matches the typical 32-bit memory layout in generated code;
+        override for byte- or 64-bit-addressed memories.
+        """
+        base = _resolve_address(mem_or_addr)
+        # Prefer .tolist() when available (ndarray) — avoids per-element
+        # numpy scalar overhead in the dict store.
+        tolist = getattr(values, "tolist", None)
+        seq: Sequence[int] = tolist() if callable(tolist) else list(values)
+        mask = (1 << (word_size * 8)) - 1
+        for i, value in enumerate(seq):
+            self.memory[base + i * word_size] = int(value) & mask
+
+    # -- core read/write paths --------------------------------------------
+
+    def read(self, address: int, width: int) -> int:
+        """Read at ``address``, dispatching to the hook if registered.
+
+        After a successful read, if the address is marked rclr, the
+        backing storage is cleared so the next non-hook read sees zero.
+        """
+        mask = (1 << (width * 8)) - 1
+        hook = self._read_hooks.get(address)
+        if hook is not None:
+            value = int(hook(address)) & mask
+        else:
+            value = self.memory.get(address, 0) & mask
+        if address in self._rclr:
+            # rclr: clear storage AND drop the hook — otherwise the hook
+            # would resurrect the value and the latch-clear would be
+            # invisible to subsequent reads.
+            self.memory[address] = 0
+            self._read_hooks.pop(address, None)
+        return value
+
+    def write(self, address: int, value: int, width: int) -> None:
+        """Write ``value`` at ``address``, applying woclr if marked.
+
+        Hooks observe the caller's requested value (not the post-woclr
+        storage), so test capture lists reflect intent rather than
+        derived state.
+        """
+        mask = (1 << (width * 8)) - 1
+        masked = value & mask
+        hook = self._write_hooks.get(address)
+        if hook is not None:
+            hook(address, masked)
+        if address in self._woclr:
+            current = self.memory.get(address, 0) & mask
+            self.memory[address] = current & ~masked & mask
+        else:
+            self.memory[address] = masked
+
+    # -- batched paths -----------------------------------------------------
+    # Override MockMaster's dict-direct fast paths so hooks and rclr/woclr
+    # still apply when callers route through transactions / memory blocks.
+
+    def read_many(self, ops: Sequence[AccessOp]) -> list[int]:
+        return [self.read(op.address, op.width) for op in ops]
+
+    def write_many(self, ops: Sequence[AccessOp]) -> None:
+        for op in ops:
+            self.write(op.address, op.value, op.width)
+
+    # -- housekeeping ------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear stored values. Hook registrations and rclr/woclr marks
+        are intentionally preserved so a fixture can be reused across
+        test phases without re-arming every hook.
+        """
+        super().reset()

--- a/tests/runtime/test_mock_extensions.py
+++ b/tests/runtime/test_mock_extensions.py
@@ -1,0 +1,304 @@
+"""Tests for :class:`MockMasterEx` (Unit 21 of the API overhaul).
+
+These tests exercise the pure-Python hook surface — they never touch the
+generated C++ extension, so they run on every platform without requiring
+a build.  Numpy is optional (used only by ``preload``); if it's missing
+those tests are skipped instead of erroring out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from peakrdl_pybind11.masters import MockMasterEx
+
+# ---- minimal stand-ins for the (still-WIP) reg/info handles -------------
+
+
+@dataclass
+class _Info:
+    """The bits of ``reg.info`` we exercise here.
+
+    Mirrors the surface from §11.2 of the API sketch — ``address`` plus
+    the side-effect tags — without dragging in the full elaborated
+    register handle, which would require a generated module.
+    """
+
+    address: int
+    on_read: str | None = None
+    on_write: str | None = None
+
+
+@dataclass
+class _Reg:
+    """A test-double register handle exposing ``.info`` like the real one."""
+
+    info: _Info
+
+
+# ---- on_read ------------------------------------------------------------
+
+
+class TestOnRead:
+    def test_raw_address_hook_returns_synthetic_value(self) -> None:
+        mock = MockMasterEx()
+        mock.on_read(0x1000, lambda a: 0x42)
+        assert mock.read(0x1000, 4) == 0x42
+
+    def test_hook_receives_address(self) -> None:
+        mock = MockMasterEx()
+        captured: list[int] = []
+
+        def hook(addr: int) -> int:
+            captured.append(addr)
+            return addr & 0xFF
+
+        mock.on_read(0x2000, hook)
+        assert mock.read(0x2000, 4) == 0x00
+        assert captured == [0x2000]
+
+    def test_hook_value_is_masked_to_width(self) -> None:
+        mock = MockMasterEx()
+        mock.on_read(0x3000, lambda a: 0x1_FFFF_FFFF)  # 33 bits
+        assert mock.read(0x3000, 4) == 0xFFFF_FFFF
+        assert mock.read(0x3000, 2) == 0xFFFF  # masked again on narrower read
+
+    def test_addresses_without_hooks_fall_back_to_storage(self) -> None:
+        mock = MockMasterEx()
+        mock.write(0x4000, 0xDEAD_BEEF, 4)
+        mock.on_read(0x5000, lambda a: 0x42)
+        assert mock.read(0x4000, 4) == 0xDEAD_BEEF
+        assert mock.read(0x5000, 4) == 0x42
+
+    def test_register_handle_resolves_address(self) -> None:
+        mock = MockMasterEx()
+        reg = _Reg(info=_Info(address=0x6000))
+        mock.on_read(reg, lambda a: 0xCAFE)
+        assert mock.read(0x6000, 4) == 0xCAFE
+
+
+# ---- on_write -----------------------------------------------------------
+
+
+class TestOnWrite:
+    def test_writes_are_captured(self) -> None:
+        mock = MockMasterEx()
+        capture: list[int] = []
+        mock.on_write(0x1004, lambda a, v: capture.append(v))
+        mock.write(0x1004, 0x11, 4)
+        mock.write(0x1004, 0x22, 4)
+        mock.write(0x1004, 0x33, 4)
+        assert capture == [0x11, 0x22, 0x33]
+
+    def test_hook_receives_address_and_value(self) -> None:
+        mock = MockMasterEx()
+        capture: list[tuple[int, int]] = []
+        mock.on_write(0x2004, lambda a, v: capture.append((a, v)))
+        mock.write(0x2004, 0xABCD, 4)
+        assert capture == [(0x2004, 0xABCD)]
+
+    def test_storage_still_updated_so_subsequent_read_observes_value(self) -> None:
+        mock = MockMasterEx()
+        mock.on_write(0x3004, lambda a, v: None)
+        mock.write(0x3004, 0xBEEF, 4)
+        assert mock.read(0x3004, 4) == 0xBEEF
+
+    def test_register_handle_resolves_address(self) -> None:
+        mock = MockMasterEx()
+        capture: list[int] = []
+        reg = _Reg(info=_Info(address=0x4004))
+        mock.on_write(reg, lambda a, v: capture.append(v))
+        mock.write(0x4004, 0x55, 4)
+        assert capture == [0x55]
+
+
+# ---- preload ------------------------------------------------------------
+
+
+class TestPreload:
+    def test_preload_with_plain_iterable(self) -> None:
+        mock = MockMasterEx()
+        mock.preload(0x4000, range(16))
+        for i in range(16):
+            assert mock.read(0x4000 + i * 4, 4) == i
+
+    def test_preload_with_register_handle_uses_info_address(self) -> None:
+        mock = MockMasterEx()
+        mem = _Reg(info=_Info(address=0x8000))
+        mock.preload(mem, [0x10, 0x20, 0x30])
+        assert mock.read(0x8000, 4) == 0x10
+        assert mock.read(0x8004, 4) == 0x20
+        assert mock.read(0x8008, 4) == 0x30
+
+    def test_preload_with_numpy_array(self) -> None:
+        np = pytest.importorskip("numpy")
+        mock = MockMasterEx()
+        mock.preload(0x4000, np.arange(16, dtype=np.uint32))
+        for i in range(16):
+            assert mock.read(0x4000 + i * 4, 4) == i
+
+    def test_preload_custom_word_size(self) -> None:
+        mock = MockMasterEx()
+        mock.preload(0x9000, [0x10, 0x20, 0x30], word_size=8)
+        assert mock.read(0x9000, 8) == 0x10
+        assert mock.read(0x9008, 8) == 0x20
+        assert mock.read(0x9010, 8) == 0x30
+
+
+# ---- rclr semantics -----------------------------------------------------
+
+
+class TestRclrSemantics:
+    def test_rclr_via_register_info(self) -> None:
+        """First read returns the value, second read returns 0."""
+        mock = MockMasterEx()
+        reg = _Reg(info=_Info(address=0x100, on_read="rclr"))
+        mock.on_read(reg, lambda a: 0xA5)
+        assert mock.read(0x100, 4) == 0xA5
+        assert mock.read(0x100, 4) == 0x00
+
+    def test_rclr_via_explicit_mark(self) -> None:
+        """Same semantics with raw addresses + ``mark_rclr``."""
+        mock = MockMasterEx()
+        mock.on_read(0x200, lambda a: 0xFF)
+        mock.mark_rclr(0x200)
+        assert mock.read(0x200, 4) == 0xFF
+        assert mock.read(0x200, 4) == 0x00
+
+    def test_rclr_without_hook_clears_storage(self) -> None:
+        """rclr also applies when the value lives in the in-memory store."""
+        mock = MockMasterEx()
+        mock.write(0x300, 0xDEAD, 4)
+        mock.mark_rclr(0x300)
+        assert mock.read(0x300, 4) == 0xDEAD
+        assert mock.read(0x300, 4) == 0x00
+
+    def test_non_rclr_register_does_not_clear(self) -> None:
+        mock = MockMasterEx()
+        reg = _Reg(info=_Info(address=0x400, on_read=None))
+        mock.on_read(reg, lambda a: 0x77)
+        assert mock.read(0x400, 4) == 0x77
+        assert mock.read(0x400, 4) == 0x77  # value persists
+
+
+# ---- woclr semantics ----------------------------------------------------
+
+
+class TestWoclrSemantics:
+    def test_woclr_via_register_info(self) -> None:
+        """Writing 1 to a bit clears it; writing 0 leaves it untouched."""
+        mock = MockMasterEx()
+        reg = _Reg(info=_Info(address=0x500, on_write="woclr"))
+        # Pre-load the latched state via direct memory poke (simulating
+        # a hardware-set status bit in production).
+        mock.memory[0x500] = 0b1111
+        mock.on_write(reg, lambda a, v: None)
+        # Clear the low two bits.
+        mock.write(0x500, 0b0011, 4)
+        assert mock.read(0x500, 4) == 0b1100
+
+    def test_woclr_via_explicit_mark(self) -> None:
+        mock = MockMasterEx()
+        mock.memory[0x600] = 0xFF
+        mock.mark_woclr(0x600)
+        mock.write(0x600, 0x0F, 4)  # clears low nibble
+        assert mock.read(0x600, 4) == 0xF0
+
+    def test_woclr_does_not_set_zero_bits(self) -> None:
+        """A 0 bit in the write must leave the storage bit untouched —
+        otherwise it'd be plain overwrite, not write-1-to-clear."""
+        mock = MockMasterEx()
+        mock.memory[0x700] = 0xAA
+        mock.mark_woclr(0x700)
+        mock.write(0x700, 0x00, 4)  # no bits set => no clears
+        assert mock.read(0x700, 4) == 0xAA
+
+    def test_woclr_hook_sees_raw_written_value(self) -> None:
+        """Hooks observe the caller's intent, not the post-woclr storage."""
+        mock = MockMasterEx()
+        capture: list[int] = []
+        reg = _Reg(info=_Info(address=0x800, on_write="woclr"))
+        mock.memory[0x800] = 0xFF
+        mock.on_write(reg, lambda a, v: capture.append(v))
+        mock.write(0x800, 0x0F, 4)
+        assert capture == [0x0F]
+        assert mock.read(0x800, 4) == 0xF0
+
+    def test_non_woclr_register_overwrites(self) -> None:
+        mock = MockMasterEx()
+        mock.memory[0x900] = 0xFF
+        mock.write(0x900, 0x0F, 4)  # plain overwrite
+        assert mock.read(0x900, 4) == 0x0F
+
+
+# ---- batched paths honor hooks ------------------------------------------
+
+
+class TestBatchedPaths:
+    def test_read_many_dispatches_through_hooks(self) -> None:
+        from peakrdl_pybind11.masters import AccessOp
+
+        mock = MockMasterEx()
+        mock.on_read(0x1000, lambda a: 0x11)
+        mock.on_read(0x1004, lambda a: 0x22)
+        mock.write(0x1008, 0x33, 4)
+        ops = [
+            AccessOp(address=0x1000, width=4),
+            AccessOp(address=0x1004, width=4),
+            AccessOp(address=0x1008, width=4),
+        ]
+        assert mock.read_many(ops) == [0x11, 0x22, 0x33]
+
+    def test_write_many_invokes_hooks_and_woclr(self) -> None:
+        from peakrdl_pybind11.masters import AccessOp
+
+        mock = MockMasterEx()
+        capture: list[tuple[int, int]] = []
+        mock.on_write(0x2000, lambda a, v: capture.append((a, v)))
+        mock.memory[0x2004] = 0xFF
+        mock.mark_woclr(0x2004)
+        ops = [
+            AccessOp(address=0x2000, value=0xABCD, width=4),
+            AccessOp(address=0x2004, value=0x0F, width=4),
+        ]
+        mock.write_many(ops)
+        assert capture == [(0x2000, 0xABCD)]
+        assert mock.read(0x2004, 4) == 0xF0
+
+
+# ---- subclass compatibility ---------------------------------------------
+
+
+def test_is_a_mockmaster() -> None:
+    """``MockMasterEx`` must be drop-in-compatible with code that takes a
+    ``MockMaster`` (so test fixtures can swap in extensions transparently)."""
+    from peakrdl_pybind11.masters import MockMaster
+
+    mock = MockMasterEx()
+    assert isinstance(mock, MockMaster)
+
+
+def test_reset_preserves_hooks() -> None:
+    """A ``reset()`` should clear values but keep the hook config — this
+    is the common pattern for re-running a parameterised test."""
+    mock = MockMasterEx()
+    mock.on_read(0x100, lambda a: 0x42)
+    mock.write(0x100, 0xFF, 4)
+    mock.reset()
+    # Storage cleared, but the hook still wins on read.
+    assert mock.read(0x100, 4) == 0x42
+
+
+def test_resolve_address_rejects_unknown_handle() -> None:
+    """Bare objects without ``info.address`` or ``address`` should fail
+    loudly — silent zero-coercion would produce extremely confusing test
+    failures down the line."""
+    mock = MockMasterEx()
+
+    class _Bogus:
+        pass
+
+    with pytest.raises(TypeError):
+        mock.on_read(_Bogus(), lambda a: 0)

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-pybind11"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
- Adds `MockMasterEx`, a pure-Python subclass of `MockMaster` with `on_read(reg_or_addr, fn)`, `on_write(reg_or_addr, fn)`, and `preload(mem_or_addr, ndarray)` hooks (per `IDEAL_API_SKETCH.md` §13.7).
- Honors `info.on_read == "rclr"` (read clears the latched value) and `info.on_write == "woclr"` (write-1-to-clear) when the caller passes a register handle — also exposes `mark_rclr` / `mark_woclr` for raw addresses.
- Preserves the existing `MockMaster` dict-backed fallback for addresses without a registered hook, and routes batched `read_many` / `write_many` through the per-op path so hooks and side-effects still fire.

## Test plan
- [x] `uv sync --group test`
- [x] `pytest tests/runtime/test_mock_extensions.py -v` — 26 passed, 1 skipped (numpy-only test, gracefully skipped since numpy is not in deps)
- [x] `ruff check src/peakrdl_pybind11/masters/mock_extensions.py` — clean
- [x] Full unit-test suite runs green; no existing test perturbed.

Branches off `exp/api_overhaul`. Sibling deps on Unit 4 (`info.on_read`/`info.on_write`) are duck-typed — works with both string-valued metadata (today) and enum-valued metadata (eventual long-term form).

Generated with [Claude Code](https://claude.com/claude-code)