### PR TITLE
feat(runtime): InterruptGroup runtime (Unit 12)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,9 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design. This package houses the
+pure-Python helpers that ride on top of the generated pybind11 module — the
+generated tree exposes raw register/field accessors, and the runtime layers
+the higher-level ergonomics (transactions, snapshots, interrupts, waits, …).
+"""
+
+from __future__ import annotations

--- a/src/peakrdl_pybind11/runtime/errors.py
+++ b/src/peakrdl_pybind11/runtime/errors.py
@@ -1,0 +1,40 @@
+"""Error taxonomy for the PeakRDL-pybind11 runtime.
+
+Minimal subset shipped with this unit so it can be tested standalone; the
+full taxonomy described in ``docs/IDEAL_API_SKETCH.md`` §19 lands in Unit 2
+and supersedes this module on merge. Only :class:`WaitTimeoutError` is
+exercised here — the interrupt runtime raises it on poll exhaustion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+__all__ = ["WaitTimeoutError"]
+
+
+class WaitTimeoutError(TimeoutError):
+    """Raised when a poll-based wait exceeds its ``timeout``.
+
+    Subclasses :class:`TimeoutError` so existing ``except TimeoutError``
+    handlers still catch it. ``last_seen`` records the most recent value
+    observed before the timeout fired; ``samples`` (when supplied) is the
+    full polled trail, useful for glitch debugging.
+    """
+
+    def __init__(
+        self,
+        node_path: str,
+        expected: object,
+        last_seen: object,
+        samples: Sequence[object] | None = None,
+    ) -> None:
+        self.node_path = node_path
+        self.expected = expected
+        self.last_seen = last_seen
+        self.samples = tuple(samples) if samples is not None else None
+        message = f"timeout waiting for {node_path} == {expected!r}; last_seen={last_seen!r}"
+        if self.samples is not None:
+            message += f"; samples={list(self.samples)!r}"
+        self.message = message
+        super().__init__(message)

