### PR TITLE
feat(runtime): alias node helpers (Unit 13)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,4 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+"""

--- a/src/peakrdl_pybind11/runtime/aliases.py
+++ b/src/peakrdl_pybind11/runtime/aliases.py
@@ -1,0 +1,250 @@
+"""Alias node helpers for the PeakRDL-pybind11 runtime.
+
+Implements the surface described in ``docs/IDEAL_API_SKETCH.md`` §10 and the
+companion concept page ``docs/concepts/aliases.rst``.
+
+SystemRDL ``alias`` lets multiple register definitions point at the same
+address. The Python view treats one as **canonical** and the rest as
+**views**; reads and writes through any view land at the same underlying
+address, but the field set and access policy may differ.
+
+This module wires the relationship at module-load time onto the generated
+register classes:
+
+- ``alt.target``  — the canonical register class at the same address.
+- ``alt.is_alias`` — ``True`` for alias views, ``False`` on the canonical.
+- ``primary.aliases`` — tuple of all aliases pointing at this primary.
+- ``alt.info.alias_kind`` (defined in Unit 4's :mod:`info` module) is
+  consumed by the repr override below; this module never re-defines it.
+
+Detection (which class is an alias of what) is the exporter's job
+(Unit 23). The runtime only consumes the metadata flag ``is_alias=True``
+plus a pointer to the target primary class, and wires both sides.
+
+The seam used to wire the relationship is :func:`register_register_enhancement`,
+which mirrors Unit 1's eventual ``runtime/_registry.py``. Until Unit 1 lands,
+a minimal local stub lives here so this module can be imported and tested in
+isolation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = [
+    "apply_alias_relationship",
+    "make_alias_repr",
+    "register_register_enhancement",
+    "registered_enhancements",
+    "reset_enhancements",
+]
+
+
+# ---------------------------------------------------------------------------
+# Local stub for Unit 1's enhancement registry.
+#
+# TODO(Unit 1): Replace this with an import from
+# ``peakrdl_pybind11.runtime._registry`` once that module lands. The signature
+# of :func:`register_register_enhancement` is intentionally kept narrow (a
+# single-argument callable) so it can re-export the upstream registry verbatim.
+# ---------------------------------------------------------------------------
+
+EnhancementCallable = Callable[[type], None]
+
+_REGISTERED_ENHANCEMENTS: list[EnhancementCallable] = []
+
+
+def register_register_enhancement(enhancement: EnhancementCallable) -> EnhancementCallable:
+    """Register a class-level enhancement callable.
+
+    The callable is stored for later invocation against generated register
+    classes by the per-SoC runtime template. Returns the callable so the
+    function can be used as a decorator.
+
+    This is a local placeholder. Unit 1 will own the canonical registry; the
+    contract here is intentionally narrow so the upstream version can be a
+    drop-in replacement.
+    """
+
+    _REGISTERED_ENHANCEMENTS.append(enhancement)
+    return enhancement
+
+
+def registered_enhancements() -> tuple[EnhancementCallable, ...]:
+    """Return the currently-registered enhancement callables (for tests)."""
+
+    return tuple(_REGISTERED_ENHANCEMENTS)
+
+
+def reset_enhancements() -> None:
+    """Clear the registered enhancements (test-only helper)."""
+
+    _REGISTERED_ENHANCEMENTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def make_alias_repr(alt_cls: type, primary_cls: type) -> Callable[[object], str]:
+    """Build a ``__repr__`` override that names the alias relationship.
+
+    The output matches the form documented in the sketch §10, e.g.::
+
+        <Reg uart.control_alt @ 0x40001000  alias-of=uart.control  rw>
+
+    The primary's path is captured at wiring time so the alias still renders
+    sensibly even if its ``info`` is later mutated.
+    """
+
+    primary_path = _node_path(primary_cls)
+
+    def __repr__(self: object) -> str:
+        info = getattr(self, "info", None)
+        kind = getattr(self, "_kind_label", "Reg")
+        path = _info_lookup(info, "path", default=type(self).__name__)
+        address = _info_lookup(info, "address", default=None)
+        access = _info_lookup(info, "access", default="rw")
+
+        addr_part = ""
+        if isinstance(address, int):
+            addr_part = f" @ 0x{address:08x}"
+        elif address is not None:
+            addr_part = f" @ {address}"
+
+        access_label = _access_label(access)
+        return f"<{kind} {path}{addr_part}  alias-of={primary_path}  {access_label}>"
+
+    return __repr__
+
+
+def apply_alias_relationship(
+    alt_cls: type,
+    primary_cls: type,
+    *,
+    kind: str | None = None,
+) -> None:
+    """Wire ``alt_cls`` as an alias of ``primary_cls``.
+
+    Side effects on the classes (idempotent — safe to call twice):
+
+    - ``alt_cls.target`` is set to ``primary_cls``.
+    - ``alt_cls.is_alias`` is set to ``True``.
+    - ``alt_cls.aliases`` is set to ``()`` (an alias has no further aliases).
+    - ``primary_cls.aliases`` is updated to include ``alt_cls`` (de-duplicated).
+    - ``primary_cls.is_alias`` is set to ``False`` if not already set.
+    - ``primary_cls.target`` is set to ``primary_cls`` (canonical points at self).
+    - ``alt_cls.__repr__`` is replaced with one that names the relationship.
+    - When ``kind`` is given and the alt's ``info`` has no ``alias_kind``
+      already, the kind is attached as ``info.alias_kind`` for backwards
+      compatibility with metadata pipelines that don't pre-populate it.
+
+    Parameters
+    ----------
+    alt_cls:
+        The generated register class detected as an alias.
+    primary_cls:
+        The canonical register class at the same address.
+    kind:
+        Optional alias kind hint. Per the sketch §10 vocabulary:
+        ``{"full", "sw_view", "hw_view", "scrambled"}``. Unit 4's ``Info``
+        already exposes :attr:`alias_kind`; this module never redefines that
+        enum and only uses ``kind`` to backfill missing metadata.
+    """
+
+    if alt_cls is primary_cls:
+        raise ValueError(
+            f"apply_alias_relationship: alt_cls and primary_cls must differ (got {alt_cls!r} for both)"
+        )
+
+    # Alias side. Aliases don't chain — an alias's own ``.aliases`` is empty.
+    alt_cls.target = primary_cls
+    alt_cls.is_alias = True
+    alt_cls.aliases = ()
+    if kind is not None:
+        _ensure_info_alias_kind(alt_cls, kind)
+    alt_cls.__repr__ = make_alias_repr(alt_cls, primary_cls)
+
+    # Primary side. Canonical points at itself so ``.target`` is always valid.
+    if getattr(primary_cls, "target", None) is None:
+        primary_cls.target = primary_cls
+    if not hasattr(primary_cls, "is_alias"):
+        primary_cls.is_alias = False
+    existing = tuple(getattr(primary_cls, "aliases", ()) or ())
+    if alt_cls not in existing:
+        primary_cls.aliases = (*existing, alt_cls)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _node_path(cls: type) -> str:
+    """Return a path-like label for ``cls``.
+
+    Prefers ``info.path`` (set by Unit 4); falls back to the class name. Reads
+    from the class object directly so the helper can be used at wiring time
+    before any instance exists.
+    """
+
+    info = getattr(cls, "info", None)
+    path = _info_lookup(info, "path", default=None)
+    if isinstance(path, str) and path:
+        return path
+    return cls.__name__
+
+
+def _info_lookup(info: object, name: str, *, default: object) -> object:
+    """Read an attribute from an ``info`` namespace, dict, or ``None``."""
+
+    if info is None:
+        return default
+    if isinstance(info, dict):
+        return info.get(name, default)
+    return getattr(info, name, default)
+
+
+def _access_label(access: object) -> str:
+    """Render an access mode into the short repr token (``rw``, ``ro``, ...)."""
+
+    if access is None:
+        return "rw"
+    # Unit 4's ``AccessMode`` enum members carry a ``.value`` already in the
+    # canonical short form ("rw", "ro", "wo", "na"). Fall back to ``str()``
+    # so duck-typed test fixtures work without depending on the enum.
+    value = getattr(access, "value", None)
+    if isinstance(value, str) and value:
+        return value
+    text = str(access).lower()
+    # Strip ``AccessMode.RW``-style prefixes that ``str(enum_member)`` may
+    # produce when the enum is not str-valued.
+    if "." in text:
+        text = text.rsplit(".", maxsplit=1)[-1]
+    return text or "rw"
+
+
+def _ensure_info_alias_kind(alt_cls: type, kind: str) -> None:
+    """Best-effort: stamp ``info.alias_kind`` if Unit 4's slot is empty.
+
+    Unit 4 owns the ``Info.alias_kind`` field. We only fill it when the
+    exporter (Unit 23) hasn't already, so this helper is a safe no-op
+    in production where metadata is fully populated upstream.
+    """
+
+    info = getattr(alt_cls, "info", None)
+    if info is None:
+        return
+    existing = _info_lookup(info, "alias_kind", default=None)
+    if existing is not None:
+        return
+    if isinstance(info, dict):
+        info["alias_kind"] = kind
+    else:
+        try:
+            info.alias_kind = kind
+        except (AttributeError, TypeError):
+            # Frozen dataclass or read-only namespace — the exporter is
+            # responsible for populating ``alias_kind`` upstream.
+            pass

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``peakrdl_pybind11.runtime``."""

--- a/tests/runtime/test_aliases.py
+++ b/tests/runtime/test_aliases.py
@@ -1,0 +1,407 @@
+"""Tests for ``peakrdl_pybind11.runtime.aliases`` (sketch §10).
+
+These tests stand in for Unit 23's exporter-side detection: each test
+synthesises a tiny pair of register *classes* (one canonical, one alias)
+with just enough metadata for the runtime helpers to consume, then drives
+:func:`peakrdl_pybind11.runtime.aliases.apply_alias_relationship` to wire
+the relationship.
+
+Reads and writes go through a shared :class:`_FakeMaster` so the assertion
+"both sides hit the same address" can be checked at the bus boundary.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime.aliases import (
+    apply_alias_relationship,
+    register_register_enhancement,
+    registered_enhancements,
+    reset_enhancements,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeMaster:
+    """Minimal master capturing every read/write for cross-checks.
+
+    Stores last value per address; reads return whatever was last written
+    (default 0). Records every operation so tests can assert "both sides
+    hit the same address" at the bus boundary.
+    """
+
+    def __init__(self) -> None:
+        self.reads: list[int] = []
+        self.writes: list[tuple[int, int]] = []
+        self.memory: dict[int, int] = {}
+
+    def read(self, addr: int, _width: int = 32) -> int:
+        self.reads.append(addr)
+        return self.memory.get(addr, 0)
+
+    def write(self, addr: int, val: int, _width: int = 32) -> None:
+        self.writes.append((addr, val))
+        self.memory[addr] = val
+
+
+def _make_register_class(
+    *,
+    name: str,
+    path: str,
+    address: int,
+    access: str = "rw",
+) -> type:
+    """Spin up a fresh register class for one test.
+
+    Each call returns a *new* class so that tests don't bleed state through
+    class-level monkey patches.
+    """
+
+    info = SimpleNamespace(
+        name=name,
+        path=path,
+        address=address,
+        access=access,
+        alias_kind=None,
+    )
+
+    class Register:
+        # Class-level metadata, the way generated code exposes it.
+        info = None  # populated below
+        _kind_label = "Reg"
+
+        def __init__(self, master: _FakeMaster) -> None:
+            self._master = master
+            self._address = address
+
+        def read(self) -> int:
+            return self._master.read(self._address)
+
+        def write(self, value: int) -> None:
+            self._master.write(self._address, value)
+
+    Register.__name__ = name
+    Register.__qualname__ = name
+    Register.info = info
+    return Register
+
+
+# ---------------------------------------------------------------------------
+# Wiring: alias relationship attaches both sides
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipWiring:
+    def test_alt_points_at_primary(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        apply_alias_relationship(alt, primary, kind="full")
+
+        assert alt.target is primary
+        assert alt.is_alias is True
+
+    def test_primary_lists_alias_in_aliases_tuple(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        apply_alias_relationship(alt, primary, kind="full")
+
+        # Sketch §10 example: ``soc.uart.control.aliases  # (soc.uart.control_alt,)``
+        assert primary.aliases == (alt,)
+        assert isinstance(primary.aliases, tuple)
+        # Canonical reports False per docs/concepts/aliases.rst.
+        assert primary.is_alias is False
+        # Canonical's target is itself so callers can use ``.target`` uniformly.
+        assert primary.target is primary
+
+    def test_alias_has_empty_aliases_tuple(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        apply_alias_relationship(alt, primary, kind="full")
+
+        # Aliases don't chain — an alias has no aliases of its own.
+        assert alt.aliases == ()
+
+    def test_multiple_aliases_accumulate_in_order(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        first = _make_register_class(
+            name="UartControlAlt1", path="uart.control_alt1", address=0x40001000
+        )
+        second = _make_register_class(
+            name="UartControlAlt2", path="uart.control_alt2", address=0x40001000
+        )
+
+        apply_alias_relationship(first, primary, kind="full")
+        apply_alias_relationship(second, primary, kind="sw_view")
+
+        assert primary.aliases == (first, second)
+        assert first.target is primary
+        assert second.target is primary
+
+    def test_idempotent_wiring_does_not_duplicate(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        apply_alias_relationship(alt, primary, kind="full")
+        apply_alias_relationship(alt, primary, kind="full")
+
+        assert primary.aliases == (alt,)
+        assert alt.target is primary
+
+    def test_self_alias_raises(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+
+        with pytest.raises(ValueError, match="must differ"):
+            apply_alias_relationship(primary, primary, kind="full")
+
+
+# ---------------------------------------------------------------------------
+# Bus behaviour: alias and primary share an address
+# ---------------------------------------------------------------------------
+
+
+class TestBusBehaviour:
+    def test_alias_read_hits_primary_address(self) -> None:
+        primary_cls = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt_cls = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+        apply_alias_relationship(alt_cls, primary_cls, kind="full")
+
+        master = _FakeMaster()
+        master.memory[0x40001000] = 0xCAFEBABE
+
+        primary = primary_cls(master)
+        alt = alt_cls(master)
+
+        assert primary.read() == 0xCAFEBABE
+        assert alt.read() == 0xCAFEBABE
+        # Both reads landed on the same address.
+        assert master.reads == [0x40001000, 0x40001000]
+
+    def test_alias_write_hits_primary_address(self) -> None:
+        primary_cls = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt_cls = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+        apply_alias_relationship(alt_cls, primary_cls, kind="full")
+
+        master = _FakeMaster()
+        primary = primary_cls(master)
+        alt = alt_cls(master)
+
+        alt.write(0xDEADBEEF)
+        # Reading via the primary sees the alias's write — same address.
+        assert primary.read() == 0xDEADBEEF
+        assert master.writes == [(0x40001000, 0xDEADBEEF)]
+
+
+# ---------------------------------------------------------------------------
+# Repr override
+# ---------------------------------------------------------------------------
+
+
+class TestAliasRepr:
+    def test_repr_includes_alias_of_marker(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+        apply_alias_relationship(alt, primary, kind="full")
+
+        master = _FakeMaster()
+        rendered = repr(alt(master))
+
+        # The sketch §10 example:
+        #   <Reg uart.control_alt @ 0x40001000  alias-of=uart.control  rw>
+        assert rendered == (
+            "<Reg uart.control_alt @ 0x40001000  alias-of=uart.control  rw>"
+        )
+
+    def test_repr_components_present(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+        apply_alias_relationship(alt, primary, kind="full")
+
+        master = _FakeMaster()
+        rendered = repr(alt(master))
+
+        assert "alias-of=uart.control" in rendered
+        assert "uart.control_alt" in rendered
+        assert "0x40001000" in rendered
+
+    def test_repr_uses_access_from_info(self) -> None:
+        primary = _make_register_class(
+            name="ScrambleSrc", path="otp.src", address=0x40005000, access="rw"
+        )
+        alt = _make_register_class(
+            name="ScrambleView",
+            path="otp.src_scrambled",
+            address=0x40005000,
+            access="ro",
+        )
+        apply_alias_relationship(alt, primary, kind="scrambled")
+
+        master = _FakeMaster()
+        rendered = repr(alt(master))
+
+        # Access label flows through from ``info.access``.
+        assert rendered.endswith("  ro>")
+        assert "alias-of=otp.src" in rendered
+
+    def test_repr_handles_enum_value_access(self) -> None:
+        # Some Info implementations store access as an enum member with a
+        # ``.value`` attribute. The repr should pick the short token.
+        access = SimpleNamespace(value="wo")
+        primary = _make_register_class(
+            name="CmdReg", path="dma.cmd", address=0x40006000
+        )
+        alt = _make_register_class(
+            name="CmdRegAlt", path="dma.cmd_alt", address=0x40006000
+        )
+        alt.info.access = access  # type: ignore[attr-defined]
+        apply_alias_relationship(alt, primary, kind="full")
+
+        rendered = repr(alt(_FakeMaster()))
+        assert rendered.endswith("  wo>")
+
+
+# ---------------------------------------------------------------------------
+# Info.alias_kind backfill (Unit 4 lives downstream)
+# ---------------------------------------------------------------------------
+
+
+class TestAliasKindMetadata:
+    def test_kind_backfilled_when_info_slot_empty(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        apply_alias_relationship(alt, primary, kind="sw_view")
+
+        assert alt.info.alias_kind == "sw_view"  # type: ignore[attr-defined]
+
+    def test_kind_does_not_overwrite_existing(self) -> None:
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+        # Exporter pre-populated the slot — Unit 23's job in production.
+        alt.info.alias_kind = "scrambled"  # type: ignore[attr-defined]
+
+        apply_alias_relationship(alt, primary, kind="full")
+
+        # Runtime did not overwrite exporter-supplied metadata.
+        assert alt.info.alias_kind == "scrambled"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# register_register_enhancement seam (Unit 1 lives elsewhere)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterEnhancementSeam:
+    def setup_method(self) -> None:
+        reset_enhancements()
+
+    def teardown_method(self) -> None:
+        reset_enhancements()
+
+    def test_register_returns_callable(self) -> None:
+        def enhancer(_cls: type) -> None:
+            return None
+
+        returned = register_register_enhancement(enhancer)
+        assert returned is enhancer
+        assert registered_enhancements() == (enhancer,)
+
+    def test_register_can_be_used_as_decorator(self) -> None:
+        @register_register_enhancement
+        def enhancer(_cls: type) -> None:
+            return None
+
+        assert enhancer in registered_enhancements()
+
+    def test_alias_metadata_drives_enhancement(self) -> None:
+        # Simulates how the per-SoC runtime template will eventually iterate
+        # over the metadata that Unit 23 emits and call into Unit 13's
+        # helpers via Unit 1's registry seam.
+        primary = _make_register_class(
+            name="UartControl", path="uart.control", address=0x40001000
+        )
+        alt = _make_register_class(
+            name="UartControlAlt", path="uart.control_alt", address=0x40001000
+        )
+
+        # Per-class metadata as Unit 23 would emit it. The runtime decides
+        # what to do with it; this test mirrors that wiring step.
+        metadata: dict[type, dict[str, Any]] = {
+            alt: {
+                "is_alias": True,
+                "target_cls": primary,
+                "alias_kind": "full",
+            },
+        }
+
+        @register_register_enhancement
+        def alias_wirer(cls: type) -> None:
+            entry = metadata.get(cls)
+            if entry is None or not entry.get("is_alias"):
+                return
+            apply_alias_relationship(
+                cls, entry["target_cls"], kind=entry.get("alias_kind")
+            )
+
+        # Exercise the seam the way the runtime template would.
+        for enhancement in registered_enhancements():
+            for cls in (primary, alt):
+                enhancement(cls)
+
+        assert alt.is_alias is True
+        assert alt.target is primary
+        assert primary.aliases == (alt,)


### PR DESCRIPTION
## Summary

Implements **Unit 13** of the API overhaul (`docs/IDEAL_API_SKETCH.md` §10) — alias node helpers for the runtime.

Wires the SystemRDL `alias` relationship onto generated register classes:

- `alt.target` points at the canonical register at the same address
- `alt.is_alias` is `True`; the canonical reports `False`
- `primary.aliases` accumulates as a deduplicated tuple, preserving insertion order
- `__repr__` on the alias names the link inline:
  ```
  <Reg uart.control_alt @ 0x40001000  alias-of=uart.control  rw>
  ```
- `info.alias_kind` (owned by Unit 4) is consumed read-only; the optional `kind` argument only backfills when the exporter (Unit 23) hasn't pre-populated.

A minimal `register_register_enhancement` seam lives in this module as a local placeholder for **Unit 1**'s `runtime/_registry.py`. The contract is intentionally narrow (single-argument callable) so the upstream registry can be a drop-in replacement when it lands. Marked with `TODO(Unit 1)`.

## What this PR does **not** do

- Define `Info` / `AliasKind` enum — that's Unit 4
- Build the canonical enhancement registry — that's Unit 1
- Detect alias relationships in RDL — that's Unit 23

This PR consumes the metadata flag `is_alias=True` plus a target-class pointer; tests synthesise that metadata directly so the unit is independently verifiable.

## Test plan

- [x] `pytest tests/runtime/test_aliases.py -v` (17 tests, all passing)
- [x] `ruff check` and `ruff format --check` clean
- [x] Repr matches §10 example character-for-character (including the double-space before `alias-of=` and `rw`)
- [x] Idempotent wiring (calling twice does not duplicate)
- [x] Self-alias raises `ValueError`
- [x] Multiple aliases accumulate in registration order
- [x] Reads/writes through alias and primary land at the same address (verified via shared fake master)

## Files

- `src/peakrdl_pybind11/runtime/__init__.py` (new package)
- `src/peakrdl_pybind11/runtime/aliases.py`
- `tests/runtime/__init__.py`
- `tests/runtime/test_aliases.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)