### PR TITLE
feat(runtime): Jupyter widgets & rich display (Unit 15)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = ["systemrdl-compiler >= 1.30.1", "jinja2"]
 
 [project.optional-dependencies]
 cli = ["peakrdl-cli >= 1.2.3"]
+# Soft deps for the Jupyter / IPython rich-display surface in
+# ``peakrdl_pybind11.runtime.widgets``. Installing this extra is only
+# required if you want ``node.watch(...)`` live monitors -- the
+# ``_repr_html_`` / ``_repr_pretty_`` renderers themselves are pure
+# Python and ship without any extra dependencies.
+notebook = ["ipywidgets >= 8.0"]
 
 [dependency-groups]
 docs = [

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,10 @@
+"""
+peakrdl_pybind11.runtime
+
+Pure-Python runtime helpers consumed by generated SoC modules. Each
+sub-module owns a slice of the public API sketched in
+``docs/IDEAL_API_SKETCH.md`` and wires itself onto the generated classes
+through the registration seam in ``_registry``.
+"""
+
+from __future__ import annotations

--- a/src/peakrdl_pybind11/runtime/_registry.py
+++ b/src/peakrdl_pybind11/runtime/_registry.py
@@ -1,0 +1,85 @@
+"""
+Lightweight registration seam (Unit 1).
+
+Generated modules call into this module at import time to attach
+runtime-only Python features (rich repr, widgets, snapshots, ...) onto
+the C++ register/field/memory classes.
+
+Unit 1 owns this module; other units consume it. If Unit 1 has not
+landed yet on the branch, the surface defined here is intentionally
+minimal: a pair of `register_*_enhancement` functions plus a couple of
+hook lists. Later units can extend the surface without breaking the
+contract documented here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# A "register enhancement" is any callable that takes a generated node
+# class (Reg, Field, Mem, RegFile, AddrMap) and decorates it with extra
+# Python-only attributes/methods. These run once per class at module
+# import time.
+_register_enhancements: list[Callable[[type], None]] = []
+
+# A "master extension" runs once per generated SoC class (the top-level
+# AddrMap). Used for cross-cutting features that need a handle on the
+# whole tree -- for instance, the `watch()` method on snapshots or the
+# `_repr_html_` registered on the SoC root.
+_master_extensions: list[Callable[[type], None]] = []
+
+
+def register_register_enhancement(fn: Callable[[type], None]) -> Callable[[type], None]:
+    """Register *fn* to run on every generated register/field/mem/regfile/addrmap class.
+
+    The function is also returned, so it can be used as a decorator.
+    """
+    _register_enhancements.append(fn)
+    return fn
+
+
+def register_master_extension(fn: Callable[[type], None]) -> Callable[[type], None]:
+    """Register *fn* to run on every generated top-level SoC class.
+
+    The function is also returned, so it can be used as a decorator.
+    """
+    _master_extensions.append(fn)
+    return fn
+
+
+def apply_register_enhancements(cls: type) -> None:
+    """Apply every registered enhancement to *cls*. Called by generated modules."""
+    for fn in _register_enhancements:
+        fn(cls)
+
+
+def apply_master_extensions(cls: type) -> None:
+    """Apply every registered master-level extension to *cls*. Called by generated modules."""
+    for fn in _master_extensions:
+        fn(cls)
+
+
+def _reset_for_tests() -> None:
+    """Drop all registrations. Test-only escape hatch."""
+    _register_enhancements.clear()
+    _master_extensions.clear()
+
+
+# Public re-exports for type-checkers / IDE completion.
+__all__ = [
+    "apply_master_extensions",
+    "apply_register_enhancements",
+    "register_master_extension",
+    "register_register_enhancement",
+]
+
+
+# Side-effect badge alphabet shared across runtime modules. Kept here so
+# a single import gets the canonical glyph table -- changing them in one
+# place updates every renderer.
+SIDE_EFFECT_BADGES: dict[str, str] = {
+    "rclr": "⚠",          # ⚠ read-clears
+    "singlepulse": "↻",    # ↻ single-pulse
+    "sticky": "✱",         # ✱ sticky
+    "volatile": "⚡",       # ⚡ hardware-volatile
+}

--- a/src/peakrdl_pybind11/runtime/widgets.py
+++ b/src/peakrdl_pybind11/runtime/widgets.py
@@ -1,0 +1,1052 @@
+"""
+Jupyter & rich-display surface (Unit 15).
+
+Implements §5 of ``docs/IDEAL_API_SKETCH.md``:
+
+* ``_repr_html_`` for every node kind (Reg, Field, Mem, RegFile, AddrMap)
+  + ``MemView``, ``SnapshotDiff``, ``InterruptGroup``.
+* ``_repr_pretty_`` for IPython terminals (ANSI-coloured, aligned columns).
+* ``watch(node, period=0.1)`` -- ipywidgets-backed live monitor.
+
+The module is **pure Python** and has **no required third-party
+dependencies**. ``ipywidgets`` is a soft dependency -- importing this
+module with no ipywidgets installed succeeds; only calling :func:`watch`
+raises :class:`NotSupportedError`.
+
+The renderers are intentionally tolerant of missing metadata: when a
+generated node lacks an ``info`` namespace, we fall back to whatever
+attributes the C++ ``RegisterBase``/``FieldBase``/``MemoryBase`` classes
+already expose. That way this module is useful both before and after
+Unit 4 (``info``), Unit 8 (``SnapshotDiff``), Unit 10 (``MemView``) and
+Unit 12 (``InterruptGroup``) land.
+"""
+
+# Renderers operate on duck-typed nodes from generated SoC modules, user
+# subclasses, and test fakes -- no shared base class exists. ``Any`` is
+# the only honest input annotation here.
+# ruff: noqa: ANN401
+
+from __future__ import annotations
+
+import html as _html
+import threading
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from ._registry import (
+    SIDE_EFFECT_BADGES,
+    register_master_extension,
+    register_register_enhancement,
+)
+
+# Soft import of ipywidgets. Only :func:`watch` needs it; the rest of
+# the rich-display surface (HTML repr, pretty repr, hex dumps, diff
+# tables) is pure Python and ships without third-party deps.
+try:  # pragma: no cover - exercised indirectly
+    import ipywidgets  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - exercised in tests via patching
+    ipywidgets = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Local error type. Unit 19 owns the canonical error hierarchy; until it
+# lands we ship a minimal stub here so the public ``raise
+# NotSupportedError("...")`` contract from the API sketch is honoured.
+# ``except Exception`` (the typical user catch-all) still catches it.
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - real Unit 19 error type if available
+    from peakrdl_pybind11.errors import NotSupportedError  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - fallback for unit isolation
+
+    class NotSupportedError(RuntimeError):
+        """Raised when the surrounding environment cannot satisfy a feature.
+
+        Replaced by the canonical ``peakrdl_pybind11.errors.NotSupportedError``
+        once Unit 19 lands.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Style tokens. Inline-styled spans keep the rendered HTML self-contained
+# (no external CSS), which is what JupyterLab and VS Code's notebook
+# viewer expect; both strip <style> blocks aggressively.
+# ---------------------------------------------------------------------------
+_ACCESS_COLORS: dict[str, str] = {
+    "rw": "#1565c0",   # blue
+    "ro": "#616161",   # grey
+    "wo": "#ef6c00",   # orange
+    "na": "#c62828",   # red
+    "rwl": "#1565c0",
+    "r": "#616161",
+    "w": "#ef6c00",
+}
+
+_ANSI_ACCESS_COLORS: dict[str, str] = {
+    "rw": "\x1b[34m",      # blue
+    "ro": "\x1b[37m",      # grey/white
+    "wo": "\x1b[33m",      # orange/yellow
+    "na": "\x1b[31m",      # red
+    "rwl": "\x1b[34m",
+    "r": "\x1b[37m",
+    "w": "\x1b[33m",
+}
+_ANSI_RESET = "\x1b[0m"
+_ANSI_STRIKE = "\x1b[9m"
+
+_TABLE_STYLE = (
+    "border-collapse: collapse; font-family: monospace; "
+    "font-size: 0.85em; margin: 0.25em 0;"
+)
+_CELL_STYLE = "border: 1px solid #d0d0d0; padding: 2px 6px; text-align: left;"
+_HEADER_CELL_STYLE = (
+    f"{_CELL_STYLE} background: #f5f5f5; font-weight: bold;"
+)
+
+
+def _esc(text: Any) -> str:
+    """HTML-escape *text*, coercing to ``str`` first."""
+    return _html.escape(str(text), quote=True)
+
+
+def _access_html(access: str) -> str:
+    """Render an access mode as a coloured (and possibly strikethrough) span."""
+    mode = (access or "rw").lower()
+    color = _ACCESS_COLORS.get(mode, "#1565c0")
+    style = f"color: {color};"
+    if mode == "na":
+        style += " text-decoration: line-through;"
+    return f'<span style="{style}">{_esc(mode)}</span>'
+
+
+def _access_ansi(access: str) -> str:
+    """Render an access mode for an ANSI-capable terminal."""
+    mode = (access or "rw").lower()
+    color = _ANSI_ACCESS_COLORS.get(mode, "")
+    if mode == "na":
+        return f"{color}{_ANSI_STRIKE}{mode}{_ANSI_RESET}"
+    return f"{color}{mode}{_ANSI_RESET}" if color else mode
+
+
+def _badges_for(field: Any) -> list[str]:
+    """Pick the side-effect badge glyphs that apply to *field*.
+
+    The function understands two metadata shapes:
+
+    * ``field.info.on_read``/``on_write`` etc. (target API in §5)
+    * raw RDL-style attributes left over from older descriptor surfaces
+      (``rclr``, ``singlepulse``, ...).
+    """
+    badges: list[str] = []
+    info = getattr(field, "info", None)
+
+    def _truthy(*paths: tuple[str, ...]) -> bool:
+        for path in paths:
+            target: Any = info if info is not None else field
+            for attr in path:
+                target = getattr(target, attr, None)
+                if target is None:
+                    break
+            if target:
+                # Consider both bool truthiness *and* enum/string equality
+                # to the canonical name. A string-valued attribute like
+                # ``on_read = "rclr"`` should match ``rclr`` here.
+                value = str(target).lower()
+                if value not in {"none", "no", "false", "0", ""}:
+                    return True
+        return False
+
+    if _truthy(("on_read",), ("rclr",)):
+        on_read = getattr(info or field, "on_read", "")
+        if "rclr" in str(on_read).lower() or getattr(field, "rclr", False):
+            badges.append(SIDE_EFFECT_BADGES["rclr"])
+
+    if _truthy(("singlepulse",)):
+        badges.append(SIDE_EFFECT_BADGES["singlepulse"])
+
+    if _truthy(("sticky",), ("stickybit",)):
+        badges.append(SIDE_EFFECT_BADGES["sticky"])
+
+    if _truthy(("is_volatile",), ("volatile",)):
+        badges.append(SIDE_EFFECT_BADGES["volatile"])
+
+    return badges
+
+
+def _badge_html(field: Any) -> str:
+    """Inline-render the side-effect badges for *field*."""
+    glyphs = _badges_for(field)
+    if not glyphs:
+        return ""
+    return ' <span title="side-effects">' + " ".join(_esc(g) for g in glyphs) + "</span>"
+
+
+# ---------------------------------------------------------------------------
+# Field metadata helpers. They look at ``field.info.<attr>`` first, then
+# fall back to the raw attribute on the field object. Everything is
+# wrapped in try/except so a partly-built mock can still be rendered.
+# ---------------------------------------------------------------------------
+def _field_attr(field: Any, *names: str, default: Any = None) -> Any:
+    info = getattr(field, "info", None)
+    for name in names:
+        if info is not None:
+            value = getattr(info, name, None)
+            if value is not None:
+                return value
+        value = getattr(field, name, None)
+        if value is not None:
+            return value
+    return default
+
+
+def _has_rclr(field: Any) -> bool:
+    """``True`` iff *field* has ``onread = rclr`` -- i.e. reads destroy state."""
+    return "rclr" in str(_field_attr(field, "on_read", default="")).lower()
+
+
+def _field_bits(field: Any) -> str:
+    """Render the bit range as ``[msb:lsb]`` or ``[bit]``."""
+    lsb = _field_attr(field, "lsb", default=0)
+    width = _field_attr(field, "width", default=1)
+    msb = _field_attr(field, "msb", default=lsb + width - 1)
+    if msb == lsb:
+        return f"[{lsb}]"
+    return f"[{msb}:{lsb}]"
+
+
+def _field_access(field: Any) -> str:
+    """Approximate the textual access mode of *field*."""
+    raw = _field_attr(field, "access")
+    if raw is not None:
+        return str(raw).lower().replace("accessmode.", "").replace(".", "")
+    readable = _field_attr(field, "is_readable", "readable", default=True)
+    writable = _field_attr(field, "is_writable", "writable", default=True)
+    if readable and writable:
+        return "rw"
+    if readable:
+        return "ro"
+    if writable:
+        return "wo"
+    return "na"
+
+
+def _field_value_repr(field: Any) -> str:
+    """Best-effort value rendering for a field. Reads ONLY when safe.
+
+    Rendering never issues a *destructive* read -- the canonical case is
+    ``onread = rclr``. Volatile/sticky/singlepulse fields can be read
+    safely; the value may simply be racy.
+    """
+    if _has_rclr(field):
+        return "-"
+    reader = getattr(field, "read", None)
+    if not callable(reader):
+        return "-"
+    try:
+        value = reader()
+    except Exception:
+        return "-"
+    return _format_value(value)
+
+
+def _format_value(value: Any) -> str:
+    """Render a read-back value in a notebook-friendly form."""
+    # Enum members render as ``Cls.MEMBER (n)``.
+    name = getattr(value, "name", None)
+    if name is not None and hasattr(value, "value"):
+        return f"{type(value).__name__}.{name} ({int(value)})"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return f"{value} (0x{int(value):x})" if value > 9 else str(int(value))
+    return str(value)
+
+
+def _node_kind(node: Any) -> str:
+    """Return a short kind tag for *node*: 'reg', 'field', 'mem', 'regfile', 'addrmap'."""
+    explicit = getattr(node, "_node_kind", None)
+    if explicit is not None:
+        return str(explicit)
+    cls = type(node).__name__.lower()
+    if "field" in cls:
+        return "field"
+    if "memory" in cls or "mem" == cls or cls.endswith("_mem"):
+        return "mem"
+    if "regfile" in cls:
+        return "regfile"
+    if "addrmap" in cls:
+        return "addrmap"
+    if "reg" in cls:
+        return "reg"
+    return "node"
+
+
+def _list_fields(reg: Any) -> list[Any]:
+    """Best-effort enumeration of the field children of *reg*."""
+    info = getattr(reg, "info", None)
+    if info is not None:
+        fields = getattr(info, "fields", None)
+        if fields is not None:
+            try:
+                return list(fields.values())
+            except AttributeError:
+                return list(fields)
+    explicit = getattr(reg, "fields", None)
+    if explicit is None:
+        return []
+    if callable(explicit):
+        try:
+            return list(explicit())
+        except TypeError:
+            return []
+    if isinstance(explicit, dict):
+        return list(explicit.values())
+    try:
+        return list(explicit)
+    except TypeError:
+        return []
+
+
+def _list_children(node: Any) -> list[Any]:
+    """List the direct children of an addrmap/regfile node."""
+    children: list[Any] = []
+    seen: set[int] = set()
+    for attr in dir(node):
+        if attr.startswith("_"):
+            continue
+        try:
+            value = getattr(node, attr)
+        except Exception:
+            continue
+        if value is node or callable(value) or id(value) in seen:
+            continue
+        kind = _node_kind(value)
+        if kind in {"reg", "regfile", "mem", "addrmap"}:
+            seen.add(id(value))
+            children.append(value)
+    return children
+
+
+def _node_address(node: Any) -> int | None:
+    """Return the absolute address of *node*, or ``None`` if unknown."""
+    info = getattr(node, "info", None)
+    if info is not None:
+        addr = getattr(info, "address", None)
+        if isinstance(addr, int):
+            return addr
+    for name in ("address", "absolute_address", "offset"):
+        value = getattr(node, name, None)
+        if isinstance(value, int):
+            return value
+        if callable(value):
+            try:
+                value = value()
+            except TypeError:
+                continue
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def _node_path(node: Any) -> str:
+    """Pretty path/name for *node*."""
+    info = getattr(node, "info", None)
+    if info is not None:
+        path = getattr(info, "path", None)
+        if path:
+            return str(path)
+    for name in ("path", "name", "inst_name"):
+        value = getattr(node, name, None)
+        if isinstance(value, str):
+            return value
+    return type(node).__name__
+
+
+def _node_description(node: Any) -> str:
+    info = getattr(node, "info", None)
+    if info is not None:
+        for attr in ("desc", "description"):
+            value = getattr(info, attr, None)
+            if value:
+                return str(value)
+    for attr in ("desc", "description", "__doc__"):
+        value = getattr(node, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip().splitlines()[0]
+    return ""
+
+
+def _node_access(node: Any) -> str:
+    info = getattr(node, "info", None)
+    if info is not None:
+        value = getattr(info, "access", None)
+        if value is not None:
+            return str(value).lower().replace("accessmode.", "").replace(".", "")
+    fields = _list_fields(node)
+    if not fields:
+        return "rw"
+    has_read = any(_field_attr(f, "is_readable", "readable", default=True) for f in fields)
+    has_write = any(_field_attr(f, "is_writable", "writable", default=True) for f in fields)
+    if has_read and has_write:
+        return "rw"
+    if has_read:
+        return "ro"
+    if has_write:
+        return "wo"
+    return "na"
+
+
+def _format_address(addr: int | None) -> str:
+    return f"0x{addr:08x}" if addr is not None else "?"
+
+
+# ---------------------------------------------------------------------------
+# HTML renderers
+# ---------------------------------------------------------------------------
+def _render_field_row_html(field: Any) -> str:
+    """One ``<tr>`` for a register's HTML table."""
+    name = getattr(field, "name", None) or _field_attr(field, "name", "inst_name", default="?")
+    bits = _field_bits(field)
+    access = _field_access(field)
+    on_read = _field_attr(field, "on_read", default="-") or "-"
+    on_write = _field_attr(field, "on_write", default="-") or "-"
+    desc = _node_description(field) or ""
+    value_repr = _field_value_repr(field)
+    badges = _badge_html(field)
+    cells = [
+        f'<td style="{_CELL_STYLE}">{_esc(bits)}</td>',
+        f'<td style="{_CELL_STYLE}">{_esc(name)}{badges}</td>',
+        f'<td style="{_CELL_STYLE}">{_esc(value_repr)}</td>',
+        f'<td style="{_CELL_STYLE}">{_access_html(access)}</td>',
+        f'<td style="{_CELL_STYLE}">{_esc(on_read)}</td>',
+        f'<td style="{_CELL_STYLE}">{_esc(on_write)}</td>',
+        f'<td style="{_CELL_STYLE}">{_esc(desc)}</td>',
+    ]
+    return "<tr>" + "".join(cells) + "</tr>"
+
+
+_FIELD_HEADERS: tuple[str, ...] = (
+    "Bits",
+    "Field",
+    "Value (decoded)",
+    "Access",
+    "On-read",
+    "On-write",
+    "Description",
+)
+
+
+def _render_register_html(reg: Any) -> str:
+    fields = _list_fields(reg)
+    addr = _node_address(reg)
+    access = _node_access(reg)
+    title = (
+        f"<b>{_esc(_node_path(reg))}</b> @ {_esc(_format_address(addr))} "
+        f"{_access_html(access)}"
+    )
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>' for h in _FIELD_HEADERS
+    )
+    rows = [_render_field_row_html(f) for f in fields]
+    if not rows:
+        rows.append(
+            f'<tr><td colspan="{len(_FIELD_HEADERS)}" style="{_CELL_STYLE}">'
+            "<em>no fields</em></td></tr>"
+        )
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody>"
+        "</table></div>"
+    )
+
+
+def _render_field_html(field: Any) -> str:
+    """A field renders as a single-row table identical to its register row."""
+    title = (
+        f"<b>{_esc(_node_path(field))}</b> "
+        f"{_esc(_field_bits(field))} "
+        f"{_access_html(_field_access(field))}"
+    )
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>' for h in _FIELD_HEADERS
+    )
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{_render_field_row_html(field)}</tbody>"
+        "</table></div>"
+    )
+
+
+def _render_container_html(node: Any, label: str) -> str:
+    """RegFile / AddrMap renderer: list child nodes with their addresses."""
+    addr = _node_address(node)
+    title = f"<b>{_esc(label)}: {_esc(_node_path(node))}</b> @ {_esc(_format_address(addr))}"
+    children = _list_children(node)
+    if not children:
+        return f'<div>{title}<table style="{_TABLE_STYLE}"></table></div>'
+
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>'
+        for h in ("Address", "Kind", "Name", "Access", "Description")
+    )
+    rows = []
+    for child in children:
+        rows.append(
+            "<tr>"
+            f'<td style="{_CELL_STYLE}">{_esc(_format_address(_node_address(child)))}</td>'
+            f'<td style="{_CELL_STYLE}">{_esc(_node_kind(child))}</td>'
+            f'<td style="{_CELL_STYLE}">{_esc(_node_path(child))}</td>'
+            f'<td style="{_CELL_STYLE}">{_access_html(_node_access(child))}</td>'
+            f'<td style="{_CELL_STYLE}">{_esc(_node_description(child))}</td>'
+            "</tr>"
+        )
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody>"
+        "</table></div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MemView -- hex/ASCII dump
+# ---------------------------------------------------------------------------
+def _coerce_bytes(view: Any) -> bytes:
+    """Try every reasonable way to produce a ``bytes`` payload from *view*."""
+    for attr in ("to_bytes", "tobytes", "as_bytes"):
+        meth = getattr(view, attr, None)
+        if callable(meth):
+            try:
+                data = meth()
+                if isinstance(data, (bytes, bytearray, memoryview)):
+                    return bytes(data)
+            except Exception:
+                pass
+
+    # Fall back to ``__iter__`` of int-like values.
+    try:
+        return bytes(int(b) & 0xFF for b in view)
+    except TypeError:
+        pass
+
+    if isinstance(view, (bytes, bytearray, memoryview)):
+        return bytes(view)
+    raise TypeError("Cannot coerce MemView to bytes for rendering")
+
+
+def _ascii_for(byte: int) -> str:
+    return chr(byte) if 0x20 <= byte < 0x7F else "."
+
+
+def _render_memview_html(view: Any) -> str:
+    """Hex/ASCII dump table for a memory view, 16 bytes per row."""
+    base = getattr(view, "base_address", None)
+    if base is None:
+        base = getattr(view, "address", 0) or 0
+    try:
+        data = _coerce_bytes(view)
+    except TypeError as exc:
+        return (
+            "<div><b>MemView</b> "
+            f"<em>{_esc(exc)}</em></div>"
+        )
+
+    title = (
+        f"<b>{_esc(_node_path(view))}</b> "
+        f"@ {_esc(_format_address(int(base)))} "
+        f"({len(data)} bytes)"
+    )
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>'
+        for h in ("Address", "Hex", "ASCII")
+    )
+    rows: list[str] = []
+    for offset in range(0, len(data), 16):
+        chunk = data[offset : offset + 16]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        if len(chunk) < 16:
+            hex_part = hex_part.ljust(16 * 3 - 1)
+        ascii_part = "".join(_ascii_for(b) for b in chunk)
+        addr_label = _format_address(int(base) + offset)
+        rows.append(
+            "<tr>"
+            f'<td style="{_CELL_STYLE}">{_esc(addr_label)}</td>'
+            f'<td style="{_CELL_STYLE}; white-space: pre;">{_esc(hex_part)}</td>'
+            f'<td style="{_CELL_STYLE}; white-space: pre;">{_esc(ascii_part)}</td>'
+            "</tr>"
+        )
+    if not rows:
+        rows.append(
+            f'<tr><td colspan="3" style="{_CELL_STYLE}"><em>empty view</em></td></tr>'
+        )
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody>"
+        "</table></div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SnapshotDiff -- side-by-side comparison
+# ---------------------------------------------------------------------------
+def _diff_entries(diff: Any) -> Sequence[tuple[str, Any, Any]]:
+    """Best-effort: yield ``(path, before, after)`` triples for a diff."""
+    raw = getattr(diff, "entries", None)
+    if raw is None:
+        raw = getattr(diff, "changes", None)
+    if raw is None:
+        raw = getattr(diff, "items", None)
+    if callable(raw):
+        try:
+            raw = raw()
+        except TypeError:
+            raw = None
+    if raw is None:
+        return []
+    out: list[tuple[str, Any, Any]] = []
+    try:
+        iterator = iter(raw)
+    except TypeError:
+        return []
+    for entry in iterator:
+        if isinstance(entry, tuple) and len(entry) == 3:
+            out.append(entry)  # type: ignore[arg-type]
+            continue
+        path = getattr(entry, "path", None) or getattr(entry, "name", "?")
+        before = getattr(entry, "before", None)
+        after = getattr(entry, "after", None)
+        if before is None and after is None and isinstance(entry, dict):
+            path = entry.get("path", path)
+            before = entry.get("before")
+            after = entry.get("after")
+        out.append((str(path), before, after))
+    return out
+
+
+def _render_snapshotdiff_html(diff: Any) -> str:
+    title = "<b>SnapshotDiff</b>"
+    entries = _diff_entries(diff)
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>'
+        for h in ("Path", "Before", "After")
+    )
+    if not entries:
+        body = (
+            f'<tr><td colspan="3" style="{_CELL_STYLE}">'
+            "<em>no differences</em></td></tr>"
+        )
+    else:
+        rows = []
+        for path, before, after in entries:
+            changed = before != after
+            highlight = "background: #fff8c4;" if changed else ""
+            rows.append(
+                "<tr>"
+                f'<td style="{_CELL_STYLE}">{_esc(path)}</td>'
+                f'<td style="{_CELL_STYLE} {highlight}">{_esc(_format_value(before))}</td>'
+                f'<td style="{_CELL_STYLE} {highlight}">{_esc(_format_value(after))}</td>'
+                "</tr>"
+            )
+        body = "".join(rows)
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{body}</tbody>"
+        "</table></div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# InterruptGroup -- matrix view (rows = sources, cols = State/Enable/Test/Pending)
+# ---------------------------------------------------------------------------
+_IRQ_COLUMNS: tuple[str, ...] = ("State", "Enable", "Test", "Pending")
+
+
+def _safe_call(fn: Any) -> Any:
+    if not callable(fn):
+        return fn
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _irq_sources(group: Any) -> list[Any]:
+    sources = getattr(group, "sources", None)
+    if sources is None:
+        sources = getattr(group, "_sources", None)
+    if callable(sources):
+        try:
+            sources = sources()
+        except TypeError:
+            sources = None
+    if sources is None:
+        return []
+    if isinstance(sources, dict):
+        return list(sources.values())
+    try:
+        return list(sources)
+    except TypeError:
+        return []
+
+
+def _irq_cell_value(source: Any, column: str) -> str:
+    state_val = _safe_call(getattr(source, "is_pending", None))
+    enable_val = _safe_call(getattr(source, "is_enabled", None))
+    test_val = getattr(source, "test", None)
+    if column == "State":
+        return _format_value(bool(state_val)) if state_val is not None else "-"
+    if column == "Enable":
+        return _format_value(bool(enable_val)) if enable_val is not None else "-"
+    if column == "Test":
+        if test_val is None:
+            return "-"
+        return _format_value(_safe_call(test_val) if callable(test_val) else test_val)
+    if column == "Pending":
+        if state_val is None or enable_val is None:
+            return "-"
+        return _format_value(bool(state_val) and bool(enable_val))
+    return "-"
+
+
+def _render_interruptgroup_html(group: Any) -> str:
+    title = f"<b>{_esc(_node_path(group))}</b> (interrupts)"
+    sources = _irq_sources(group)
+    header_cells = "".join(
+        f'<th style="{_HEADER_CELL_STYLE}">{_esc(h)}</th>'
+        for h in ("Source", *_IRQ_COLUMNS)
+    )
+    if not sources:
+        body = (
+            f'<tr><td colspan="{len(_IRQ_COLUMNS) + 1}" style="{_CELL_STYLE}">'
+            "<em>no interrupt sources detected</em></td></tr>"
+        )
+    else:
+        rows = []
+        for source in sources:
+            cells = [
+                f'<td style="{_CELL_STYLE}">{_esc(_node_path(source))}</td>'
+            ]
+            pending = (
+                _safe_call(getattr(source, "is_pending", None))
+                and _safe_call(getattr(source, "is_enabled", None))
+            )
+            highlight = "background: #ffe8b3;" if pending else ""
+            for column in _IRQ_COLUMNS:
+                cells.append(
+                    f'<td style="{_CELL_STYLE} {highlight}">'
+                    f'{_esc(_irq_cell_value(source, column))}</td>'
+                )
+            rows.append("<tr>" + "".join(cells) + "</tr>")
+        body = "".join(rows)
+    return (
+        f"<div>{title}"
+        f'<table style="{_TABLE_STYLE}">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{body}</tbody>"
+        "</table></div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level dispatcher
+# ---------------------------------------------------------------------------
+_SPECIAL_RENDERERS: dict[str, Callable[[Any], str]] = {
+    "memview": _render_memview_html,
+    "snapshotdiff": _render_snapshotdiff_html,
+    "interruptgroup": _render_interruptgroup_html,
+}
+
+_KIND_RENDERERS: dict[str, Callable[[Any], str]] = {
+    "field": _render_field_html,
+    "reg": _render_register_html,
+    "mem": _render_memview_html,
+    "regfile": lambda n: _render_container_html(n, "RegFile"),
+    "addrmap": lambda n: _render_container_html(n, "AddrMap"),
+}
+
+
+def render_html(node: Any) -> str:
+    """Render *node* to an HTML string. Public entry point."""
+    explicit = getattr(node, "_widgets_kind", None)
+    if explicit in _SPECIAL_RENDERERS:
+        return _SPECIAL_RENDERERS[explicit](node)
+
+    cls_name = type(node).__name__.lower()
+    for tag, renderer in _SPECIAL_RENDERERS.items():
+        if tag in cls_name:
+            return renderer(node)
+
+    renderer = _KIND_RENDERERS.get(_node_kind(node))
+    if renderer is not None:
+        return renderer(node)
+    return f"<div><pre>{_esc(repr(node))}</pre></div>"
+
+
+# ---------------------------------------------------------------------------
+# IPython terminal renderer (`_repr_pretty_`)
+# ---------------------------------------------------------------------------
+def _pretty_field_line(field: Any) -> str:
+    bits = _field_bits(field)
+    name = getattr(field, "name", None) or _field_attr(field, "name", "inst_name", default="?")
+    access = _access_ansi(_field_access(field))
+    value = _field_value_repr(field)
+    badges = _badges_for(field)
+    badge_str = (" " + " ".join(badges)) if badges else ""
+    desc = _node_description(field)
+    desc_str = f"  -- {desc}" if desc else ""
+    return f"  {bits:<8} {name:<14} {access:<3} {value:<28}{badge_str}{desc_str}"
+
+
+def render_pretty(node: Any) -> str:
+    """Plain-text rendering with ANSI colours, suitable for a terminal."""
+    kind = _node_kind(node)
+    if kind == "reg":
+        addr = _format_address(_node_address(node))
+        access = _access_ansi(_node_access(node))
+        header = f"<Reg {_node_path(node)} @ {addr} {access}>"
+        lines = [header]
+        for field in _list_fields(node):
+            lines.append(_pretty_field_line(field))
+        return "\n".join(lines)
+    if kind == "field":
+        return _pretty_field_line(node).strip()
+    if kind in {"regfile", "addrmap"}:
+        addr = _format_address(_node_address(node))
+        header = f"<{'AddrMap' if kind == 'addrmap' else 'RegFile'} {_node_path(node)} @ {addr}>"
+        children = _list_children(node)
+        lines = [header]
+        for child in children:
+            lines.append(
+                f"  {_format_address(_node_address(child))}  "
+                f"{_node_kind(child):<8} {_node_path(child)}"
+            )
+        return "\n".join(lines)
+    if kind == "mem":
+        return f"<Memory {_node_path(node)} @ {_format_address(_node_address(node))}>"
+    return repr(node)
+
+
+def _ipython_pretty(node: Any, p: Any, cycle: bool) -> None:
+    """Glue compatible with IPython's ``_repr_pretty_`` protocol."""
+    if cycle:
+        p.text(repr(node))
+        return
+    p.text(render_pretty(node))
+
+
+# ---------------------------------------------------------------------------
+# watch() -- live monitor backed by ipywidgets
+# ---------------------------------------------------------------------------
+class Watcher:
+    """Handle returned by :func:`watch`. Call :meth:`stop` to halt polling.
+
+    The watcher owns a daemon thread that ticks every ``period`` seconds
+    and re-renders the target node into its widget. The thread terminates
+    the next time it finishes a render cycle after :meth:`stop` is
+    invoked, or implicitly when the Python interpreter shuts down (it is
+    a daemon).
+    """
+
+    def __init__(
+        self,
+        node: Any,
+        widget: Any,
+        period: float,
+        renderer: Callable[[Any], str],
+    ) -> None:
+        self._node = node
+        self._widget = widget
+        self._period = float(period)
+        self._renderer = renderer
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def widget(self) -> Any:
+        """The underlying ipywidgets widget (so the user can ``display(w)``)."""
+        return self._widget
+
+    @property
+    def period(self) -> float:
+        """Polling interval, seconds."""
+        return self._period
+
+    @property
+    def is_running(self) -> bool:
+        """True while the polling thread is active."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> Watcher:
+        """Begin polling. Returns *self* for chaining."""
+        if self.is_running:
+            return self
+        self._stop_event.clear()
+
+        def _loop() -> None:
+            while not self._stop_event.is_set():
+                try:
+                    rendered = self._renderer(self._node)
+                except Exception as exc:
+                    rendered = f"<div><pre>watch error: {_esc(exc)}</pre></div>"
+                # ipywidgets HTML widget exposes ``value``; assigning it
+                # is the documented "update in place" idiom.
+                try:
+                    self._widget.value = rendered
+                except AttributeError:  # widget might not support ``value``
+                    pass
+                # Wait on the event so .stop() interrupts immediately.
+                if self._stop_event.wait(self._period):
+                    break
+
+        self._thread = threading.Thread(target=_loop, daemon=True, name="peakrdl-watch")
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        """Stop the polling thread. Safe to call multiple times."""
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=max(self._period * 2.0, 0.5))
+        self._thread = None
+
+    def _ipython_display_(self) -> None:
+        """Show the live widget when the watcher is evaluated in a notebook."""
+        try:  # pragma: no cover - IPython-only path
+            from IPython.display import display
+
+            display(self._widget)
+        except ImportError:
+            pass
+
+    def _repr_html_(self) -> str:
+        """Static fallback for environments that don't speak ``_ipython_display_``."""
+        return render_html(self._node)
+
+
+def _is_destructive(node: Any) -> bool:
+    """Return ``True`` if polling *node* would silently destroy state.
+
+    A field is destructive iff its ``on_read`` is ``rclr``; a register is
+    destructive iff any of its fields is. Snapshots and other composite
+    nodes are checked through ``_list_fields`` which already walks
+    children for any node that exposes a ``fields`` attribute.
+    """
+    if _node_kind(node) == "field":
+        return _has_rclr(node)
+    return any(_has_rclr(f) for f in _list_fields(node))
+
+
+def watch(
+    node: Any,
+    period: float = 0.1,
+    where: Any | None = None,
+    *,
+    allow_destructive: bool = False,
+    autostart: bool = True,
+) -> Watcher:
+    """Return a live, refreshing widget for *node*.
+
+    Args:
+        node: A register, snapshot, mem view, or any node that
+            ``render_html`` can render.
+        period: Polling interval in seconds. Defaults to 100 ms.
+        where: Optional sub-selector (glob string or callable) applied
+            inside snapshot watchers. Forwarded as-is to the renderer
+            when supported.
+        allow_destructive: If ``True``, silence the side-effect guard
+            for ``rclr`` registers/fields. The default is ``False``
+            because periodic polling of a read-clear field is a footgun.
+        autostart: If ``True`` (default), start the polling thread
+            before returning. Set to ``False`` if the caller wants to
+            ``.start()`` manually.
+
+    Raises:
+        NotSupportedError: If ``ipywidgets`` is not installed, or if
+            ``node`` requires destructive reads and ``allow_destructive``
+            is ``False``.
+    """
+    if ipywidgets is None:
+        raise NotSupportedError(
+            "install peakrdl-pybind11[notebook] for watch() (ipywidgets is required)"
+        )
+
+    if not allow_destructive and _is_destructive(node):
+        raise NotSupportedError(
+            "refusing to watch() a register with rclr fields without "
+            "allow_destructive=True (periodic polling would clear hardware state)"
+        )
+
+    period = float(period)
+    if period <= 0:
+        raise ValueError("watch(period=...) must be positive")
+
+    # ``where`` is in the public signature for forward-compatibility with
+    # snapshot.watch(...) once Unit 8 lands. Renderers ignore it today.
+    widget = ipywidgets.HTML(value=render_html(node))  # type: ignore[union-attr]
+    watcher = Watcher(node=node, widget=widget, period=period, renderer=render_html)
+    if autostart:
+        watcher.start()
+    return watcher
+
+
+# ---------------------------------------------------------------------------
+# Wiring -- attach _repr_html_/_repr_pretty_/watch onto generated classes.
+# ---------------------------------------------------------------------------
+def attach_widgets(cls: type) -> None:
+    """Attach the rich-display surface to *cls*.
+
+    Idempotent: a class that already has ``_repr_html_`` set by us is
+    not double-decorated. Manually defined ``_repr_html_`` on user
+    subclasses is preserved.
+    """
+    if getattr(cls.__dict__.get("_repr_html_"), "__peakrdl_widget__", False):
+        return
+
+    def _repr_html_(self: Any) -> str:
+        return render_html(self)
+
+    _repr_html_.__peakrdl_widget__ = True  # type: ignore[attr-defined]
+    cls._repr_html_ = _repr_html_  # type: ignore[attr-defined]
+
+    def _repr_pretty_(self: Any, p: Any, cycle: bool) -> None:
+        _ipython_pretty(self, p, cycle)
+
+    _repr_pretty_.__peakrdl_widget__ = True  # type: ignore[attr-defined]
+    cls._repr_pretty_ = _repr_pretty_  # type: ignore[attr-defined]
+
+    if not hasattr(cls, "watch"):
+        def _watch(self: Any, period: float = 0.1, **kwargs: Any) -> Watcher:
+            return watch(self, period=period, **kwargs)
+
+        cls.watch = _watch  # type: ignore[attr-defined]
+
+
+@register_register_enhancement
+def _attach_to_class(cls: type) -> None:
+    """Hook executed by Unit 1 for every Reg/Field/Mem/RegFile/AddrMap class."""
+    attach_widgets(cls)
+
+
+@register_master_extension
+def _attach_to_soc(cls: type) -> None:
+    """Hook executed by Unit 1 for every top-level SoC class."""
+    attach_widgets(cls)
+
+
+__all__ = [
+    "NotSupportedError",
+    "Watcher",
+    "attach_widgets",
+    "render_html",
+    "render_pretty",
+    "watch",
+]

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the pure-Python ``peakrdl_pybind11.runtime`` package."""

--- a/tests/runtime/test_widgets.py
+++ b/tests/runtime/test_widgets.py
@@ -1,0 +1,485 @@
+"""
+Tests for ``peakrdl_pybind11.runtime.widgets`` (Unit 15).
+
+These tests use lightweight stand-ins for the generated SoC classes so
+that we can exercise the rich-display surface without depending on a
+compiled ``_native.so``. The widgets module is pure-Python and has only
+duck-typed expectations of the node objects it renders, so this is the
+right level to test it at.
+"""
+
+from __future__ import annotations
+
+import time
+import types
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime import widgets
+
+
+# ---------------------------------------------------------------------------
+# Minimal generated-node fakes
+# ---------------------------------------------------------------------------
+class FakeField:
+    def __init__(
+        self,
+        name: str,
+        lsb: int,
+        width: int,
+        access: str = "rw",
+        on_read: str = "",
+        on_write: str = "",
+        desc: str = "",
+        value: int = 0,
+        rclr: bool = False,
+        singlepulse: bool = False,
+        sticky: bool = False,
+        is_volatile: bool = False,
+    ) -> None:
+        self.name = name
+        self.lsb = lsb
+        self.width = width
+        self.msb = lsb + width - 1
+        self.access = access
+        self.on_read = on_read
+        self.on_write = on_write
+        self.desc = desc
+        self._value = value
+        self.rclr = rclr
+        self.singlepulse = singlepulse
+        self.sticky = sticky
+        self.is_volatile = is_volatile
+
+    def read(self) -> int:
+        return self._value
+
+    @property
+    def is_readable(self) -> bool:
+        return "r" in self.access
+
+    @property
+    def is_writable(self) -> bool:
+        return "w" in self.access
+
+
+class FakeRegister:
+    """Stand-in that exposes the same surface as a generated reg class."""
+
+    def __init__(
+        self,
+        name: str = "uart.control",
+        address: int = 0x4000_1000,
+        access: str = "rw",
+        fields: list[FakeField] | None = None,
+        desc: str = "Control register",
+    ) -> None:
+        self.name = name
+        self.address = address
+        self.access = access
+        self._fields = fields or []
+        self.desc = desc
+
+    def fields(self) -> list[FakeField]:
+        return list(self._fields)
+
+
+class FakeAddrMap:
+    """A container that exposes child registers as plain attributes."""
+
+    _node_kind = "addrmap"
+
+    def __init__(self, name: str, address: int, **children: Any) -> None:
+        self.name = name
+        self.address = address
+        for key, value in children.items():
+            setattr(self, key, value)
+
+
+class FakeMemView:
+    _widgets_kind = "memview"
+
+    def __init__(self, base_address: int, data: bytes, name: str = "ram") -> None:
+        self.base_address = base_address
+        self._data = bytes(data)
+        self.name = name
+
+    def to_bytes(self) -> bytes:
+        return self._data
+
+
+class FakeSnapshotDiff:
+    _widgets_kind = "snapshotdiff"
+
+    def __init__(self, entries: list[tuple[str, Any, Any]]) -> None:
+        self.entries = entries
+
+
+class FakeIRQSource:
+    def __init__(
+        self,
+        name: str,
+        pending: bool = False,
+        enabled: bool = False,
+        test: bool = False,
+    ) -> None:
+        self.name = name
+        self._pending = pending
+        self._enabled = enabled
+        self.test = test
+
+    def is_pending(self) -> bool:
+        return self._pending
+
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+
+class FakeInterruptGroup:
+    _widgets_kind = "interruptgroup"
+
+    def __init__(self, sources: list[FakeIRQSource], name: str = "uart.interrupts") -> None:
+        self.sources = sources
+        self.name = name
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def control_reg() -> FakeRegister:
+    fields = [
+        FakeField("enable", lsb=0, width=1, value=1, desc="Enable UART"),
+        FakeField(
+            "baudrate",
+            lsb=1,
+            width=3,
+            value=1,
+            desc="Baudrate selection",
+        ),
+        FakeField("parity", lsb=4, width=2, value=0, desc="Parity mode"),
+    ]
+    return FakeRegister(
+        name="uart.control", address=0x4000_1000, fields=fields, desc="UART control"
+    )
+
+
+@pytest.fixture
+def reset_status_reg() -> FakeRegister:
+    fields = [
+        FakeField(
+            "por_flag",
+            lsb=0,
+            width=1,
+            access="ro",
+            on_read="rclr",
+            rclr=True,
+            desc="Power-on reset latched flag",
+        ),
+        FakeField(
+            "wdt_flag",
+            lsb=1,
+            width=1,
+            access="ro",
+            on_read="rclr",
+            rclr=True,
+            desc="Watchdog reset flag",
+        ),
+    ]
+    return FakeRegister(
+        name="system.reset_status", address=0x4000_0018, access="ro", fields=fields
+    )
+
+
+# ---------------------------------------------------------------------------
+# _repr_html_ on Reg / Field / RegFile / AddrMap / Mem
+# ---------------------------------------------------------------------------
+class TestRepresentationHTML:
+    def test_register_html_contains_table_and_field_names(self, control_reg: FakeRegister) -> None:
+        html = widgets.render_html(control_reg)
+        assert "<table" in html
+        assert "<thead" in html
+        assert "</table>" in html
+        for col in ("Bits", "Field", "Value", "Access", "Description"):
+            assert col in html
+        for name in ("enable", "baudrate", "parity"):
+            assert name in html
+        assert "uart.control" in html
+        assert "0x40001000" in html
+
+    def test_register_html_color_codes_access(self, control_reg: FakeRegister) -> None:
+        html = widgets.render_html(control_reg)
+        # rw should resolve to a non-empty colour style.
+        assert "#1565c0" in html
+
+    def test_register_html_renders_badges(self, reset_status_reg: FakeRegister) -> None:
+        html = widgets.render_html(reset_status_reg)
+        assert widgets.SIDE_EFFECT_BADGES["rclr"] in html
+
+    def test_field_html_contains_table(self, control_reg: FakeRegister) -> None:
+        field = control_reg.fields()[0]
+        html = widgets.render_html(field)
+        assert "<table" in html
+        assert "enable" in html
+
+    def test_addrmap_html_lists_children(self, control_reg: FakeRegister) -> None:
+        amap = FakeAddrMap(name="uart", address=0x4000_1000, control=control_reg)
+        html = widgets.render_html(amap)
+        assert "<table" in html
+        assert "uart.control" in html
+
+    def test_render_html_handles_unknown_object(self) -> None:
+        sentinel = types.SimpleNamespace(name="weird")
+        html = widgets.render_html(sentinel)
+        assert html.startswith("<div>")
+        assert "weird" in html
+
+    def test_register_html_does_not_run_destructive_reads(self) -> None:
+        """Rendering must never call ``read()`` on an rclr field."""
+
+        class TrackingField(FakeField):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                super().__init__(*args, **kwargs)
+                self.read_count = 0
+
+            def read(self) -> int:
+                self.read_count += 1
+                return super().read()
+
+        rclr_field = TrackingField(
+            "por_flag", lsb=0, width=1, access="ro", on_read="rclr", rclr=True
+        )
+        plain_field = TrackingField("counter", lsb=8, width=8, value=42)
+        reg = FakeRegister(
+            name="system.status", address=0x40000000, fields=[rclr_field, plain_field]
+        )
+
+        html = widgets.render_html(reg)
+
+        assert rclr_field.read_count == 0, "rclr field must not be read by the renderer"
+        assert plain_field.read_count >= 1, "non-destructive field should be read once"
+        assert widgets.SIDE_EFFECT_BADGES["rclr"] in html
+        assert "por_flag" in html and "counter" in html
+
+
+# ---------------------------------------------------------------------------
+# _repr_html_ on MemView / SnapshotDiff / InterruptGroup
+# ---------------------------------------------------------------------------
+class TestSpecialRenderers:
+    def test_memview_html(self) -> None:
+        view = FakeMemView(base_address=0x40000, data=bytes(range(32)))
+        html = widgets.render_html(view)
+        assert "<table" in html
+        # 16-byte rows, so 32 bytes -> two rows. Each row's first byte
+        # address is rendered: 0x00040000 and 0x00040010.
+        assert "0x00040000" in html
+        assert "0x00040010" in html
+        # Hex chars present.
+        assert "0f" in html and "10" in html
+
+    def test_snapshotdiff_html(self) -> None:
+        diff = FakeSnapshotDiff(
+            [
+                ("uart.control", 0x0, 0x22),
+                ("uart.status.tx_ready", 0, 1),
+            ]
+        )
+        html = widgets.render_html(diff)
+        assert "<table" in html
+        assert "uart.control" in html
+        assert "0x22" in html or "34" in html
+        # Highlighted cells indicate "before vs after" change.
+        assert "background:" in html or "background: #fff8c4" in html
+
+    def test_interruptgroup_html(self) -> None:
+        group = FakeInterruptGroup(
+            sources=[
+                FakeIRQSource("tx_done", pending=True, enabled=True),
+                FakeIRQSource("rx_overflow", pending=False, enabled=True),
+            ]
+        )
+        html = widgets.render_html(group)
+        assert "<table" in html
+        assert "tx_done" in html
+        for column in ("State", "Enable", "Test", "Pending"):
+            assert column in html
+
+
+# ---------------------------------------------------------------------------
+# _repr_pretty_
+# ---------------------------------------------------------------------------
+class TestReprPretty:
+    def test_pretty_register_does_not_crash(self, control_reg: FakeRegister) -> None:
+        text = widgets.render_pretty(control_reg)
+        assert "uart.control" in text
+        for name in ("enable", "baudrate", "parity"):
+            assert name in text
+
+    def test_pretty_field(self, control_reg: FakeRegister) -> None:
+        field = control_reg.fields()[0]
+        text = widgets.render_pretty(field)
+        assert "enable" in text
+
+    def test_ipython_pretty_protocol(self, control_reg: FakeRegister) -> None:
+        # IPython hands p to _repr_pretty_; we mimic that with a small
+        # collector. The protocol requires a .text(str) method.
+        class FakeP:
+            def __init__(self) -> None:
+                self.parts: list[str] = []
+
+            def text(self, value: str) -> None:
+                self.parts.append(value)
+
+        p = FakeP()
+        widgets._ipython_pretty(control_reg, p, cycle=False)
+        joined = "".join(p.parts)
+        assert "enable" in joined
+
+    def test_ipython_pretty_handles_cycle(self, control_reg: FakeRegister) -> None:
+        class FakeP:
+            def __init__(self) -> None:
+                self.parts: list[str] = []
+
+            def text(self, value: str) -> None:
+                self.parts.append(value)
+
+        p = FakeP()
+        widgets._ipython_pretty(control_reg, p, cycle=True)
+        # On a cycle we just emit repr; the only requirement is no crash.
+        assert p.parts
+
+
+# ---------------------------------------------------------------------------
+# watch()
+# ---------------------------------------------------------------------------
+class TestWatch:
+    def test_watch_raises_when_ipywidgets_missing(
+        self, control_reg: FakeRegister, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(widgets, "ipywidgets", None)
+        with pytest.raises(widgets.NotSupportedError) as excinfo:
+            widgets.watch(control_reg)
+        assert "ipywidgets" in str(excinfo.value)
+
+    def test_watch_refuses_destructive_reads(
+        self, reset_status_reg: FakeRegister, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Provide a fake ipywidgets so we get past the import check; the
+        # destructive guard should still fire.
+        fake_widgets = types.SimpleNamespace(HTML=lambda value="": types.SimpleNamespace(value=value))
+        monkeypatch.setattr(widgets, "ipywidgets", fake_widgets)
+        with pytest.raises(widgets.NotSupportedError) as excinfo:
+            widgets.watch(reset_status_reg)
+        assert "rclr" in str(excinfo.value).lower()
+
+    def test_watch_destructive_with_allow(
+        self, reset_status_reg: FakeRegister, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeHTML:
+            def __init__(self, value: str = "") -> None:
+                self.value = value
+
+        fake_widgets = types.SimpleNamespace(HTML=FakeHTML)
+        monkeypatch.setattr(widgets, "ipywidgets", fake_widgets)
+        watcher = widgets.watch(
+            reset_status_reg, period=0.05, allow_destructive=True, autostart=False
+        )
+        assert isinstance(watcher, widgets.Watcher)
+        # Without autostart, no thread is alive.
+        assert not watcher.is_running
+
+    def test_watch_returns_running_watcher_and_stop_works(
+        self, control_reg: FakeRegister, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeHTML:
+            def __init__(self, value: str = "") -> None:
+                self.value = value
+
+        fake_widgets = types.SimpleNamespace(HTML=FakeHTML)
+        monkeypatch.setattr(widgets, "ipywidgets", fake_widgets)
+
+        watcher = widgets.watch(control_reg, period=0.02)
+        try:
+            assert isinstance(watcher, widgets.Watcher)
+            assert watcher.is_running
+            # Wait a few cycles so the thread has rendered at least once.
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline and not watcher.widget.value:
+                time.sleep(0.01)
+            assert "<table" in watcher.widget.value
+        finally:
+            watcher.stop()
+        assert not watcher.is_running
+
+    def test_watch_period_must_be_positive(
+        self, control_reg: FakeRegister, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeHTML:
+            def __init__(self, value: str = "") -> None:
+                self.value = value
+
+        fake_widgets = types.SimpleNamespace(HTML=FakeHTML)
+        monkeypatch.setattr(widgets, "ipywidgets", fake_widgets)
+        with pytest.raises(ValueError):
+            widgets.watch(control_reg, period=0)
+
+
+# ---------------------------------------------------------------------------
+# attach_widgets
+# ---------------------------------------------------------------------------
+class TestAttach:
+    def test_attach_adds_repr_html_and_pretty(self) -> None:
+        class Dummy:
+            name = "dummy"
+            address = 0
+            access = "rw"
+
+            def fields(self) -> list[Any]:
+                return []
+
+        widgets.attach_widgets(Dummy)
+        instance = Dummy()
+        assert hasattr(instance, "_repr_html_")
+        assert hasattr(instance, "_repr_pretty_")
+        # The HTML repr should at least produce a string.
+        assert isinstance(instance._repr_html_(), str)
+
+    def test_attach_is_idempotent(self) -> None:
+        class Dummy:
+            name = "dummy"
+            address = 0
+            access = "rw"
+
+            def fields(self) -> list[Any]:
+                return []
+
+        widgets.attach_widgets(Dummy)
+        first_repr = Dummy._repr_html_
+        widgets.attach_widgets(Dummy)
+        # Second call should be a no-op; same callable still attached.
+        assert Dummy._repr_html_ is first_repr
+
+    def test_attach_adds_watch_method(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FakeHTML:
+            def __init__(self, value: str = "") -> None:
+                self.value = value
+
+        fake_widgets = types.SimpleNamespace(HTML=FakeHTML)
+        monkeypatch.setattr(widgets, "ipywidgets", fake_widgets)
+
+        class Dummy:
+            name = "dummy"
+            address = 0
+            access = "rw"
+
+            def fields(self) -> list[Any]:
+                return []
+
+        widgets.attach_widgets(Dummy)
+        instance = Dummy()
+        watcher = instance.watch(period=0.05, autostart=False)
+        try:
+            assert isinstance(watcher, widgets.Watcher)
+        finally:
+            watcher.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -183,6 +192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -287,6 +305,15 @@ toml = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -321,6 +348,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -376,6 +412,99 @@ wheels = [
 ]
 
 [[package]]
+name = "ipython"
+version = "8.39.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -385,6 +514,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -482,12 +620,33 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
 ]
 
 [[package]]
@@ -505,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-pybind11"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -515,6 +674,9 @@ dependencies = [
 [package.optional-dependencies]
 cli = [
     { name = "peakrdl-cli" },
+]
+notebook = [
+    { name = "ipywidgets" },
 ]
 
 [package.dev-dependencies]
@@ -544,11 +706,12 @@ tools = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ipywidgets", marker = "extra == 'notebook'", specifier = ">=8.0" },
     { name = "jinja2" },
     { name = "peakrdl-cli", marker = "extra == 'cli'", specifier = ">=1.2.3" },
     { name = "systemrdl-compiler", specifier = ">=1.30.1" },
 ]
-provides-extras = ["cli"]
+provides-extras = ["cli", "notebook"]
 
 [package.metadata.requires-dev]
 benchmark = [
@@ -572,12 +735,82 @@ tools = [
 ]
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -958,6 +1191,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "systemrdl-compiler"
 version = "1.32.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1283,15 @@ wheels = [
 ]
 
 [[package]]
+name = "traitlets"
+version = "5.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1075,6 +1331,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements Unit 15 from the ``docs/IDEAL_API_SKETCH.md`` API overhaul -- the pure-Python rich-display surface for notebooks and IPython terminals.

- ``_repr_html_`` for every node kind (Reg, Field, Mem, RegFile, AddrMap) and for ``MemView`` / ``SnapshotDiff`` / ``InterruptGroup``; bordered tables with color-coded access modes (rw blue, ro grey, wo orange, na red strikethrough) and side-effect badges (warning/refresh/asterisk/lightning for rclr, singlepulse, sticky, volatile).
- ``_repr_pretty_`` for IPython terminals -- same content, ANSI colours, aligned columns.
- ``watch(node, period=0.1, where=None)`` returns a Watcher backed by ``ipywidgets.HTML``; soft imports ``ipywidgets`` and raises ``NotSupportedError("install peakrdl-pybind11[notebook] for watch()")`` when missing; refuses to poll rclr registers unless ``allow_destructive=True``; ``.stop()`` joins the polling thread.
- Wires onto generated classes through the ``register_register_enhancement`` / ``register_master_extension`` seam in ``runtime/_registry`` (a forward-compatible stub of that seam is included so this unit lands without blocking on Unit 1's master batch interface PR).

## Notes for reviewers

- The branch was forked from ``exp/api_overhaul``; the sibling Unit 4 (``info``), Unit 8 (``SnapshotDiff``), Unit 10 (``MemView``), Unit 12 (``InterruptGroup``) units are not yet merged. Renderers therefore use duck-typing -- they consult ``node.info.<attr>`` first, then fall back to the underlying C++ ``RegisterBase`` / ``FieldBase`` / ``MemoryBase`` attributes. They will pick up richer metadata automatically once those units land.
- A local ``NotSupportedError`` stub is shipped here; it falls back to the canonical ``peakrdl_pybind11.errors.NotSupportedError`` once Unit 19 lands.
- Adds the ``[notebook]`` optional-dependency pinning ``ipywidgets >= 8.0``. Lock file growth is the ipywidgets transitive closure; nothing is installed by default.

## Test plan

- [x] ``uv run pytest tests/runtime/test_widgets.py -v`` -- 22 tests pass (HTML / pretty / watch / attach surfaces, plus a stricter regression test that fails if a future change starts calling ``read()`` on rclr fields).
- [x] ``uv run python -c "from peakrdl_pybind11.runtime.widgets import watch; print('ok')"`` -- import smoke test.
- [x] ``uv run --group tools ruff check src/peakrdl_pybind11/runtime/`` -- clean.
- [x] Existing ``tests/`` suite unaffected (94 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)