### PR TITLE
feat(runtime): master region routing (Unit 19)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,24 @@
+"""Runtime helpers layered on top of generated bindings.
+
+The :mod:`peakrdl_pybind11.runtime` package collects pure-Python pieces that
+sit *above* a generated module and don't depend on any specific chip:
+routing, transactions, observers, snapshots, etc.
+"""
+
+from __future__ import annotations
+
+from .routing import (
+    NodeLike,
+    Router,
+    RoutingError,
+    RoutingRule,
+    attach_master,
+)
+
+__all__ = [
+    "NodeLike",
+    "Router",
+    "RoutingError",
+    "RoutingRule",
+    "attach_master",
+]

--- a/src/peakrdl_pybind11/runtime/routing.py
+++ b/src/peakrdl_pybind11/runtime/routing.py
@@ -1,0 +1,491 @@
+"""Composable region-based master routing.
+
+Implements the bus-master routing layer described in
+``docs/IDEAL_API_SKETCH.md`` §13.1. A :class:`Router` accepts one or
+more masters, each tied to a *region* of the SoC's address space, and
+dispatches each ``read``/``write`` to the master whose region contains
+the target address.
+
+Regions can be specified four ways via ``where=``:
+
+* ``where=None`` — catch-all default; the master serves the entire tree.
+* ``where="peripherals.uart.*"`` — fnmatch-style glob on node paths.
+* ``where=lambda node: node.info.is_external`` — callable predicate.
+* ``where=(0x4000_0000, 0x5000_0000)`` — half-open ``[start, end)`` range.
+
+When several rules match the same address, the *most-specific* one wins:
+
+1. An explicit address-range tuple beats any glob, predicate, or catch-all
+   (smaller ranges break ties between two range tuples).
+2. A glob beats any predicate or catch-all. Globs with more literal
+   path segments beat globs with fewer (``peripherals.uart.*`` (2 literal
+   segments) beats ``peripherals.*`` (1) beats ``*`` (0)).
+3. A predicate beats only the catch-all.
+4. Any explicit ``where=`` beats ``where=None``.
+5. On any remaining tie, the first-registered rule wins (stable).
+
+Sibling-unit notes
+------------------
+The ideal API in §13.1 wires the router via a ``register_post_create``
+seam exposed by Unit 1. That seam doesn't yet exist on
+``exp/api_overhaul``; this module ships :class:`Router` and the free
+function :func:`attach_master` standalone, so generated SoC objects (or
+hand-rolled fakes) can plug it in directly. When Unit 2 lands its
+project-wide :class:`RoutingError` in a shared ``runtime/errors.py``,
+the definition here will be replaced by a re-export.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..masters.base import AccessOp
+
+
+@runtime_checkable
+class _NodeInfo(Protocol):
+    """Subset of ``node.info`` (§4.2) used by the router.
+
+    Real generated nodes expose far more; tests only need these four.
+    """
+
+    path: str
+    address: int
+    size: int
+    is_external: bool
+
+
+@runtime_checkable
+class NodeLike(Protocol):
+    """Subset of an SoC node the router traverses.
+
+    ``walk()`` must yield ``self`` followed by every descendant.
+    Generated nodes will satisfy this once Unit 4 lands; tests stub it
+    with plain dataclasses.
+    """
+
+    @property
+    def info(self) -> _NodeInfo: ...
+
+    def walk(self) -> Iterable[NodeLike]: ...
+
+
+@runtime_checkable
+class MasterLike(Protocol):
+    """Subset of :class:`~peakrdl_pybind11.masters.base.MasterBase` used here."""
+
+    def read(self, address: int, width: int) -> int: ...
+
+    def write(self, address: int, value: int, width: int) -> None: ...
+
+
+WhereGlob = str
+WherePredicate = Callable[[NodeLike], bool]
+WhereRange = tuple[int, int]
+Where = WhereGlob | WherePredicate | WhereRange | None
+
+
+class _Tier(IntEnum):
+    """Specificity tier for a rule. Higher beats lower."""
+
+    CATCH_ALL = 0
+    PREDICATE = 1
+    GLOB = 2
+    RANGE = 3
+
+
+class RoutingError(LookupError):
+    """No attached master serves the requested address.
+
+    Raised by :meth:`Router.read` and :meth:`Router.write` when no rule
+    matches *and* no catch-all is attached. The error carries the
+    offending address so callers can render whatever context they want.
+
+    Unit 2 will eventually own a project-wide :class:`RoutingError`;
+    until then this class lives here and is re-exported from
+    :mod:`peakrdl_pybind11.runtime`.
+    """
+
+    def __init__(self, address: int, message: str | None = None) -> None:
+        self.address = int(address)
+        if message is None:
+            message = f"no master attached for 0x{self.address:08x}"
+        else:
+            message = f"{message} (addr=0x{self.address:08x})"
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class _Range:
+    """Half-open ``[start, end)`` address range."""
+
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if self.end <= self.start:
+            raise ValueError(
+                f"range end (0x{self.end:x}) must be strictly greater than "
+                f"start (0x{self.start:x})"
+            )
+
+    def contains(self, addr: int) -> bool:
+        return self.start <= addr < self.end
+
+    @property
+    def size(self) -> int:
+        return self.end - self.start
+
+
+def _glob_specificity(pattern: str) -> int:
+    """Number of literal (non-wildcard) dot-separated segments in ``pattern``.
+
+    Wildcard metacharacters: ``*``, ``?``, ``[``. Used to break ties
+    between overlapping globs — more literal segments beats fewer.
+    """
+
+    return sum(
+        1
+        for seg in pattern.split(".")
+        if seg and not any(c in seg for c in "*?[")
+    )
+
+
+@dataclass
+class RoutingRule:
+    """One ``(predicate-or-region, master)`` mapping inside a :class:`Router`.
+
+    Created by :meth:`Router.attach_master`; users normally don't
+    construct this directly. Stored fields:
+
+    - ``master`` — the bus master to dispatch to.
+    - ``where`` — the original ``where=`` argument (also drives dispatch).
+    - ``ranges`` — pre-resolved address ranges (empty for catch-all).
+    - ``order`` — insertion order, used for stable tie-breaking.
+    """
+
+    master: MasterLike
+    where: Where = None
+    ranges: tuple[_Range, ...] = field(default_factory=tuple)
+    order: int = 0
+
+    @property
+    def is_catch_all(self) -> bool:
+        return self.where is None
+
+    def matches_address(self, addr: int) -> bool:
+        if self.is_catch_all:
+            return True
+        return any(r.contains(addr) for r in self.ranges)
+
+    def specificity(self) -> tuple[int, int]:
+        """Specificity score as ``(tier, sub-rank)``; higher beats lower.
+
+        ``sub-rank`` only matters between two rules in the same tier:
+
+        - ``RANGE``: ``-size`` of the range, so the smallest range wins.
+        - ``GLOB``: literal-segment count from :func:`_glob_specificity`.
+        - ``PREDICATE`` / ``CATCH_ALL``: always 0; the surrounding tie-
+          breaker (``order``) decides.
+        """
+
+        where = self.where
+        if where is None:
+            return (_Tier.CATCH_ALL, 0)
+        if isinstance(where, tuple):
+            size = self.ranges[0].size if self.ranges else 0
+            return (_Tier.RANGE, -size)
+        if isinstance(where, str):
+            return (_Tier.GLOB, _glob_specificity(where))
+        # callable predicate
+        return (_Tier.PREDICATE, 0)
+
+
+class Router:
+    """Region-based dispatch over multiple bus masters.
+
+    A :class:`Router` is itself a :class:`MasterLike`-shaped object: it
+    exposes :meth:`read`, :meth:`write`, :meth:`read_many`, and
+    :meth:`write_many`, and forwards each call to the master whose
+    attached region contains the target address.
+
+    Construct it with an optional catch-all default
+    (``Router(default)``), then add region rules with
+    :meth:`attach_master`.
+
+    Example::
+
+        router = Router()
+        router.attach_master(jtag, where="peripherals.uart.*", soc=soc)
+        router.attach_master(mem_master, where=(0x4000_0000, 0x4001_0000))
+        router.attach_master(MockMaster(),
+                             where=lambda n: n.info.is_external,
+                             soc=soc)
+        router.read(0x4000_1000, width=4)
+
+    Glob and predicate rules walk ``soc`` once at attach time and cache
+    the matching ``(start, end)`` ranges, so the per-access path never
+    needs an address-to-node reverse lookup. Range tuples and
+    ``where=None`` don't need a tree.
+    """
+
+    def __init__(self, default_master: MasterLike | None = None) -> None:
+        self._rules: list[RoutingRule] = []
+        self._next_order = 0
+        if default_master is not None:
+            self._attach_rule(default_master, where=None)
+
+    def __repr__(self) -> str:
+        rules = ", ".join(
+            f"{r.where!r}->{type(r.master).__name__}" for r in self._rules
+        )
+        return f"Router({rules})"
+
+    # ------------------------------------------------------------------
+    # Public API: attaching masters
+    # ------------------------------------------------------------------
+    def attach_master(
+        self,
+        master: MasterLike,
+        where: Where = None,
+        *,
+        soc: NodeLike | None = None,
+    ) -> RoutingRule:
+        """Attach ``master`` to serve all addresses matching ``where``.
+
+        See the module docstring for the four shapes ``where`` can take.
+        Glob and predicate forms walk ``soc`` at attach time to resolve
+        the matching set of address ranges; pass ``soc=`` for those
+        forms. Range tuples and ``where=None`` don't require a tree.
+        """
+
+        return self._attach_rule(master, where=where, soc=soc)
+
+    def _attach_rule(
+        self,
+        master: MasterLike,
+        where: Where,
+        soc: NodeLike | None = None,
+    ) -> RoutingRule:
+        ranges = self._resolve_ranges(where, soc)
+        rule = RoutingRule(
+            master=master,
+            where=where,
+            ranges=ranges,
+            order=self._next_order,
+        )
+        self._next_order += 1
+        self._rules.append(rule)
+        return rule
+
+    @staticmethod
+    def _resolve_ranges(where: Where, soc: NodeLike | None) -> tuple[_Range, ...]:
+        if where is None:
+            return ()
+        if isinstance(where, tuple):
+            start, end = where
+            return (_Range(int(start), int(end)),)
+        if isinstance(where, str):
+            if soc is None:
+                raise ValueError(
+                    "glob 'where=' requires soc=; pass the SoC root so the "
+                    "router can resolve matching addresses at attach time"
+                )
+            return _resolve_glob(soc, where)
+        if callable(where):
+            if soc is None:
+                raise ValueError(
+                    "predicate 'where=' requires soc=; pass the SoC root so "
+                    "the router can resolve matching addresses at attach time"
+                )
+            return _resolve_predicate(soc, where)
+        raise TypeError(
+            f"where= must be None, a glob string, a (start, end) tuple, "
+            f"or a callable predicate; got {type(where).__name__}"
+        )
+
+    # ------------------------------------------------------------------
+    # Public API: bus operations
+    # ------------------------------------------------------------------
+    def read(self, address: int, width: int = 4) -> int:
+        return self._lookup(address).master.read(address, width)
+
+    def write(self, address: int, value: int, width: int = 4) -> None:
+        self._lookup(address).master.write(address, value, width)
+
+    def read_many(self, ops: Sequence[AccessOp]) -> list[int]:
+        return [self._lookup(op.address).master.read(op.address, op.width) for op in ops]
+
+    def write_many(self, ops: Sequence[AccessOp]) -> None:
+        for op in ops:
+            self._lookup(op.address).master.write(op.address, op.value, op.width)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    @property
+    def rules(self) -> tuple[RoutingRule, ...]:
+        return tuple(self._rules)
+
+    def master_for(self, address: int) -> MasterLike:
+        """Master that would service ``address``; raises :class:`RoutingError`."""
+
+        return self._lookup(address).master
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _lookup(self, address: int) -> RoutingRule:
+        addr = int(address)
+        best: RoutingRule | None = None
+        best_score: tuple[int, int, int] | None = None
+        for rule in self._rules:
+            if not rule.matches_address(addr):
+                continue
+            tier, sub = rule.specificity()
+            # Negate ``order`` so first-registered (lowest order) wins
+            # under tuple comparison.
+            score = (tier, sub, -rule.order)
+            if best_score is None or score > best_score:
+                best = rule
+                best_score = score
+        if best is None:
+            raise RoutingError(addr)
+        return best
+
+
+# ----------------------------------------------------------------------
+# Tree walking helpers
+# ----------------------------------------------------------------------
+def _walk(node: NodeLike) -> Iterator[NodeLike]:
+    """Yield every node in ``node.walk()``, plus the root if missing.
+
+    The :class:`NodeLike` contract says ``walk()`` yields ``self`` then
+    descendants, but real generated trees may eventually choose either
+    convention. We materialise the iterable, prepend the root if it's
+    not already first, and de-duplicate by ``id`` so callers are robust
+    to either shape.
+    """
+
+    try:
+        seq = list(node.walk())
+    except (AttributeError, TypeError):
+        seq = []
+    if not seq or seq[0] is not node:
+        seq.insert(0, node)
+
+    seen: set[int] = set()
+    for n in seq:
+        key = id(n)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield n
+
+
+def _node_range(node: NodeLike) -> _Range | None:
+    """``[address, address+size)`` for ``node``, or ``None`` if missing/invalid."""
+
+    info = getattr(node, "info", None)
+    if info is None:
+        return None
+    addr = getattr(info, "address", None)
+    size = getattr(info, "size", None)
+    if addr is None or size is None or size <= 0:
+        return None
+    return _Range(int(addr), int(addr) + int(size))
+
+
+def _coalesce(ranges: Iterable[_Range]) -> tuple[_Range, ...]:
+    """Merge overlapping/adjacent ``_Range`` objects."""
+
+    sorted_ranges = sorted(ranges, key=lambda r: (r.start, r.end))
+    merged: list[_Range] = []
+    for r in sorted_ranges:
+        if merged and r.start <= merged[-1].end:
+            last = merged[-1]
+            merged[-1] = _Range(last.start, max(last.end, r.end))
+        else:
+            merged.append(r)
+    return tuple(merged)
+
+
+def _resolve_glob(root: NodeLike, pattern: str) -> tuple[_Range, ...]:
+    """Merged address ranges of nodes whose ``info.path`` matches ``pattern``."""
+
+    out: list[_Range] = []
+    for node in _walk(root):
+        info = getattr(node, "info", None)
+        path = getattr(info, "path", None) if info is not None else None
+        if not isinstance(path, str):
+            continue
+        if fnmatch.fnmatchcase(path, pattern):
+            rng = _node_range(node)
+            if rng is not None:
+                out.append(rng)
+    return _coalesce(out)
+
+
+def _resolve_predicate(
+    root: NodeLike,
+    predicate: WherePredicate,
+) -> tuple[_Range, ...]:
+    """Merged address ranges of nodes for which ``predicate`` is truthy."""
+
+    out: list[_Range] = []
+    for node in _walk(root):
+        try:
+            ok = bool(predicate(node))
+        except Exception:
+            # User-supplied predicates may raise on unrelated nodes
+            # (e.g. ``n.info.is_external`` on a node without that
+            # attribute). Skip rather than abort the whole attach.
+            ok = False
+        if not ok:
+            continue
+        rng = _node_range(node)
+        if rng is not None:
+            out.append(rng)
+    return _coalesce(out)
+
+
+# ----------------------------------------------------------------------
+# Free-function entry point — the API sketch §13.1 spells
+# ``soc.attach_master(...)``, but Unit 1's post-create seam isn't here
+# yet. This helper installs a Router on any SoC that exposes a
+# writable ``master`` attribute, so callers can use the sketch's API
+# verbatim today.
+# ----------------------------------------------------------------------
+def attach_master(
+    soc: NodeLike,
+    master: MasterLike,
+    where: Where = None,
+) -> Router:
+    """Attach ``master`` to ``soc`` via a :class:`Router`.
+
+    If ``soc.master`` is already a :class:`Router`, the new rule is
+    added to it. Otherwise this creates a fresh router seeded with the
+    existing ``soc.master`` (if any) as the catch-all default, replaces
+    ``soc.master`` with the router, and adds the new rule.
+    """
+
+    existing = getattr(soc, "master", None)
+    if isinstance(existing, Router):
+        router = existing
+    else:
+        router = Router(default_master=existing)
+        try:
+            soc.master = router  # type: ignore[attr-defined]
+        except AttributeError as exc:
+            raise TypeError(
+                f"cannot install Router on {type(soc).__name__}: "
+                f"'master' attribute is not assignable"
+            ) from exc
+
+    router.attach_master(master, where=where, soc=soc)
+    return router

--- a/tests/runtime/test_routing.py
+++ b/tests/runtime/test_routing.py
@@ -1,0 +1,383 @@
+"""Unit-19 tests for :mod:`peakrdl_pybind11.runtime.routing`.
+
+The router is exercised against a hand-rolled fake node tree (plain
+dataclasses) so the tests don't depend on the exporter or any sibling
+unit. Each test asserts the public contract spelled out in the API
+sketch §13.1: where=glob, where=range, where=predicate, miss raises,
+most-specific match wins.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+import pytest
+
+from peakrdl_pybind11.runtime.routing import (
+    Router,
+    RoutingError,
+    attach_master,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding: minimal node + master fakes.
+# ---------------------------------------------------------------------------
+@dataclass
+class FakeInfo:
+    path: str
+    address: int
+    size: int
+    is_external: bool = False
+
+
+@dataclass
+class FakeNode:
+    info: FakeInfo
+    children: list[FakeNode] = field(default_factory=list)
+
+    def walk(self) -> Iterable[FakeNode]:
+        # NodeLike contract: yield self + every descendant.
+        yield self
+        for child in self.children:
+            yield from child.walk()
+
+
+class RecordingMaster:
+    """Captures every read/write so tests can assert on dispatch."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.reads: list[tuple[int, int]] = []
+        self.writes: list[tuple[int, int, int]] = []
+
+    def read(self, address: int, width: int = 4) -> int:
+        self.reads.append((address, width))
+        # Encode the master identity in the readback so tests can
+        # assert on it without checking ``self.reads``.
+        return (id(self) & 0xFFFF_0000) | (address & 0xFFFF)
+
+    def write(self, address: int, value: int, width: int = 4) -> None:
+        self.writes.append((address, value, width))
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"RecordingMaster({self.name!r})"
+
+
+# ---------------------------------------------------------------------------
+# A small SoC tree the tests reuse:
+#   soc                       0x4000_0000 (size 0x1_0000)
+#   ├── uart                  0x4000_1000 (size 0x100)
+#   │   ├── control           0x4000_1000 (size 4)
+#   │   └── data              0x4000_1004 (size 4)
+#   ├── ram                   0x4000_2000 (size 0x1000)
+#   │   └── word0             0x4000_2000 (size 4)
+#   └── ext_block (external)  0x4000_5000 (size 0x10)
+# ---------------------------------------------------------------------------
+def make_soc() -> FakeNode:
+    uart_control = FakeNode(FakeInfo("uart.control", 0x4000_1000, 4))
+    uart_data = FakeNode(FakeInfo("uart.data", 0x4000_1004, 4))
+    uart = FakeNode(
+        FakeInfo("uart", 0x4000_1000, 0x100),
+        children=[uart_control, uart_data],
+    )
+
+    ram_word = FakeNode(FakeInfo("ram[0]", 0x4000_2000, 4))
+    ram = FakeNode(
+        FakeInfo("ram", 0x4000_2000, 0x1000),
+        children=[ram_word],
+    )
+
+    ext = FakeNode(FakeInfo("ext_block", 0x4000_5000, 0x10, is_external=True))
+    soc = FakeNode(
+        FakeInfo("soc", 0x4000_0000, 0x1_0000),
+        children=[uart, ram, ext],
+    )
+    return soc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_glob_dispatch_uart_vs_ram() -> None:
+    """`attach_master(jtag, where="uart.*")` and a separate `where="ram"`
+    rule must route correctly."""
+
+    soc = make_soc()
+    jtag = RecordingMaster("jtag")
+    mem = RecordingMaster("mem")
+
+    router = Router()
+    router.attach_master(jtag, where="uart.*", soc=soc)
+    router.attach_master(mem, where="ram", soc=soc)
+
+    # Read on uart.control goes to jtag.
+    router.read(0x4000_1000)
+    assert jtag.reads == [(0x4000_1000, 4)]
+    assert mem.reads == []
+
+    # Read on ram[0] goes to mem.
+    router.read(0x4000_2000)
+    assert mem.reads == [(0x4000_2000, 4)]
+
+    # Writes route the same way.
+    router.write(0x4000_1004, 0xC0FFEE)
+    assert jtag.writes == [(0x4000_1004, 0xC0FFEE, 4)]
+
+
+def test_address_range_routing() -> None:
+    """`where=(start, end)` half-open range matches addresses in range."""
+
+    soc = make_soc()
+    inside = RecordingMaster("inside")
+    fallback = RecordingMaster("fallback")
+
+    router = Router(default_master=fallback)
+    router.attach_master(inside, where=(0x4000_0000, 0x4001_0000))
+
+    # Inside [start, end): range master.
+    router.read(0x4000_0000)
+    router.read(0x4000_FFFC)
+    assert len(inside.reads) == 2
+    assert fallback.reads == []
+
+    # `end` is exclusive — addr == end falls through to default.
+    router.read(0x4001_0000)
+    assert fallback.reads == [(0x4001_0000, 4)]
+
+
+def test_predicate_routing_is_external() -> None:
+    """`where=lambda n: n.info.is_external` matches external nodes."""
+
+    soc = make_soc()
+    ext_master = RecordingMaster("ext")
+    default = RecordingMaster("default")
+
+    router = Router(default_master=default)
+    router.attach_master(
+        ext_master,
+        where=lambda n: n.info.is_external,
+        soc=soc,
+    )
+
+    # ext_block is external — routes to ext_master.
+    router.read(0x4000_5000)
+    assert ext_master.reads == [(0x4000_5000, 4)]
+    assert default.reads == []
+
+    # uart.control isn't — falls back to default.
+    router.read(0x4000_1000)
+    assert default.reads == [(0x4000_1000, 4)]
+
+
+def test_routing_miss_raises() -> None:
+    """No matching rule and no catch-all -> RoutingError with the addr."""
+
+    router = Router()  # no default
+    router.attach_master(
+        RecordingMaster("range"),
+        where=(0x4000_0000, 0x4000_1000),
+    )
+
+    with pytest.raises(RoutingError) as exc_info:
+        router.read(0x9999_9999)
+
+    assert exc_info.value.address == 0x9999_9999
+    msg = str(exc_info.value)
+    assert "no master attached" in msg
+    assert "9999" in msg or "0x99999999" in msg
+
+
+def test_most_specific_match_wins_overlapping_ranges() -> None:
+    """Smaller range beats larger range when both contain the address."""
+
+    soc = make_soc()
+    wide = RecordingMaster("wide")
+    narrow = RecordingMaster("narrow")
+
+    router = Router()
+    router.attach_master(wide, where=(0x4000_0000, 0x5000_0000))
+    router.attach_master(narrow, where=(0x4000_1000, 0x4000_1100))
+
+    # 0x4000_1000 is in both ranges; narrow wins.
+    router.read(0x4000_1000)
+    assert narrow.reads == [(0x4000_1000, 4)]
+    assert wide.reads == []
+
+    # 0x4000_2000 is only in the wide range.
+    router.read(0x4000_2000)
+    assert wide.reads == [(0x4000_2000, 4)]
+
+
+def test_most_specific_match_wins_overlapping_globs() -> None:
+    """Longer-prefix glob beats shorter-prefix glob (segment count)."""
+
+    soc = make_soc()
+    broad = RecordingMaster("broad")
+    narrow = RecordingMaster("narrow")
+
+    router = Router()
+    router.attach_master(broad, where="*", soc=soc)
+    router.attach_master(narrow, where="uart.*", soc=soc)
+
+    router.read(0x4000_1000)  # matches uart.control via uart.* AND *
+    assert narrow.reads == [(0x4000_1000, 4)]
+    assert broad.reads == []
+
+
+def test_explicit_beats_catch_all() -> None:
+    """Any `where=` beats `where=None` (the default master)."""
+
+    soc = make_soc()
+    explicit = RecordingMaster("explicit")
+    default = RecordingMaster("default")
+
+    router = Router(default_master=default)
+    router.attach_master(
+        explicit,
+        where=lambda n: n.info.path == "uart.control",
+        soc=soc,
+    )
+
+    router.read(0x4000_1000)
+    assert explicit.reads == [(0x4000_1000, 4)]
+    assert default.reads == []
+
+
+def test_first_registered_breaks_tie() -> None:
+    """When two equally-specific rules match, the first one registered wins."""
+
+    soc = make_soc()
+    first = RecordingMaster("first")
+    second = RecordingMaster("second")
+
+    router = Router()
+    router.attach_master(first, where=(0x4000_0000, 0x4001_0000))
+    router.attach_master(second, where=(0x4000_0000, 0x4001_0000))
+
+    router.read(0x4000_1000)
+    assert first.reads == [(0x4000_1000, 4)]
+    assert second.reads == []
+
+
+def test_range_beats_glob_of_same_size() -> None:
+    """An explicit range tuple is treated as more specific than a glob."""
+
+    # uart subtree: 0x4000_1000..0x4000_1100 (size 0x100), same as the
+    # range tuple below.
+    soc = make_soc()
+    range_master = RecordingMaster("range")
+    glob_master = RecordingMaster("glob")
+
+    router = Router()
+    router.attach_master(glob_master, where="uart", soc=soc)
+    router.attach_master(range_master, where=(0x4000_1000, 0x4000_1100))
+
+    router.read(0x4000_1000)
+    assert range_master.reads == [(0x4000_1000, 4)]
+    assert glob_master.reads == []
+
+
+def test_attach_master_helper_installs_router() -> None:
+    """The free function replaces ``soc.master`` with a Router."""
+
+    soc = make_soc()
+    soc.master = RecordingMaster("default")  # type: ignore[attr-defined]
+    explicit = RecordingMaster("explicit")
+
+    router = attach_master(soc, explicit, where="uart.*")
+    assert soc.master is router  # type: ignore[attr-defined]
+
+    # Calling attach_master again reuses the existing router.
+    second = RecordingMaster("second")
+    router2 = attach_master(soc, second, where="ram")
+    assert router2 is router
+
+    # Routing still works through the installed router.
+    router.read(0x4000_1000)
+    assert explicit.reads == [(0x4000_1000, 4)]
+    router.read(0x4000_2000)
+    assert second.reads == [(0x4000_2000, 4)]
+
+
+def test_glob_resolves_only_through_walk() -> None:
+    """Glob requires soc=; without it, attach_master raises."""
+
+    router = Router()
+    with pytest.raises(ValueError, match="soc="):
+        router.attach_master(RecordingMaster("x"), where="uart.*")
+
+
+def test_predicate_requires_soc() -> None:
+    """Same for predicate-form `where=`."""
+
+    router = Router()
+    with pytest.raises(ValueError, match="soc="):
+        router.attach_master(
+            RecordingMaster("x"),
+            where=lambda n: True,
+        )
+
+
+def test_invalid_where_type_raises() -> None:
+    """Anything other than None/str/tuple/callable is a TypeError."""
+
+    router = Router()
+    with pytest.raises(TypeError, match="where="):
+        router.attach_master(RecordingMaster("x"), where=42)  # type: ignore[arg-type]
+
+
+def test_range_must_be_non_empty() -> None:
+    """Empty/inverted ranges are rejected at attach time."""
+
+    router = Router()
+    with pytest.raises(ValueError):
+        router.attach_master(
+            RecordingMaster("x"),
+            where=(0x4000_1000, 0x4000_1000),  # end == start, half-open is empty
+        )
+
+
+def test_master_for_returns_master() -> None:
+    """`master_for(addr)` exposes the resolution without a bus call."""
+
+    soc = make_soc()
+    explicit = RecordingMaster("explicit")
+    router = Router()
+    router.attach_master(explicit, where="uart.*", soc=soc)
+
+    assert router.master_for(0x4000_1000) is explicit
+    with pytest.raises(RoutingError):
+        router.master_for(0x4000_2000)
+
+
+def test_read_many_dispatches_per_address() -> None:
+    """Each entry in a batched read is dispatched to its own master."""
+
+    from peakrdl_pybind11.masters.base import AccessOp
+
+    soc = make_soc()
+    jtag = RecordingMaster("jtag")
+    mem = RecordingMaster("mem")
+    router = Router()
+    router.attach_master(jtag, where="uart.*", soc=soc)
+    router.attach_master(mem, where="ram", soc=soc)
+
+    ops = [
+        AccessOp(address=0x4000_1000, width=4),
+        AccessOp(address=0x4000_2000, width=4),
+        AccessOp(address=0x4000_1004, width=4),
+    ]
+    out = router.read_many(ops)
+    assert len(out) == 3
+    assert jtag.reads == [(0x4000_1000, 4), (0x4000_1004, 4)]
+    assert mem.reads == [(0x4000_2000, 4)]
+
+
+def test_routing_error_carries_address_attribute() -> None:
+    """The exception object exposes `.address` programmatically."""
+
+    err = RoutingError(0xCAFEBABE)
+    assert err.address == 0xCAFEBABE
+    assert "0xcafebabe" in str(err)


### PR DESCRIPTION
## Summary

- Adds `peakrdl_pybind11.runtime.routing` with `Router`, `RoutingRule`, `RoutingError`, and the `attach_master(...)` free function — the composable region-based dispatch layer from `docs/IDEAL_API_SKETCH.md` §13.1.
- Four `where=` forms supported: catch-all (`None`), fnmatch glob on `info.path`, callable predicate, half-open `(start, end)` range tuple. Glob/predicate rules resolve to address ranges at attach time so per-access dispatch is O(rules), no reverse lookup.
- Most-specific match wins: range > glob > predicate > catch-all, with smaller range / longer-prefix glob breaking ties inside a tier, and first-registered breaking remaining ties.
- 17 tests use a hand-rolled `FakeNode` tree, so this unit is independent of sibling Units 1 (`_registry`), 2 (`RoutingError` shared module), and 4 (`info`). Local `RoutingError` is re-exported from `peakrdl_pybind11.runtime`; will collapse into Unit 2's shared definition when that lands.

## Test plan

- [x] `pytest tests/runtime/test_routing.py -v` — 17 passed
- [x] `ruff check src/peakrdl_pybind11/runtime/ tests/runtime/` — clean
- [x] `pytest tests/` (Python-only) — 58 passed, 14 skipped, 0 failed
- [x] Glob dispatch (`uart.*` vs `ram`) — verified
- [x] Address-range routing (half-open `[start, end)`) — verified
- [x] Predicate routing (`is_external`) — verified
- [x] Routing miss raises `RoutingError(addr, ...)` — verified
- [x] Most-specific wins for overlapping ranges and overlapping globs — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)