--- a/src/peakrdl_pybind11/runtime/interrupts.py
+++ b/src/peakrdl_pybind11/runtime/interrupts.py
@@ -1,0 +1,692 @@
+"""Interrupt runtime — Unit 12.
+
+Implements the marquee runtime described in ``docs/IDEAL_API_SKETCH.md`` §9:
+:class:`InterruptSource` wraps a single ``intr`` field and the optional
+enable/test partners; :class:`InterruptGroup` groups sources that live under
+the same trio (``INTR_STATE`` / ``INTR_ENABLE`` / ``INTR_TEST``).
+
+Detection of the trio (the exporter plugin work) is Unit 23. This module
+consumes the detected metadata and is also usable manually via
+:meth:`InterruptGroup.manual` for the (rare) chips where auto-detection
+fails.
+
+The runtime is bus-aware via the field objects it is handed — every read
+and write goes through the same masters as the rest of the API. There is no
+direct register/master wiring here; all I/O is delegated to the field
+objects passed in. That keeps the unit testable with a tiny mock instead of
+the full generated tree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Protocol, runtime_checkable
+
+from .errors import WaitTimeoutError
+
+__all__ = [
+    "FieldLike",
+    "InterruptGroup",
+    "InterruptSource",
+    "InterruptTree",
+    "register_interrupt_group",
+    "register_post_create_hook",
+    "register_register_enhancement_hook",
+]
+
+
+# ---------------------------------------------------------------------------
+# Protocol — what we need from a field object.
+#
+# The generated tree's field classes already expose ``read()``/``write()`` and
+# carry ``info`` metadata under Unit 4; we duck-type against that so this
+# unit can be tested with a trivial mock and still slot into the real tree
+# without ceremony. The minimum surface is intentionally small.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FieldLike(Protocol):
+    """Subset of the generated field API consumed by the interrupt runtime.
+
+    Every interrupt-bearing field on the generated tree satisfies this
+    protocol; tests stub it with a minimal mock.
+    """
+
+    def read(self) -> int: ...
+
+    def write(self, value: int) -> None: ...
+
+
+def _lookup_or_attr_error(obj: object, attr_name: str, mapping_name: str, kind: str) -> object:
+    """Resolve ``obj.<attr_name>`` against the mapping at ``obj.<mapping_name>``.
+
+    Shared by :class:`InterruptGroup` and :class:`InterruptTree` to give a
+    consistent ``did-you-mean``-style :class:`AttributeError` and to dodge
+    recursion during partial init (Python pings ``__getattr__`` for dunder
+    lookups before ``__init__`` finishes).
+    """
+
+    if attr_name.startswith("_"):
+        raise AttributeError(attr_name)
+    try:
+        mapping = object.__getattribute__(obj, mapping_name)
+    except AttributeError as exc:
+        raise AttributeError(attr_name) from exc
+    try:
+        return mapping[attr_name]
+    except KeyError as exc:
+        raise AttributeError(f"{kind} has no {attr_name!r}; known: {sorted(mapping)}") from exc
+
+
+def _info_tag(field: FieldLike | None, key: str, default: str = "") -> str:
+    """Best-effort extraction of an ``info.<key>`` side-effect tag.
+
+    The Unit 4 ``info`` block exposes SystemRDL ``onwrite``/``onread`` as
+    ``info.on_write`` / ``info.on_read`` (e.g. ``"woclr"`` for write-1-to-
+    clear). Tolerates fields without ``info`` and returns ``default``,
+    which lets the runtime stay useful before Unit 4's seam reaches every
+    field.
+    """
+
+    if field is None:
+        return ""
+    info = getattr(field, "info", None)
+    if info is None:
+        return default
+    value = getattr(info, key, None)
+    return value if isinstance(value, str) else default
+
+
+# ---------------------------------------------------------------------------
+# InterruptSource
+# ---------------------------------------------------------------------------
+
+
+class InterruptSource:
+    """A single interrupt — typically one bit of an ``INTR_STATE`` register.
+
+    Wraps the state field plus the optional enable and test partner fields.
+    Mirrors the surface in §9.1: ``is_pending``/``is_enabled``/``enable``/
+    ``disable``/``clear``/``acknowledge``/``fire`` plus the wait family
+    (``wait``, ``wait_clear``, ``aiowait``, ``poll``) and the subscription
+    helper ``on_fire``.
+    """
+
+    def __init__(
+        self,
+        state_field: FieldLike,
+        enable_field: FieldLike | None = None,
+        test_field: FieldLike | None = None,
+        name: str = "",
+    ) -> None:
+        self._state_field = state_field
+        self._enable_field = enable_field
+        self._test_field = test_field
+        self._name = name
+
+    # -- introspection ------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Source name as seen on the parent group (e.g. ``"tx_done"``)."""
+
+        return self._name
+
+    @property
+    def state_field(self) -> FieldLike:
+        return self._state_field
+
+    @property
+    def enable_field(self) -> FieldLike | None:
+        return self._enable_field
+
+    @property
+    def test_field(self) -> FieldLike | None:
+        return self._test_field
+
+    def __repr__(self) -> str:
+        return f"InterruptSource(name={self._name!r})"
+
+    # -- state queries ------------------------------------------------------
+
+    def is_pending(self) -> bool:
+        """``True`` iff the state bit currently reads as 1."""
+
+        return bool(self._state_field.read())
+
+    def is_enabled(self) -> bool:
+        """``True`` iff the enable bit reads as 1, or no enable partner exists.
+
+        Sources without an enable partner are always considered enabled —
+        there is no way to mask them, so reporting them as disabled would be
+        misleading.
+        """
+
+        if self._enable_field is None:
+            return True
+        return bool(self._enable_field.read())
+
+    # -- mutators -----------------------------------------------------------
+
+    def enable(self) -> None:
+        """Set the enable bit. Raises if there is no enable partner."""
+
+        if self._enable_field is None:
+            raise NotImplementedError(f"interrupt {self._name!r} has no enable field")
+        self._enable_field.write(1)
+
+    def disable(self) -> None:
+        """Clear the enable bit. Raises if there is no enable partner."""
+
+        if self._enable_field is None:
+            raise NotImplementedError(f"interrupt {self._name!r} has no enable field")
+        self._enable_field.write(0)
+
+    def clear(self) -> None:
+        """Clear the pending state bit, doing the right thing per RDL.
+
+        - ``woclr`` (write-1-to-clear, OpenTitan default): write 1.
+        - ``wzc`` (write-0-to-clear, rare): write 0.
+        - ``rclr`` (read-to-clear): the bit clears on read, so just read it.
+        - Anything else falls through to the OpenTitan default of writing 1,
+          which is what the overwhelming majority of vendor RDL emits.
+        """
+
+        on_write = _info_tag(self._state_field, "on_write", "woclr")
+        on_read = _info_tag(self._state_field, "on_read")
+        if on_write == "wzc":
+            self._state_field.write(0)
+            return
+        if on_read in ("rclr", "rset"):
+            # Read is the documented clear mechanism; no write needed.
+            self._state_field.read()
+            return
+        # woclr (the OpenTitan default) and any unspecified field.
+        self._state_field.write(1)
+
+    def acknowledge(self) -> None:
+        """Alias for :meth:`clear`. Matches the §9.1 sketch."""
+
+        self.clear()
+
+    def fire(self) -> None:
+        """Software self-trigger via the test partner (write 1).
+
+        Raises if there is no test partner — there's no portable way to
+        synthesize a hardware interrupt without one.
+        """
+
+        if self._test_field is None:
+            raise NotImplementedError(f"interrupt {self._name!r} has no test field")
+        self._test_field.write(1)
+
+    # -- wait / poll --------------------------------------------------------
+
+    def wait(self, timeout: float = 1.0, period: float = 0.001) -> None:
+        """Block until the source is pending or ``timeout`` elapses.
+
+        Raises :class:`WaitTimeoutError` on timeout. ``period`` is the polling
+        interval; the default of 1 ms balances bus traffic against latency.
+        """
+
+        self._wait_for(True, timeout=timeout, period=period)
+
+    def wait_clear(self, timeout: float = 1.0, period: float = 0.001) -> None:
+        """Block until the source is *not* pending or ``timeout`` elapses."""
+
+        self._wait_for(False, timeout=timeout, period=period)
+
+    async def aiowait(self, timeout: float = 1.0, period: float = 0.001) -> None:
+        """Async variant of :meth:`wait`. Sleeps via :func:`asyncio.sleep`."""
+
+        deadline = time.monotonic() + timeout
+        last_seen = self.is_pending()
+        while not last_seen:
+            if time.monotonic() >= deadline:
+                raise WaitTimeoutError(f"interrupts.{self._name}", True, last_seen)
+            await asyncio.sleep(period)
+            last_seen = self.is_pending()
+
+    def poll(self, period: float = 0.001, timeout: float = 1.0) -> None:
+        """Explicit-period poll; alias for :meth:`wait` with both knobs.
+
+        Argument order matches §9.1 (``period`` first), distinct from
+        :meth:`wait` whose primary knob is ``timeout``.
+        """
+
+        self._wait_for(True, timeout=timeout, period=period)
+
+    def _wait_for(self, target: bool, *, timeout: float, period: float) -> None:
+        """Polling loop shared by ``wait`` / ``wait_clear`` / ``poll``.
+
+        Matches the §14 contract: returns once the target value is observed,
+        else raises :class:`WaitTimeoutError` carrying the last value seen.
+        """
+
+        deadline = time.monotonic() + timeout
+        last_seen = self.is_pending()
+        while last_seen != target:
+            if time.monotonic() >= deadline:
+                raise WaitTimeoutError(f"interrupts.{self._name}", target, last_seen)
+            time.sleep(period)
+            last_seen = self.is_pending()
+
+    # -- subscription -------------------------------------------------------
+
+    def on_fire(
+        self,
+        callback: Callable[[], None],
+        *,
+        period: float = 0.001,
+    ) -> Callable[[], None]:
+        """Register ``callback`` to fire when the source becomes pending.
+
+        Polls in a daemon thread, debouncing on the 0→1 edge so the callback
+        fires once per assertion (not once per poll while the bit is high).
+        Returns an unsubscribe callable.
+
+        Master-driven IRQ delivery is intentionally a future hook: backends
+        that natively expose interrupts will swap out this body, but the
+        polling fallback works against any master that can read the state
+        register.
+        """
+
+        # Backends with native IRQ delivery install themselves via the
+        # package-level ``_irq_backend``; polling is the fallback.
+        if _irq_backend is not None:
+            return _irq_backend(self, callback)
+
+        stop = threading.Event()
+        prev_pending = self.is_pending()
+
+        def _loop() -> None:
+            nonlocal prev_pending
+            while not stop.is_set():
+                try:
+                    pending_now = self.is_pending()
+                except Exception:
+                    # Backend hiccup; stop the poller silently.
+                    return
+                # Rising-edge only — don't spam while the source stays asserted.
+                if pending_now and not prev_pending:
+                    try:
+                        callback()
+                    except Exception:
+                        # Never let a callback crash kill the poller thread.
+                        pass
+                prev_pending = pending_now
+                if stop.wait(period):
+                    return
+
+        thread = threading.Thread(
+            target=_loop,
+            name=f"on_fire[{self._name or 'interrupt'}]",
+            daemon=True,
+        )
+        thread.start()
+
+        def _unsubscribe() -> None:
+            stop.set()
+
+        return _unsubscribe
+
+
+# ---------------------------------------------------------------------------
+# Backend hook seam — for native IRQ-capable masters (no installer here).
+#
+# Masters that learn to wake on real interrupts (rather than poll) install
+# themselves by overwriting ``_irq_backend``. The hook receives ``(source,
+# callback)`` and returns an unsubscribe — same shape as the polling
+# fallback returns from :meth:`InterruptSource.on_fire`.
+# ---------------------------------------------------------------------------
+
+_IRQBackendHook = Callable[["InterruptSource", Callable[[], None]], Callable[[], None]]
+_irq_backend: _IRQBackendHook | None = None
+
+
+# ---------------------------------------------------------------------------
+# InterruptGroup
+# ---------------------------------------------------------------------------
+
+
+class InterruptGroup:
+    """A group of related :class:`InterruptSource` objects.
+
+    Typical case: every field of one ``INTR_STATE`` register lives in one
+    group — that's how OpenTitan, ARM, RISC-V CLIC, etc. lay out their IRQs.
+
+    Sources are reachable both as named attributes (``group.tx_done``) and
+    by iteration. The §9.2 group helpers (``pending``, ``enabled``,
+    ``clear_all``, ``disable_all``, ``enable``, ``snapshot``) operate on
+    the union.
+    """
+
+    def __init__(self, sources: Mapping[str, InterruptSource]) -> None:
+        # Stamp the canonical name on each source so ``InterruptSource.name``
+        # reflects the key the user reaches them under, even when callers
+        # pass freshly-constructed sources without ``name=`` set.
+        validated: dict[str, InterruptSource] = {}
+        for key, source in sources.items():
+            if not source.name:
+                source._name = key
+            validated[key] = source
+        self._sources: dict[str, InterruptSource] = validated
+
+    # -- factories ----------------------------------------------------------
+
+    @classmethod
+    def manual(
+        cls,
+        state: object,
+        enable: object | None = None,
+        test: object | None = None,
+    ) -> InterruptGroup:
+        """Build a group from raw register objects when auto-detect failed.
+
+        Matches sources by field name across the trio. ``state`` is required
+        (it's where the pending bits live); ``enable`` and ``test`` are
+        optional and matched by best-effort name lookup so missing partners
+        on individual sources don't sink the whole group.
+
+        Each register is expected to expose a ``fields()`` iterator yielding
+        objects with ``.inst_name`` (or ``.name``) — the convention shared by
+        the generated pybind11 module and the systemrdl-compiler tree.
+        """
+
+        state_fields = _enumerate_fields(state)
+        if not state_fields:
+            raise ValueError("state register exposes no fields")
+        enable_fields = _enumerate_fields(enable)
+        test_fields = _enumerate_fields(test)
+
+        sources: dict[str, InterruptSource] = {}
+        for fname, sfield in state_fields.items():
+            sources[fname] = InterruptSource(
+                state_field=sfield,
+                enable_field=enable_fields.get(fname),
+                test_field=test_fields.get(fname),
+                name=fname,
+            )
+        return cls(sources)
+
+    # -- container surface --------------------------------------------------
+
+    def __getattr__(self, name: str) -> InterruptSource:
+        return _lookup_or_attr_error(self, name, "_sources", "interrupt group")
+
+    def __iter__(self) -> Iterator[InterruptSource]:
+        return iter(self._sources.values())
+
+    def __len__(self) -> int:
+        return len(self._sources)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._sources
+
+    def __repr__(self) -> str:
+        return f"InterruptGroup(sources={sorted(self._sources)!r})"
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(self._sources)
+
+    # -- group queries ------------------------------------------------------
+
+    def pending(self) -> frozenset[InterruptSource]:
+        """Frozenset of sources whose state bit currently reads as 1."""
+
+        return frozenset(s for s in self._sources.values() if s.is_pending())
+
+    def enabled(self) -> frozenset[InterruptSource]:
+        """Frozenset of sources whose enable bit currently reads as 1.
+
+        Sources with no enable partner are reported as enabled (see
+        :meth:`InterruptSource.is_enabled`).
+        """
+
+        return frozenset(s for s in self._sources.values() if s.is_enabled())
+
+    def snapshot(self) -> dict[str, tuple[int, int]]:
+        """Per-source ``(state, enable)`` pairs at this instant.
+
+        Matches the §9.2 sketch — handy for golden-state assertions and the
+        post-mortem dumps that follow a flaky test.
+        """
+
+        out: dict[str, tuple[int, int]] = {}
+        for name, source in self._sources.items():
+            state = int(source.state_field.read())
+            enable = int(source.enable_field.read()) if source.enable_field is not None else 1
+            out[name] = (state, enable)
+        return out
+
+    # -- group mutators -----------------------------------------------------
+
+    def clear_all(self) -> None:
+        """Clear every pending source. Safe to call when none are pending —
+        write-1-to-clear is idempotent on a 0 bit."""
+
+        for source in self._sources.values():
+            source.clear()
+
+    def disable_all(self) -> None:
+        """Disable every source that exposes an enable partner."""
+
+        for source in self._sources.values():
+            if source.enable_field is not None:
+                source.disable()
+
+    def enable(self, set_: Iterable[str] | None = None) -> None:
+        """Enable a subset of sources by name (or all, if ``set_`` is None).
+
+        Unknown names raise :class:`KeyError`. Known sources that lack an
+        enable partner are silently skipped — there is no enable bit to
+        toggle, so requesting their enable is a no-op rather than an error.
+        """
+
+        targets = self._sources.keys() if set_ is None else set_
+        for name in targets:
+            source = self._sources.get(name)
+            if source is None:
+                raise KeyError(f"interrupt group has no source {name!r}; known: {sorted(self._sources)}")
+            if source.enable_field is not None:
+                source.enable()
+
+
+# ---------------------------------------------------------------------------
+# manual() helper — accept a register-like or a mapping of fields.
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_fields(obj: object) -> dict[str, FieldLike]:
+    """Return a ``{name: field}`` map for a register-like ``obj``.
+
+    Tolerates four shapes so :meth:`InterruptGroup.manual` is forgiving:
+
+    1. ``None`` → empty dict (the partner is absent).
+    2. ``Mapping[str, FieldLike]`` → returned as a plain dict.
+    3. An object with ``fields()`` → SystemRDL/pybind11 generated registers.
+    4. An object whose attributes look like fields (``read``/``write``) —
+       last-resort fallback. We exclude private names and methods.
+    """
+
+    if obj is None:
+        return {}
+    if isinstance(obj, Mapping):
+        return {str(k): v for k, v in obj.items()}
+
+    out: dict[str, FieldLike] = {}
+    fields_method = getattr(obj, "fields", None)
+    if callable(fields_method):
+        for field in fields_method():
+            name = getattr(field, "inst_name", None) or getattr(field, "name", None) or ""
+            if name:
+                out[str(name)] = field
+        if out:
+            return out
+
+    # Attribute scan — the slowest path, kept for hand-built test doubles.
+    for name in dir(obj):
+        if name.startswith("_"):
+            continue
+        attr = getattr(obj, name, None)
+        if attr is obj:
+            continue
+        if hasattr(attr, "read") and hasattr(attr, "write") and not callable(attr):
+            out[name] = attr
+    return out
+
+
+# ---------------------------------------------------------------------------
+# InterruptTree — top-level ``soc.interrupts`` namespace.
+# ---------------------------------------------------------------------------
+
+
+class InterruptTree:
+    """Aggregate of every :class:`InterruptGroup` on the SoC tree.
+
+    Wired by Unit 1's ``register_post_create`` seam: as the generated
+    ``Soc`` finishes constructing, post-create walks the tree, collects
+    every :class:`InterruptGroup`, and instantiates one of these. The
+    sketch §9.3 surface (``tree``, ``pending``, ``wait_any``) lives here.
+    """
+
+    def __init__(self, groups: Mapping[str, InterruptGroup]) -> None:
+        self._groups: dict[str, InterruptGroup] = dict(groups)
+
+    @property
+    def groups(self) -> dict[str, InterruptGroup]:
+        # Defensive copy — callers shouldn't mutate the underlying dict.
+        return dict(self._groups)
+
+    def __getattr__(self, name: str) -> InterruptGroup:
+        return _lookup_or_attr_error(self, name, "_groups", "interrupts")
+
+    def __iter__(self) -> Iterator[InterruptGroup]:
+        return iter(self._groups.values())
+
+    def __len__(self) -> int:
+        return len(self._groups)
+
+    def __repr__(self) -> str:
+        return f"InterruptTree(groups={sorted(self._groups)!r})"
+
+    def pending(self) -> frozenset[InterruptSource]:
+        """Frozenset of pending sources across every group."""
+
+        out: set[InterruptSource] = set()
+        for group in self._groups.values():
+            out.update(group.pending())
+        return frozenset(out)
+
+    def wait_any(self, timeout: float = 1.0, period: float = 0.001) -> InterruptSource:
+        """Return the first source observed pending, or raise on timeout.
+
+        The polling order is deterministic (group insertion order, then
+        source insertion order) so flaky tests get reproducible failures.
+        """
+
+        deadline = time.monotonic() + timeout
+        while True:
+            for group in self._groups.values():
+                for source in group:
+                    if source.is_pending():
+                        return source
+            if time.monotonic() >= deadline:
+                raise WaitTimeoutError("soc.interrupts", "any pending", None)
+            time.sleep(period)
+
+    def tree(self) -> str:
+        """Pretty-print every group + source with its current status.
+
+        Returns the rendered string (and prints it) so callers can capture
+        the dump for golden-file checks. Reading every state/enable bit
+        triggers real bus traffic — the call is intentionally not free,
+        same as ``snapshot()``.
+        """
+
+        lines: list[str] = ["interrupts:"]
+        for gname, group in self._groups.items():
+            lines.append(f"  {gname}:")
+            for sname, (state, enable) in group.snapshot().items():
+                marker = "*" if state and enable else " "
+                lines.append(f"    {marker} {sname:<20} state={state} enable={enable}")
+        text = "\n".join(lines)
+        print(text)
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Hook seams — Unit 1 owns the formal seams; we expose tiny shims so the
+# real ``register_post_create`` / ``register_register_enhancement`` from
+# the scaffolding land in this same module without a rewrite. Every hook
+# is idempotent and has no effect until the seam plugs them in.
+# ---------------------------------------------------------------------------
+
+_GROUP_REGISTRY: dict[str, InterruptGroup] = {}
+
+
+def register_interrupt_group(path: str, group: InterruptGroup) -> None:
+    """Record a group under its dotted path so :class:`InterruptTree`
+    can collect it later. Used by both auto-detection (Unit 23) and
+    manual wiring."""
+
+    _GROUP_REGISTRY[path] = group
+
+
+def register_post_create_hook(soc: object) -> InterruptTree:
+    """``register_post_create`` callback — attach ``soc.interrupts``.
+
+    Walks the registry populated by Unit 23's auto-detection (and any
+    manual ``register_interrupt_group`` calls), instantiates an
+    :class:`InterruptTree`, and assigns it to ``soc.interrupts``. Returns
+    the tree for tests/inspection.
+    """
+
+    tree = InterruptTree(dict(_GROUP_REGISTRY))
+    try:
+        soc.interrupts = tree
+    except (AttributeError, TypeError):
+        # Some generated trees use slots — callers can still pull the
+        # InterruptTree from the return value.
+        pass
+    return tree
+
+
+def register_register_enhancement_hook(register: object, info: object) -> InterruptGroup | None:
+    """``register_register_enhancement`` callback — attach
+    ``regfile.interrupts`` when this register is the ``state`` half of a
+    detected trio.
+
+    ``info`` is the detection metadata produced by Unit 23's exporter
+    plugin: it carries the partner registers (enable/test) on attributes
+    of the same name. The hook builds an :class:`InterruptGroup` from the
+    trio, attaches it to the parent regfile under ``.interrupts``, and
+    registers it for top-level ``soc.interrupts`` aggregation.
+    """
+
+    if info is None or not getattr(info, "is_interrupt_state", False):
+        return None
+    enable = getattr(info, "enable_register", None)
+    test = getattr(info, "test_register", None)
+    group = InterruptGroup.manual(state=register, enable=enable, test=test)
+
+    parent = getattr(register, "parent", None) or getattr(register, "_parent", None)
+    if parent is not None:
+        try:
+            parent.interrupts = group
+        except (AttributeError, TypeError):
+            pass
+
+    path = getattr(register, "path", None) or getattr(info, "path", None) or ""
+    if path:
+        # Strip the trailing ``.intr_state`` (or whatever the state register
+        # is named) so the group is registered under the parent block —
+        # ``soc.uart.interrupts`` rather than ``soc.uart.intr_state``.
+        prefix = path.rsplit(".", 1)[0] if "." in path else path
+        register_interrupt_group(prefix, group)
+    return group

--- a/tests/runtime/test_interrupts.py
+++ b/tests/runtime/test_interrupts.py
@@ -1,0 +1,734 @@
+"""Unit tests for ``runtime.interrupts`` (Unit 12)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime.errors import WaitTimeoutError
+from peakrdl_pybind11.runtime.interrupts import (
+    InterruptGroup,
+    InterruptSource,
+    InterruptTree,
+    register_interrupt_group,
+    register_post_create_hook,
+    register_register_enhancement_hook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+#
+# We model the generated-tree contract with the smallest field/register
+# stand-in that satisfies the runtime's protocols. Each ``MockField`` carries
+# one bit of state and (optionally) ``info`` metadata so the runtime can
+# pick the right ``clear()`` semantics.
+# ---------------------------------------------------------------------------
+
+
+class MockField:
+    """Minimal :class:`FieldLike` stub: holds a single bit + side-effect tags.
+
+    Tracks every read and write so tests can assert the runtime issues the
+    expected sequence of operations.
+    """
+
+    def __init__(
+        self,
+        value: int = 0,
+        *,
+        on_write: str = "woclr",
+        on_read: str = "",
+        name: str = "",
+    ) -> None:
+        self._value = int(value)
+        self.info = SimpleNamespace(on_write=on_write, on_read=on_read)
+        self.inst_name = name
+        self.reads: list[None] = []
+        self.writes: list[int] = []
+
+    def read(self) -> int:
+        self.reads.append(None)
+        # Honor read-clears semantics so woclr fields and rclr fields can
+        # be tested through the same API.
+        v = self._value
+        if self.info.on_read == "rclr":
+            self._value = 0
+        return v
+
+    def write(self, value: int) -> None:
+        v = int(value)
+        self.writes.append(v)
+        if self.info.on_write == "woclr":
+            # Write-1-to-clear: writing 1 clears, writing 0 is a no-op.
+            if v:
+                self._value = 0
+        elif self.info.on_write == "wzc":
+            # Write-0-to-clear.
+            if not v:
+                self._value = 0
+        else:
+            # Default: regular RW.
+            self._value = v
+
+    # Test-only accessor: lets tests poke the underlying bit (simulating
+    # hardware setting INTR_STATE) without going through ``write`` and its
+    # side-effect machinery.
+    def set_hw(self, value: int) -> None:
+        self._value = int(value)
+
+
+class MockRegister:
+    """A register-like object that exposes its fields via ``fields()``."""
+
+    def __init__(self, **fields: MockField) -> None:
+        for name, field in fields.items():
+            field.inst_name = name
+            setattr(self, name, field)
+        self._fields = fields
+
+    def fields(self) -> list[MockField]:
+        return list(self._fields.values())
+
+
+# ---------------------------------------------------------------------------
+# Per-source behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_is_pending_reads_state_bit() -> None:
+    """``group.tx_done.is_pending()`` reads the state bit."""
+
+    state = MockField(value=0, name="tx_done")
+    group = InterruptGroup({"tx_done": InterruptSource(state, name="tx_done")})
+
+    assert group.tx_done.is_pending() is False
+    state.set_hw(1)
+    assert group.tx_done.is_pending() is True
+    # Each query goes through the bus; cache-free behaviour matters for HW.
+    assert len(state.reads) == 2
+
+
+def test_clear_writes_one_for_woclr() -> None:
+    """``clear()`` honors ``info.on_write="woclr"`` and writes 1."""
+
+    state = MockField(value=1, on_write="woclr")
+    src = InterruptSource(state, name="tx_done")
+
+    src.clear()
+
+    assert state.writes == [1]
+    assert state._value == 0  # woclr: write 1 cleared the bit.
+
+
+def test_clear_writes_zero_for_wzc() -> None:
+    """``clear()`` writes 0 for the (rare) ``wzc`` semantic."""
+
+    state = MockField(value=1, on_write="wzc")
+    src = InterruptSource(state, name="tx_done")
+
+    src.clear()
+
+    assert state.writes == [0]
+    assert state._value == 0
+
+
+def test_clear_reads_for_rclr() -> None:
+    """``clear()`` triggers a read when the field is read-to-clear."""
+
+    state = MockField(value=1, on_write="rw", on_read="rclr")
+    src = InterruptSource(state, name="tx_done")
+
+    src.clear()
+
+    assert state.reads == [None]
+    assert state.writes == []
+    assert state._value == 0
+
+
+def test_acknowledge_is_alias_for_clear() -> None:
+    """The §9.1 spelling: ``ack()`` and ``clear()`` are interchangeable."""
+
+    state = MockField(value=1)
+    src = InterruptSource(state, name="tx_done")
+
+    src.acknowledge()
+
+    assert state.writes == [1]
+
+
+def test_fire_writes_test_bit() -> None:
+    """``fire()`` writes 1 to the test partner — the SW self-trigger."""
+
+    state = MockField(value=0)
+    test = MockField(value=0, on_write="rw")
+    src = InterruptSource(state, test_field=test, name="tx_done")
+
+    src.fire()
+
+    assert test.writes == [1]
+
+
+def test_fire_without_test_field_raises() -> None:
+    """Sources with no test partner can't be SW-triggered."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    with pytest.raises(NotImplementedError):
+        src.fire()
+
+
+def test_enable_disable_round_trip() -> None:
+    """``enable()`` / ``disable()`` set and clear the enable bit."""
+
+    state = MockField(value=0)
+    enable = MockField(value=0, on_write="rw")
+    src = InterruptSource(state, enable_field=enable, name="tx_done")
+
+    assert src.is_enabled() is False
+    src.enable()
+    assert enable.writes == [1]
+    assert src.is_enabled() is True
+    src.disable()
+    assert enable.writes == [1, 0]
+
+
+def test_is_enabled_without_partner_is_true() -> None:
+    """Sources lacking an enable bit are reported as always enabled."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    assert src.is_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Group surface
+# ---------------------------------------------------------------------------
+
+
+def _build_group() -> tuple[
+    InterruptGroup, dict[str, MockField], dict[str, MockField]
+]:
+    """Three-source group with state + enable + test partners."""
+
+    state_fields = {
+        "tx_done": MockField(value=0, name="tx_done"),
+        "rx_overflow": MockField(value=0, name="rx_overflow"),
+        "parity_err": MockField(value=0, name="parity_err"),
+    }
+    enable_fields = {
+        n: MockField(value=0, on_write="rw") for n in state_fields
+    }
+    test_fields = {
+        n: MockField(value=0, on_write="rw") for n in state_fields
+    }
+    sources = {
+        n: InterruptSource(
+            state_fields[n], enable_fields[n], test_fields[n], name=n
+        )
+        for n in state_fields
+    }
+    return InterruptGroup(sources), state_fields, enable_fields
+
+
+def test_group_getattr_returns_named_source() -> None:
+    """``group.tx_done`` returns the matching :class:`InterruptSource`."""
+
+    group, _, _ = _build_group()
+    assert isinstance(group.tx_done, InterruptSource)
+    assert group.tx_done.name == "tx_done"
+
+
+def test_group_getattr_unknown_raises_attribute_error() -> None:
+    """Mistyped names produce an actionable :class:`AttributeError`."""
+
+    group, _, _ = _build_group()
+    with pytest.raises(AttributeError) as exc:
+        _ = group.nonexistent  # noqa: F841
+    assert "nonexistent" in str(exc.value)
+
+
+def test_group_iter_yields_sources() -> None:
+    """Iterating the group yields each source exactly once."""
+
+    group, _, _ = _build_group()
+    names = sorted(s.name for s in group)
+    assert names == ["parity_err", "rx_overflow", "tx_done"]
+    assert "tx_done" in group
+    assert len(group) == 3
+
+
+def test_group_pending_returns_frozenset() -> None:
+    """``group.pending()`` returns a frozenset of currently-pending sources."""
+
+    group, state_fields, _ = _build_group()
+    state_fields["tx_done"].set_hw(1)
+    state_fields["parity_err"].set_hw(1)
+
+    pending = group.pending()
+    assert isinstance(pending, frozenset)
+    names = {s.name for s in pending}
+    assert names == {"tx_done", "parity_err"}
+
+
+def test_group_enabled_returns_frozenset() -> None:
+    """``group.enabled()`` mirrors ``pending()`` for the enable column."""
+
+    group, _, enable_fields = _build_group()
+    enable_fields["tx_done"].set_hw(1)
+    enable_fields["rx_overflow"].set_hw(1)
+
+    enabled = group.enabled()
+    names = {s.name for s in enabled}
+    assert names == {"tx_done", "rx_overflow"}
+
+
+def test_group_clear_all_writes_one_to_each_state() -> None:
+    """``clear_all()`` issues one write per source."""
+
+    group, state_fields, _ = _build_group()
+    for f in state_fields.values():
+        f.set_hw(1)
+
+    group.clear_all()
+
+    for f in state_fields.values():
+        assert f.writes == [1]
+        assert f._value == 0
+
+
+def test_group_disable_all_clears_each_enable_bit() -> None:
+    """``disable_all()`` writes 0 to every enable partner."""
+
+    group, _, enable_fields = _build_group()
+    for f in enable_fields.values():
+        f.set_hw(1)
+
+    group.disable_all()
+
+    for f in enable_fields.values():
+        assert f.writes == [0]
+
+
+def test_group_enable_subset() -> None:
+    """``enable(set_={...})`` enables only the named sources."""
+
+    group, _, enable_fields = _build_group()
+
+    group.enable(set_={"tx_done", "parity_err"})
+
+    assert enable_fields["tx_done"].writes == [1]
+    assert enable_fields["parity_err"].writes == [1]
+    assert enable_fields["rx_overflow"].writes == []
+
+
+def test_group_enable_no_set_enables_all() -> None:
+    """``enable()`` with no argument enables every source."""
+
+    group, _, enable_fields = _build_group()
+
+    group.enable()
+
+    for f in enable_fields.values():
+        assert f.writes == [1]
+
+
+def test_group_enable_unknown_name_raises() -> None:
+    """Unknown source name in ``enable(set_=...)`` raises ``KeyError``."""
+
+    group, _, _ = _build_group()
+    with pytest.raises(KeyError):
+        group.enable(set_={"missing"})
+
+
+def test_group_snapshot_returns_state_enable_pairs() -> None:
+    """``snapshot()`` shape matches the §9.2 sketch."""
+
+    group, state_fields, enable_fields = _build_group()
+    state_fields["tx_done"].set_hw(1)
+    enable_fields["tx_done"].set_hw(1)
+    enable_fields["rx_overflow"].set_hw(1)
+
+    snap = group.snapshot()
+
+    assert snap == {
+        "tx_done": (1, 1),
+        "rx_overflow": (0, 1),
+        "parity_err": (0, 0),
+    }
+
+
+def test_group_snapshot_without_enable_partner_reports_one() -> None:
+    """Sources lacking an enable partner snapshot as enabled."""
+
+    state = MockField(value=1, name="lone")
+    group = InterruptGroup({"lone": InterruptSource(state, name="lone")})
+
+    assert group.snapshot() == {"lone": (1, 1)}
+
+
+# ---------------------------------------------------------------------------
+# manual() factory
+# ---------------------------------------------------------------------------
+
+
+def test_manual_builds_group_from_registers() -> None:
+    """``InterruptGroup.manual`` glues the trio into a :class:`InterruptGroup`."""
+
+    state = MockRegister(
+        tx_done=MockField(value=1),
+        rx_overflow=MockField(value=0),
+    )
+    enable = MockRegister(
+        tx_done=MockField(value=1, on_write="rw"),
+        rx_overflow=MockField(value=0, on_write="rw"),
+    )
+    test = MockRegister(
+        tx_done=MockField(value=0, on_write="rw"),
+        rx_overflow=MockField(value=0, on_write="rw"),
+    )
+
+    group = InterruptGroup.manual(state=state, enable=enable, test=test)
+
+    assert sorted(s.name for s in group) == ["rx_overflow", "tx_done"]
+    assert group.tx_done.is_pending() is True
+    assert group.tx_done.is_enabled() is True
+
+
+def test_manual_tolerates_missing_enable_test() -> None:
+    """Manual wiring works with state alone — partners are optional."""
+
+    state = MockRegister(tx_done=MockField(value=0))
+    group = InterruptGroup.manual(state=state)
+
+    assert group.tx_done.enable_field is None
+    assert group.tx_done.test_field is None
+    # No enable partner → always reported enabled.
+    assert group.tx_done.is_enabled() is True
+
+
+def test_manual_state_register_with_no_fields_raises() -> None:
+    """``manual`` rejects an empty state register — there's nothing to wrap."""
+
+    state = MockRegister()
+    with pytest.raises(ValueError):
+        InterruptGroup.manual(state=state)
+
+
+def test_manual_accepts_field_mapping() -> None:
+    """Passing a plain ``{name: field}`` dict instead of a register works."""
+
+    state = {"tx_done": MockField(value=1)}
+    group = InterruptGroup.manual(state=state)
+    assert group.tx_done.is_pending() is True
+
+
+# ---------------------------------------------------------------------------
+# Wait family
+# ---------------------------------------------------------------------------
+
+
+def test_wait_returns_when_pending() -> None:
+    """``wait()`` returns once the bit goes high."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    def _flip_after_delay() -> None:
+        # Tiny delay so the wait actually has to poll once.
+        time.sleep(0.01)
+        state.set_hw(1)
+
+    threading.Thread(target=_flip_after_delay, daemon=True).start()
+    # Should return cleanly — no exception.
+    src.wait(timeout=1.0, period=0.001)
+
+
+def test_wait_timeout_raises_wait_timeout_error() -> None:
+    """``wait()`` raises :class:`WaitTimeoutError` when nothing fires."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    with pytest.raises(WaitTimeoutError) as exc:
+        src.wait(timeout=0.05, period=0.001)
+    assert "tx_done" in str(exc.value)
+    assert exc.value.expected is True
+    assert exc.value.last_seen is False
+
+
+def test_wait_clear_returns_when_no_longer_pending() -> None:
+    """``wait_clear()`` is the falling-edge analogue of ``wait()``."""
+
+    state = MockField(value=1)
+    src = InterruptSource(state, name="tx_done")
+
+    def _clear_after_delay() -> None:
+        time.sleep(0.01)
+        state.set_hw(0)
+
+    threading.Thread(target=_clear_after_delay, daemon=True).start()
+    src.wait_clear(timeout=1.0, period=0.001)
+
+
+def test_wait_clear_timeout_raises() -> None:
+    """``wait_clear()`` raises if the bit stays high."""
+
+    state = MockField(value=1)
+    src = InterruptSource(state, name="tx_done")
+
+    with pytest.raises(WaitTimeoutError):
+        src.wait_clear(timeout=0.02, period=0.001)
+
+
+def test_poll_alias_returns_when_pending() -> None:
+    """``poll(period=, timeout=)`` matches §9.1 with the period knob first."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    threading.Timer(0.01, lambda: state.set_hw(1)).start()
+    src.poll(period=0.001, timeout=1.0)
+
+
+def test_aiowait_async_path() -> None:
+    """``aiowait`` is the asyncio dual; it returns when pending."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    async def _runner() -> None:
+        async def flipper() -> None:
+            await asyncio.sleep(0.01)
+            state.set_hw(1)
+
+        await asyncio.gather(flipper(), src.aiowait(timeout=1.0, period=0.001))
+
+    asyncio.run(_runner())
+
+
+def test_aiowait_timeout() -> None:
+    """``aiowait`` raises :class:`WaitTimeoutError` on timeout."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    async def _runner() -> None:
+        await src.aiowait(timeout=0.02, period=0.001)
+
+    with pytest.raises(WaitTimeoutError):
+        asyncio.run(_runner())
+
+
+# ---------------------------------------------------------------------------
+# on_fire subscription
+# ---------------------------------------------------------------------------
+
+
+def test_on_fire_callback_runs_on_rising_edge() -> None:
+    """The callback fires when the state bit transitions 0 → 1."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    fired = threading.Event()
+    calls: list[None] = []
+
+    def _cb() -> None:
+        calls.append(None)
+        fired.set()
+
+    unsub = src.on_fire(_cb, period=0.001)
+    try:
+        # Briefly idle, then assert.
+        time.sleep(0.01)
+        assert not calls  # Stayed at 0 — no firings yet.
+
+        state.set_hw(1)
+        assert fired.wait(timeout=1.0)
+        assert len(calls) == 1
+    finally:
+        unsub()
+
+
+def test_on_fire_unsubscribe_stops_callbacks() -> None:
+    """The unsubscribe handle stops further callbacks."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    calls: list[None] = []
+    unsub = src.on_fire(lambda: calls.append(None), period=0.001)
+    unsub()
+
+    # Give the poller a generous grace window to die out.
+    time.sleep(0.02)
+    state.set_hw(1)
+    time.sleep(0.02)
+
+    assert calls == []
+
+
+def test_on_fire_no_double_fire_while_held_high() -> None:
+    """Holding the source asserted yields a single rising-edge callback."""
+
+    state = MockField(value=0)
+    src = InterruptSource(state, name="tx_done")
+
+    calls: list[None] = []
+    unsub = src.on_fire(lambda: calls.append(None), period=0.001)
+    try:
+        state.set_hw(1)
+        time.sleep(0.05)  # Multiple poll cycles, but one edge.
+        assert len(calls) == 1
+    finally:
+        unsub()
+
+
+# ---------------------------------------------------------------------------
+# InterruptTree (top-level soc.interrupts)
+# ---------------------------------------------------------------------------
+
+
+def test_tree_aggregates_groups() -> None:
+    """``InterruptTree`` exposes groups by attribute and iteration."""
+
+    g1, _, _ = _build_group()
+    g2 = InterruptGroup({"alone": InterruptSource(MockField(0), name="alone")})
+
+    tree = InterruptTree({"uart": g1, "spi": g2})
+
+    assert tree.uart is g1
+    assert tree.spi is g2
+    # InterruptGroup is unhashable-ordered; iterate by identity.
+    iterated = list(tree)
+    assert iterated == [g1, g2]
+    assert len(tree) == 2
+
+
+def test_tree_pending_unions_across_groups() -> None:
+    """Top-level ``pending()`` is the union across every group."""
+
+    g1, state1, _ = _build_group()
+    state1["tx_done"].set_hw(1)
+    g2_state = MockField(value=1, name="alone")
+    g2 = InterruptGroup({"alone": InterruptSource(g2_state, name="alone")})
+
+    tree = InterruptTree({"uart": g1, "spi": g2})
+    pending = tree.pending()
+    names = {s.name for s in pending}
+    assert names == {"tx_done", "alone"}
+
+
+def test_tree_wait_any_returns_first_pending() -> None:
+    """``wait_any`` returns the first observed pending source."""
+
+    g, state_fields, _ = _build_group()
+    tree = InterruptTree({"uart": g})
+
+    threading.Timer(0.01, lambda: state_fields["rx_overflow"].set_hw(1)).start()
+
+    src = tree.wait_any(timeout=1.0, period=0.001)
+    assert src.name == "rx_overflow"
+
+
+def test_tree_wait_any_timeout_raises() -> None:
+    """``wait_any`` raises ``WaitTimeoutError`` when nothing fires."""
+
+    g, _, _ = _build_group()
+    tree = InterruptTree({"uart": g})
+
+    with pytest.raises(WaitTimeoutError):
+        tree.wait_any(timeout=0.02, period=0.001)
+
+
+def test_tree_tree_renders_status() -> None:
+    """``tree()`` renders a human-readable dump of every group."""
+
+    g, state_fields, enable_fields = _build_group()
+    state_fields["tx_done"].set_hw(1)
+    enable_fields["tx_done"].set_hw(1)
+    tree = InterruptTree({"uart": g})
+
+    text = tree.tree()
+    assert "uart:" in text
+    assert "tx_done" in text
+    assert "state=1" in text
+    assert "enable=1" in text
+
+
+# ---------------------------------------------------------------------------
+# Hooks (Unit 1 / Unit 23 seams)
+# ---------------------------------------------------------------------------
+
+
+def test_register_post_create_hook_attaches_tree() -> None:
+    """``register_post_create_hook`` attaches ``soc.interrupts``."""
+
+    g = InterruptGroup({"tx_done": InterruptSource(MockField(0), name="tx_done")})
+    register_interrupt_group("uart", g)
+
+    soc: Any = SimpleNamespace()
+    tree = register_post_create_hook(soc)
+
+    assert isinstance(tree, InterruptTree)
+    assert soc.interrupts is tree
+    assert tree.uart is g
+
+    # Reset for other tests.
+    from peakrdl_pybind11.runtime import interrupts
+
+    interrupts._GROUP_REGISTRY.clear()
+
+
+def test_register_register_enhancement_hook_builds_group() -> None:
+    """The detection-metadata hook synthesises an :class:`InterruptGroup`."""
+
+    state_reg = MockRegister(
+        tx_done=MockField(value=1),
+        rx_overflow=MockField(value=0),
+    )
+    enable_reg = MockRegister(
+        tx_done=MockField(value=1, on_write="rw"),
+        rx_overflow=MockField(value=0, on_write="rw"),
+    )
+    test_reg = MockRegister(
+        tx_done=MockField(value=0, on_write="rw"),
+        rx_overflow=MockField(value=0, on_write="rw"),
+    )
+    parent = SimpleNamespace()
+    state_reg.parent = parent  # type: ignore[attr-defined]
+    state_reg.path = "uart.intr_state"  # type: ignore[attr-defined]
+
+    info = SimpleNamespace(
+        is_interrupt_state=True,
+        enable_register=enable_reg,
+        test_register=test_reg,
+    )
+
+    group = register_register_enhancement_hook(state_reg, info)
+
+    assert isinstance(group, InterruptGroup)
+    assert parent.interrupts is group
+    assert group.tx_done.is_pending() is True
+
+    # Reset for other tests.
+    from peakrdl_pybind11.runtime import interrupts
+
+    interrupts._GROUP_REGISTRY.clear()
+
+
+def test_register_register_enhancement_hook_skips_non_interrupt() -> None:
+    """Non-interrupt registers are passed through untouched."""
+
+    reg = MockRegister(field=MockField(0))
+    info = SimpleNamespace(is_interrupt_state=False)
+
+    assert register_register_enhancement_hook(reg, info) is None

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-pybind11"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Adds the marquee interrupt runtime per [IDEAL_API_SKETCH](docs/IDEAL_API_SKETCH.md) §9: `InterruptSource`, `InterruptGroup`, and `InterruptTree`. Detection of the `INTR_STATE`/`INTR_ENABLE`/`INTR_TEST` trio remains Unit 23 (exporter plugin); this is the pure-Python runtime that consumes the detected metadata.
- `InterruptSource`: `is_pending`/`is_enabled`/`enable`/`disable`/`clear` (with `woclr`/`wzc`/`rclr` semantics)/`acknowledge`/`fire` (write `INTR_TEST`), plus the wait family (`wait`, `wait_clear`, `aiowait`, `poll`) and `on_fire` subscription (rising-edge polling fallback; backend hook for native IRQs).
- `InterruptGroup`: named-attribute access, iteration, `pending()`/`enabled()` frozensets, `clear_all`/`disable_all`/`enable(set_={...})`, `snapshot()`, and the `InterruptGroup.manual(state, enable, test)` factory for chips where auto-detection fails.
- `InterruptTree` (top-level `soc.interrupts`): `pending()` across all blocks, `wait_any(timeout=...)`, and `tree()` pretty-print.
- Hooks: `register_post_create_hook` (Unit 1's seam — wires `soc.interrupts`) and `register_register_enhancement_hook` (Unit 23's seam — per-regfile `.interrupts` attachment from detection metadata).
- Ships a minimal `runtime/errors.py` with `WaitTimeoutError` so the unit stands alone; Unit 2 (`feat/errors`) supersedes this stub on merge.

## Test plan

- [x] `pytest tests/runtime/test_interrupts.py -v` — 43/43 pass
- [x] Full suite (excluding integration tests that need C++ build) — 115 pass, 14 pre-existing skips
- [x] `ruff check src/peakrdl_pybind11/runtime/` clean
- [x] `ruff format` applied
- [ ] Integration with Unit 23 detection metadata (waits on Unit 23 landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)