### PR TITLE
feat(masters): recording/replay/sim + trace (Unit 20)

### DIFF
--- a/src/peakrdl_pybind11/masters/__init__.py
+++ b/src/peakrdl_pybind11/masters/__init__.py
@@ -6,13 +6,25 @@ from .base import AccessOp, MasterBase
 from .callback import CallbackMaster
 from .mock import MockMaster
 from .openocd import OpenOCDMaster
+from .recording_replay import (
+    Event,
+    RecordingMaster,
+    ReplayMaster,
+    ReplayMismatchError,
+)
+from .sim import SimMaster
 from .ssh import SSHMaster
 
 __all__ = [
     "AccessOp",
     "CallbackMaster",
+    "Event",
     "MasterBase",
     "MockMaster",
     "OpenOCDMaster",
+    "RecordingMaster",
+    "ReplayMaster",
+    "ReplayMismatchError",
     "SSHMaster",
+    "SimMaster",
 ]

--- a/src/peakrdl_pybind11/masters/recording_replay.py
+++ b/src/peakrdl_pybind11/masters/recording_replay.py
@@ -1,0 +1,332 @@
+"""Recording and replay masters (sketch §13.6).
+
+``RecordingMaster`` wraps any other :class:`MasterBase` and logs every
+read/write transaction to an in-memory list of events. The log can be
+saved to disk as JSON (one array, default for ``.json`` paths) or NDJSON
+(one event per line, ideal for streaming via ``file=`` so each op is
+flushed as it occurs and a crashed test still leaves a usable trace).
+
+``ReplayMaster`` consumes a saved trace and re-serves the recorded
+values to the caller. Two modes are supported:
+
+* **Strict** (default): the next requested op must match the next
+  recorded op exactly (op kind + address + width). Mismatches raise
+  :class:`ReplayMismatchError`. This is the mode regression tests want.
+* **Loose**: requested reads are served from the recording when an
+  address matches; extras (reads or writes not in the recording) are
+  silently ignored. This is the mode quick "what does the driver do
+  with these reads" experiments want.
+
+The on-disk format is intentionally trivial — one event per transaction
+with the keys described in :data:`Event` — so external tools (graphing,
+diffing, golden-trace assertions) can consume it without importing
+peakrdl_pybind11.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from types import TracebackType
+from typing import IO, Any, TypedDict
+
+from .base import AccessOp, MasterBase
+
+__all__ = [
+    "Event",
+    "RecordingMaster",
+    "ReplayMaster",
+    "ReplayMismatchError",
+]
+
+
+class Event(TypedDict):
+    """One recorded bus transaction.
+
+    The schema is the same on the wire (NDJSON / JSON) and in memory.
+    Keys mirror sketch §13.6:
+
+    * ``op`` — ``"read"`` or ``"write"``.
+    * ``address`` — absolute address (int).
+    * ``value`` — the value read (for ``read``) or written (for ``write``).
+    * ``width`` — register width in bytes.
+    * ``timestamp`` — monotonic seconds since the recorder started.
+    """
+
+    op: str
+    address: int
+    value: int
+    width: int
+    timestamp: float
+
+
+class ReplayMismatchError(Exception):
+    """Raised by :class:`ReplayMaster` (strict mode) when a requested
+    transaction does not match the next recorded event."""
+
+    def __init__(
+        self,
+        expected: Event | None,
+        actual: dict[str, Any],
+        message: str | None = None,
+    ) -> None:
+        self.expected = expected
+        self.actual = actual
+        if message is None:
+            if expected is None:
+                message = (
+                    f"replay log exhausted: requested {actual['op']} @ "
+                    f"0x{actual['address']:x} width={actual['width']} "
+                    "but the recording has no more events"
+                )
+            else:
+                message = (
+                    f"replay mismatch: expected {expected['op']} @ "
+                    f"0x{expected['address']:x} width={expected['width']}, "
+                    f"got {actual['op']} @ 0x{actual['address']:x} "
+                    f"width={actual['width']}"
+                )
+        super().__init__(message)
+
+
+def _is_ndjson_path(path: str | Path) -> bool:
+    """Return True if ``path`` looks like an NDJSON-format trace file."""
+    s = str(path).lower()
+    return s.endswith(".ndjson") or s.endswith(".jsonl")
+
+
+class RecordingMaster(MasterBase):
+    """Master that records every read/write to an event log.
+
+    Args:
+        inner: The wrapped master that actually services transactions.
+        file: Optional path. When set, every event is appended to the
+            file as a single JSON document on its own line (NDJSON).
+            Streaming this way means a long-running session that
+            crashes still leaves a usable trace on disk. Use
+            :meth:`save` to dump the in-memory log as a JSON array if
+            you prefer a single-file artefact.
+    """
+
+    def __init__(
+        self,
+        inner: MasterBase,
+        file: str | Path | None = None,
+    ) -> None:
+        self.inner = inner
+        self.events: list[Event] = []
+        self._start = time.monotonic()
+        self._file: IO[str] | None = None
+        if file is not None:
+            # Open in append mode so multiple sessions can stream into
+            # one log file. NDJSON's one-event-per-line shape is
+            # specifically chosen so concatenation is valid.
+            self._file = Path(file).open("a", encoding="utf-8")
+
+    def __enter__(self) -> RecordingMaster:  # convenience for ad-hoc traces
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Flush and close the streaming file if one was opened."""
+        if self._file is not None:
+            try:
+                self._file.flush()
+                self._file.close()
+            finally:
+                self._file = None
+
+    def __del__(self) -> None:  # best-effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # MasterBase contract
+    # ------------------------------------------------------------------
+
+    def read(self, address: int, width: int) -> int:
+        value = self.inner.read(address, width)
+        self._record("read", address, value, width)
+        return value
+
+    def write(self, address: int, value: int, width: int) -> None:
+        self.inner.write(address, value, width)
+        self._record("write", address, value, width)
+
+    def read_many(self, ops: Sequence[AccessOp]) -> list[int]:
+        # Delegate to inner.read_many when available so we get its
+        # batched fast path; record per op so the trace is granular
+        # enough for replay against a non-batching master.
+        values = self.inner.read_many(ops)
+        for op, v in zip(ops, values, strict=True):
+            self._record("read", op.address, int(v), op.width)
+        return list(values)
+
+    def write_many(self, ops: Sequence[AccessOp]) -> None:
+        self.inner.write_many(ops)
+        for op in ops:
+            self._record("write", op.address, op.value, op.width)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
+    def save(self, path: str | Path) -> None:
+        """Write the in-memory event log to ``path``.
+
+        Format is selected by extension: ``.ndjson`` / ``.jsonl`` writes
+        one event per line (the same shape as the streaming ``file=``
+        output); anything else writes a single JSON array.
+        """
+        out = Path(path)
+        if _is_ndjson_path(out):
+            with out.open("w", encoding="utf-8") as fh:
+                for event in self.events:
+                    fh.write(json.dumps(event))
+                    fh.write("\n")
+        else:
+            out.write_text(json.dumps(list(self.events), indent=2), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _record(self, op: str, address: int, value: int, width: int) -> None:
+        event: Event = {
+            "op": op,
+            "address": int(address),
+            "value": int(value),
+            "width": int(width),
+            "timestamp": time.monotonic() - self._start,
+        }
+        self.events.append(event)
+        if self._file is not None:
+            self._file.write(json.dumps(event))
+            self._file.write("\n")
+            # Flush per-op so a crashed run still leaves a usable trace.
+            self._file.flush()
+
+
+class ReplayMaster(MasterBase):
+    """Master that replays a previously recorded trace.
+
+    Reads return the recorded value; writes are accepted (and
+    optionally compared in strict mode). The recording is loaded from
+    a JSON array or NDJSON file; both formats produced by
+    :meth:`RecordingMaster.save` round-trip.
+
+    Args:
+        events: The recorded events. Use :meth:`from_file` for the
+            common case of loading from disk.
+        strict: When True (default), every transaction must match the
+            next recorded event in order. When False, reads serve
+            matching addresses from the recording and unmatched ops
+            are silently ignored — useful for shorter/longer scripts
+            that want to share a recording.
+    """
+
+    def __init__(self, events: Sequence[Event], strict: bool = True) -> None:
+        self.events: list[Event] = [dict(e) for e in events]  # type: ignore[misc]
+        self.strict = strict
+        self._cursor = 0
+
+    @classmethod
+    def from_file(cls, path: str | Path, strict: bool = True) -> ReplayMaster:
+        """Load a recording from ``path``.
+
+        The format is auto-detected: NDJSON (one event per line) or a
+        single JSON array. ``RecordingMaster.save`` writes whichever
+        shape matches the path's extension.
+        """
+        p = Path(path)
+        text = p.read_text(encoding="utf-8")
+        events: list[Event]
+        if _is_ndjson_path(p):
+            events = [json.loads(line) for line in text.splitlines() if line.strip()]
+        else:
+            stripped = text.lstrip()
+            if stripped.startswith("["):
+                events = json.loads(text)
+            else:
+                # Tolerant fallback: NDJSON with a non-standard
+                # extension (saving to ``run.log`` is common).
+                events = [json.loads(line) for line in text.splitlines() if line.strip()]
+        return cls(events, strict=strict)
+
+    # ------------------------------------------------------------------
+    # MasterBase contract
+    # ------------------------------------------------------------------
+
+    def read(self, address: int, width: int) -> int:
+        if self.strict:
+            event = self._consume("read", address, width)
+            return int(event["value"])
+        # Loose: scan from cursor forward for the first matching read.
+        for i in range(self._cursor, len(self.events)):
+            event = self.events[i]
+            if event["op"] == "read" and event["address"] == address:
+                self._cursor = i + 1
+                return int(event["value"])
+        # Nothing matched — return 0 as a benign default. Tests that
+        # care use strict mode.
+        return 0
+
+    def write(self, address: int, value: int, width: int) -> None:
+        if self.strict:
+            self._consume("write", address, width, value=value)
+            return
+        # Loose mode: writes are simply not validated. Advance the
+        # cursor past any matching write so subsequent reads line up.
+        for i in range(self._cursor, len(self.events)):
+            event = self.events[i]
+            if (
+                event["op"] == "write"
+                and event["address"] == address
+                and int(event.get("value", 0)) == int(value)
+            ):
+                self._cursor = i + 1
+                return
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _consume(
+        self,
+        op: str,
+        address: int,
+        width: int,
+        value: int | None = None,
+    ) -> Event:
+        actual: dict[str, Any] = {"op": op, "address": int(address), "width": int(width)}
+        if value is not None:
+            actual["value"] = int(value)
+        if self._cursor >= len(self.events):
+            raise ReplayMismatchError(None, actual)
+        event = self.events[self._cursor]
+        if event["op"] != op or int(event["address"]) != int(address):
+            raise ReplayMismatchError(event, actual)
+        # Width is checked because a 1-byte vs 4-byte read at the same
+        # address is a real semantic difference; do not require a match
+        # if the recording dropped width (older traces).
+        if "width" in event and int(event["width"]) != int(width):
+            raise ReplayMismatchError(event, actual)
+        # Writes also compare value: replaying ``write(0x0, 0xCAFE)``
+        # against a recording of ``write(0x0, 0xDEAD)`` is a real
+        # divergence. Reads pass ``value=None`` so this only fires for
+        # writes.
+        if value is not None and int(event["value"]) != int(value):
+            raise ReplayMismatchError(event, actual)
+        self._cursor += 1
+        return event

--- a/src/peakrdl_pybind11/masters/sim.py
+++ b/src/peakrdl_pybind11/masters/sim.py
@@ -1,0 +1,36 @@
+"""Sim master — alpha-quality stub that mimics hardware as a dict.
+
+.. warning::
+   Status: **alpha**. The intent of :class:`SimMaster` is to evolve
+   into a behavioural simulator that honours RDL side-effects (rclr,
+   W1C, single-pulse, …). Today it's a :class:`MockMaster` with one
+   convenience: seeding state at construction time. Code that relies
+   on side-effect simulation should continue to use the
+   mock-with-callbacks pattern from sketch §13.7 until this class is
+   upgraded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .mock import MockMaster
+
+__all__ = ["SimMaster"]
+
+
+class SimMaster(MockMaster):
+    """In-memory master pre-seeded with hardware-like state.
+
+    Args:
+        state: Mapping of ``address -> value``. Copied into the
+            internal store so the caller can safely mutate the
+            original. ``None`` (the default) starts with empty state,
+            which makes :class:`SimMaster` a drop-in replacement for
+            :class:`MockMaster`.
+    """
+
+    def __init__(self, state: Mapping[int, int] | None = None) -> None:
+        super().__init__()
+        if state:
+            self.memory.update(state)

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,20 @@
+"""PeakRDL-pybind11 runtime support package.
+
+This package collects the small Python-side helpers that compose with
+the generated C++ binding (snapshots, observers, tracing, …) without
+the per-SoC ``runtime.py`` module having to know about every feature.
+
+Only the modules this unit owns are imported eagerly here. Sibling
+units of the API overhaul that ship their own runtime modules can
+extend this package by adding more imports — see
+``IDEAL_API_SKETCH.md`` §1-§3 for the broader registry seam.
+"""
+
+from __future__ import annotations
+
+from .trace import Trace, attach_trace
+
+__all__ = [
+    "Trace",
+    "attach_trace",
+]

--- a/src/peakrdl_pybind11/runtime/trace.py
+++ b/src/peakrdl_pybind11/runtime/trace.py
@@ -1,0 +1,214 @@
+"""Scoped tracing of master transactions (sketch §13.6).
+
+``soc.trace()`` is sugar around :class:`peakrdl_pybind11.masters.RecordingMaster`:
+on entry the SoC's master is swapped for a recorder; on exit it is
+restored. The yielded :class:`Trace` is a thin view over the recorder's
+event log so callers can inspect, save, or pretty-print captured
+transactions::
+
+    with soc.trace() as t:
+        soc.uart.control.write(0x42)
+        soc.uart.status.read()
+    print(t)
+    t.save("session.json")
+
+The implementation uses the same :class:`RecordingMaster` that powers
+``soc.attach_master(RecordingMaster(...))`` — one mechanism for both
+"record this whole session" and "trace this block".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..masters.recording_replay import Event, RecordingMaster
+
+if TYPE_CHECKING:
+    from ..masters.base import MasterBase
+
+__all__ = [
+    "Trace",
+    "attach_trace",
+]
+
+
+class Trace:
+    """Live view onto a :class:`RecordingMaster`'s event log.
+
+    The trace shares its event list with the recorder, so events appear
+    in :attr:`events` as transactions occur. After the trace's context
+    manager exits, the recorder is decoupled from the SoC but the
+    event list remains.
+
+    Methods mirror :class:`RecordingMaster` for the bits users need:
+    :meth:`save` writes the log to disk, ``str(t)`` pretty-prints the
+    captured transactions, and :func:`len` is the transaction count.
+    """
+
+    __slots__ = ("_recorder",)
+
+    def __init__(self, recorder: RecordingMaster) -> None:
+        self._recorder = recorder
+
+    @property
+    def events(self) -> list[Event]:
+        """The list of recorded events. Mutating the list is not part
+        of the contract; treat it as read-only."""
+        return self._recorder.events
+
+    def __len__(self) -> int:
+        return len(self._recorder.events)
+
+    def __iter__(self) -> Iterator[Event]:
+        return iter(self._recorder.events)
+
+    def save(self, path: str | Path) -> None:
+        """Write the captured events to ``path``.
+
+        Format follows :meth:`RecordingMaster.save`: ``.ndjson`` /
+        ``.jsonl`` writes one event per line; anything else writes a
+        single JSON array.
+        """
+        self._recorder.save(path)
+
+    def __str__(self) -> str:
+        events = self._recorder.events
+        n = len(events)
+        # Width in bytes is per-op; total bytes is the sum so callers
+        # can spot "1k transactions, 4kB" at a glance.
+        total_bytes = sum(e["width"] for e in events)
+        plural = "transaction" if n == 1 else "transactions"
+        lines = [f"{n} {plural}, {total_bytes} bytes"]
+        for e in events:
+            op = e["op"]
+            addr = e["address"]
+            value = e["value"]
+            width = e["width"]
+            hex_value = f"0x{value:0{width * 2}x}" if width else f"0x{value:x}"
+            if op == "read":
+                lines.append(f"  rd  @0x{addr:08x}  -> {hex_value}")
+            elif op == "write":
+                lines.append(f"  wr  @0x{addr:08x}  {hex_value}")
+            else:
+                lines.append(f"  {op:<3} @0x{addr:08x}  {hex_value}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"<Trace events={len(self._recorder.events)}>"
+
+
+def _trace_context_manager(
+    soc: object,
+    file: str | Path | None = None,
+) -> Callable[..., AbstractContextManager[Trace]]:
+    """Build the context-manager callable that becomes ``soc.trace``.
+
+    The returned callable supports two usage shapes:
+
+    * ``with soc.trace() as t: ...`` — the canonical form. Swaps the
+      master for a :class:`RecordingMaster` for the duration of the
+      block.
+    * ``soc.trace(file=...)`` — same, but stream events to ``file``
+      while the block runs (useful for huge sessions).
+    """
+
+    @contextmanager
+    def trace(file: str | Path | None = file) -> Iterator[Trace]:
+        # Capture the current master, wrap it, and put the recorder
+        # back in place. We restore on exit, even if the body raised,
+        # so a flaky test never leaves a recorder dangling on the SoC.
+        original = _get_master(soc)
+        if original is None:
+            raise RuntimeError(
+                "soc.trace() requires a master to be attached; "
+                "call soc.attach_master(...) first"
+            )
+        recorder = RecordingMaster(original, file=file)
+        _set_master(soc, recorder)
+        try:
+            yield Trace(recorder)
+        finally:
+            _set_master(soc, original)
+            recorder.close()
+
+    return trace
+
+
+def attach_trace(soc: object) -> None:
+    """Attach the ``trace()`` helper to ``soc``.
+
+    This is the integration seam used by :func:`register_post_create`
+    in the runtime registry — it mutates ``soc`` in place so the
+    documented ``with soc.trace() as t:`` shape becomes available
+    without subclassing the generated SoC type.
+
+    Calling this twice on the same SoC is a no-op.
+    """
+    existing = getattr(soc, "trace", None)
+    if existing is not None and getattr(existing, "__peakrdl_trace__", False):
+        return
+
+    cm = _trace_context_manager(soc)
+    cm.__peakrdl_trace__ = True  # type: ignore[attr-defined]
+    # Bind to the instance directly. Using a plain attribute assignment
+    # rather than method-on-class keeps the helper's lifetime tied to
+    # the SoC instance; multiple SoCs in one process don't share state.
+    soc.trace = cm  # type: ignore[attr-defined]
+
+
+def _get_master(soc: object) -> MasterBase | None:
+    """Pull the active master out of ``soc``.
+
+    Generated SoC objects expose the master through different shapes
+    depending on the binding's history (``soc.master``, ``soc._master``,
+    ``soc.get_master()``). Probe in order and return the first hit so
+    sibling units don't have to know which surface their version of
+    the binding uses.
+    """
+    for attr in ("master", "_master"):
+        m = getattr(soc, attr, None)
+        if m is not None:
+            return m
+    getter = getattr(soc, "get_master", None)
+    if callable(getter):
+        return getter()
+    return None
+
+
+def _set_master(soc: object, master: MasterBase | None) -> None:
+    """Inverse of :func:`_get_master`. Probe in the same order."""
+    setter = getattr(soc, "attach_master", None)
+    if callable(setter):
+        setter(master)
+        return
+    if hasattr(soc, "master"):
+        soc.master = master  # type: ignore[attr-defined]
+        return
+    if hasattr(soc, "_master"):
+        soc._master = master  # type: ignore[attr-defined]
+        return
+    raise RuntimeError(
+        "could not assign master back to SoC: no attach_master / master / _master"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring (sibling-dep: Unit 1's runtime/_registry).
+#
+# When the registry seam is present we register ``attach_trace`` as a
+# post-create hook so every ``MySoc.create()`` automatically gains the
+# ``soc.trace()`` helper. When it isn't (this unit can land before
+# Unit 1), the import quietly fails and callers can still use
+# ``attach_trace(soc)`` explicitly.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - depends on Unit 1 landing order
+    from . import _registry  # type: ignore[attr-defined]
+except ImportError:
+    _registry = None  # type: ignore[assignment]
+
+if _registry is not None and hasattr(_registry, "register_post_create"):
+    _registry.register_post_create(attach_trace)

--- a/tests/runtime/test_trace.py
+++ b/tests/runtime/test_trace.py
@@ -1,0 +1,355 @@
+"""Tests for Unit 20 — recording, replay, sim, and scoped tracing.
+
+Covers:
+
+* :class:`RecordingMaster` capturing reads + writes.
+* :class:`ReplayMaster` (strict + loose) replaying a saved log.
+* :class:`ReplayMismatchError` on mis-ordered ops.
+* ``soc.trace()`` capture via the ``attach_trace`` integration helper.
+* :class:`SimMaster` initialising from a state dict and serving reads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from peakrdl_pybind11.masters import (
+    AccessOp,
+    MockMaster,
+    RecordingMaster,
+    ReplayMaster,
+    ReplayMismatchError,
+    SimMaster,
+)
+from peakrdl_pybind11.runtime import Trace, attach_trace
+
+# ---------------------------------------------------------------------------
+# RecordingMaster
+# ---------------------------------------------------------------------------
+
+
+class TestRecordingMaster:
+    def test_logs_reads_and_writes(self) -> None:
+        inner = MockMaster()
+        rec = RecordingMaster(inner)
+
+        rec.write(0x0, 0xAA, 4)
+        rec.write(0x4, 0xBB, 4)
+        rec.read(0x0, 4)
+        rec.read(0x4, 4)
+        rec.read(0x8, 4)
+
+        assert len(rec.events) == 5
+        ops = [e["op"] for e in rec.events]
+        assert ops == ["write", "write", "read", "read", "read"]
+        # Recorded reads return the underlying mock's view.
+        assert rec.events[2]["value"] == 0xAA
+        assert rec.events[3]["value"] == 0xBB
+        assert rec.events[4]["value"] == 0
+        # Every event has the documented schema.
+        for e in rec.events:
+            for key in ("op", "address", "value", "width", "timestamp"):
+                assert key in e
+            assert isinstance(e["timestamp"], float)
+
+    def test_save_writes_valid_json(self, tmp_path: Path) -> None:
+        rec = RecordingMaster(MockMaster())
+        for addr in (0x0, 0x4, 0x8):
+            rec.write(addr, addr * 0x11, 4)
+        for addr in (0x0, 0x8):
+            rec.read(addr, 4)
+
+        path = tmp_path / "trace.json"
+        rec.save(path)
+
+        loaded = json.loads(path.read_text())
+        assert isinstance(loaded, list)
+        assert len(loaded) == len(rec.events)
+        assert loaded[0]["op"] == "write"
+        assert loaded[0]["address"] == 0x0
+
+    def test_save_ndjson_round_trips(self, tmp_path: Path) -> None:
+        rec = RecordingMaster(MockMaster())
+        rec.write(0x10, 0x42, 4)
+        rec.read(0x10, 4)
+
+        path = tmp_path / "trace.ndjson"
+        rec.save(path)
+
+        lines = [
+            json.loads(line)
+            for line in path.read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 2
+        assert lines[0]["address"] == 0x10
+        assert lines[0]["op"] == "write"
+
+    def test_streaming_file_appends_per_op(self, tmp_path: Path) -> None:
+        path = tmp_path / "stream.ndjson"
+        rec = RecordingMaster(MockMaster(), file=path)
+        try:
+            rec.write(0x100, 0xCAFE, 4)
+            rec.read(0x100, 4)
+        finally:
+            rec.close()
+
+        events = [
+            json.loads(line)
+            for line in path.read_text().splitlines()
+            if line.strip()
+        ]
+        assert [e["op"] for e in events] == ["write", "read"]
+        assert events[0]["value"] == 0xCAFE
+        # Streaming events match in-memory events.
+        assert events == list(rec.events)
+
+    def test_read_many_records_each_op(self) -> None:
+        inner = MockMaster()
+        inner.write(0x0, 0x1, 4)
+        inner.write(0x4, 0x2, 4)
+        inner.write(0x8, 0x3, 4)
+
+        rec = RecordingMaster(inner)
+        ops = [AccessOp(0x0, 0, 4), AccessOp(0x4, 0, 4), AccessOp(0x8, 0, 4)]
+        values = rec.read_many(ops)
+
+        assert values == [0x1, 0x2, 0x3]
+        assert len(rec.events) == 3
+        assert all(e["op"] == "read" for e in rec.events)
+
+
+# ---------------------------------------------------------------------------
+# ReplayMaster
+# ---------------------------------------------------------------------------
+
+
+class TestReplayMaster:
+    def _record(self, tmp_path: Path) -> Path:
+        rec = RecordingMaster(MockMaster())
+        rec.write(0x0, 0xDEAD, 4)
+        rec.write(0x4, 0xBEEF, 4)
+        rec.read(0x0, 4)
+        rec.read(0x4, 4)
+        path = tmp_path / "trace.json"
+        rec.save(path)
+        return path
+
+    def test_replays_reads(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path)
+
+        replay.write(0x0, 0xDEAD, 4)
+        replay.write(0x4, 0xBEEF, 4)
+        assert replay.read(0x0, 4) == 0xDEAD
+        assert replay.read(0x4, 4) == 0xBEEF
+
+    def test_strict_mismatch_raises(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path)
+
+        # Wrong address on the first write.
+        with pytest.raises(ReplayMismatchError):
+            replay.write(0x100, 0xDEAD, 4)
+
+    def test_strict_op_swap_raises(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path)
+
+        # Recording starts with a write; calling read first must raise.
+        with pytest.raises(ReplayMismatchError):
+            replay.read(0x0, 4)
+
+    def test_strict_write_value_mismatch_raises(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path)
+
+        # Same op + address but different value — strict mode must catch this.
+        with pytest.raises(ReplayMismatchError):
+            replay.write(0x0, 0xCAFE, 4)
+
+    def test_strict_exhaustion_raises(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path)
+        replay.write(0x0, 0xDEAD, 4)
+        replay.write(0x4, 0xBEEF, 4)
+        replay.read(0x0, 4)
+        replay.read(0x4, 4)
+        # No more events left.
+        with pytest.raises(ReplayMismatchError):
+            replay.read(0x0, 4)
+
+    def test_loose_mode_serves_matching_reads(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path, strict=False)
+
+        # Skip the writes entirely; loose mode only cares about reads.
+        assert replay.read(0x0, 4) == 0xDEAD
+        assert replay.read(0x4, 4) == 0xBEEF
+
+    def test_loose_mode_unknown_address_returns_zero(self, tmp_path: Path) -> None:
+        path = self._record(tmp_path)
+        replay = ReplayMaster.from_file(path, strict=False)
+        # Address never read in the recording — loose mode tolerates it.
+        assert replay.read(0xFFFF, 4) == 0
+
+    def test_ndjson_round_trip(self, tmp_path: Path) -> None:
+        rec = RecordingMaster(MockMaster())
+        rec.write(0x10, 0x42, 4)
+        rec.read(0x10, 4)
+        path = tmp_path / "trace.ndjson"
+        rec.save(path)
+
+        replay = ReplayMaster.from_file(path)
+        replay.write(0x10, 0x42, 4)
+        assert replay.read(0x10, 4) == 0x42
+
+
+# ---------------------------------------------------------------------------
+# soc.trace()
+# ---------------------------------------------------------------------------
+
+
+class _FakeSoC:
+    """Minimal stand-in for a generated SoC.
+
+    Real SoCs are produced by the C++ binding; this tiny shim is
+    enough to exercise the ``attach_trace`` integration without
+    pulling cmake into the unit-test suite.
+    """
+
+    def __init__(self, master: MockMaster) -> None:
+        self.master = master
+
+    def attach_master(self, master: object) -> None:
+        self.master = master  # type: ignore[assignment]
+
+
+class TestSocTrace:
+    def test_with_block_captures_events(self) -> None:
+        soc = _FakeSoC(MockMaster())
+        attach_trace(soc)
+
+        with soc.trace() as t:
+            soc.master.write(0x0, 0xAA, 4)
+            soc.master.read(0x0, 4)
+            soc.master.read(0x4, 4)
+
+        assert isinstance(t, Trace)
+        assert len(t) == 3
+        assert t.events[0]["op"] == "write"
+        assert t.events[1]["op"] == "read"
+        assert t.events[1]["value"] == 0xAA
+        assert t.events[2]["value"] == 0
+
+    def test_master_restored_on_exit(self) -> None:
+        original = MockMaster()
+        soc = _FakeSoC(original)
+        attach_trace(soc)
+
+        with soc.trace():
+            assert soc.master is not original
+            assert isinstance(soc.master, RecordingMaster)
+        assert soc.master is original
+
+    def test_master_restored_on_exception(self) -> None:
+        original = MockMaster()
+        soc = _FakeSoC(original)
+        attach_trace(soc)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with soc.trace():
+                raise RuntimeError("boom")
+        assert soc.master is original
+
+    def test_save_round_trips(self, tmp_path: Path) -> None:
+        soc = _FakeSoC(MockMaster())
+        attach_trace(soc)
+
+        with soc.trace() as t:
+            soc.master.write(0x10, 0x42, 4)
+            soc.master.read(0x10, 4)
+
+        path = tmp_path / "session.json"
+        t.save(path)
+
+        loaded = json.loads(path.read_text())
+        assert len(loaded) == 2
+        assert loaded[0]["address"] == 0x10
+        assert loaded[1]["op"] == "read"
+        assert loaded[1]["value"] == 0x42
+
+    def test_str_pretty_prints(self) -> None:
+        soc = _FakeSoC(MockMaster())
+        attach_trace(soc)
+
+        with soc.trace() as t:
+            soc.master.write(0x100, 0xABCD, 4)
+            soc.master.read(0x100, 4)
+
+        text = str(t)
+        # Header line summarises transaction count and total bytes.
+        assert "2 transactions" in text
+        assert "8 bytes" in text
+        # Each event renders one line. Address shown in 0x... form.
+        assert "0x00000100" in text
+        # Read line shows the value with an arrow.
+        assert "rd" in text and "0x0000abcd" in text
+        # Write line shows the value.
+        assert "wr" in text
+
+    def test_idempotent_attach(self) -> None:
+        soc = _FakeSoC(MockMaster())
+        attach_trace(soc)
+        first = soc.trace
+        attach_trace(soc)
+        assert soc.trace is first
+
+
+# ---------------------------------------------------------------------------
+# SimMaster
+# ---------------------------------------------------------------------------
+
+
+class TestSimMaster:
+    def test_initialises_from_state(self) -> None:
+        sim = SimMaster({0x0: 0xAA, 0x4: 0xBB})
+        assert sim.read(0x0, 4) == 0xAA
+        assert sim.read(0x4, 4) == 0xBB
+        # Untouched addresses return 0 (mirrors MockMaster).
+        assert sim.read(0x100, 4) == 0
+
+    def test_state_is_copied(self) -> None:
+        seed = {0x0: 0xAA}
+        sim = SimMaster(seed)
+        seed[0x0] = 0xFF
+        # Mutation of the input dict must not leak into the master.
+        assert sim.read(0x0, 4) == 0xAA
+
+    def test_writes_update_state(self) -> None:
+        sim = SimMaster()
+        sim.write(0x10, 0x42, 4)
+        assert sim.read(0x10, 4) == 0x42
+
+    def test_width_masking(self) -> None:
+        sim = SimMaster()
+        sim.write(0x0, 0xDEADBEEF, 2)
+        # Only the low 2 bytes survive a 2-byte write.
+        assert sim.read(0x0, 2) == 0xBEEF
+
+    def test_read_many_and_write_many(self) -> None:
+        sim = SimMaster()
+        sim.write_many([
+            AccessOp(0x0, 0xAA, 4),
+            AccessOp(0x4, 0xBB, 4),
+        ])
+        values = sim.read_many([AccessOp(0x0, 0, 4), AccessOp(0x4, 0, 4)])
+        assert values == [0xAA, 0xBB]
+
+    def test_reset(self) -> None:
+        sim = SimMaster({0x0: 0xAA})
+        sim.reset()
+        assert sim.read(0x0, 4) == 0


### PR DESCRIPTION
## Summary
Implements Unit 20 from `docs/IDEAL_API_SKETCH.md` §13.6 — the recording / replay / scoped-trace surface for the master layer.

- `RecordingMaster(inner, file=)` wraps any `MasterBase` and logs every read/write to an in-memory event list. `file=` streams events as NDJSON so a session that crashes still leaves a usable trace. `.save(path)` writes a JSON array, or NDJSON when the path ends in `.ndjson` / `.jsonl`.
- `ReplayMaster.from_file(path)` consumes a saved trace. Strict mode (default) compares op + address + width + write-value against the next recorded event and raises `ReplayMismatchError` on divergence; loose mode serves matching reads and ignores extras.
- `SimMaster(state)` is a `MockMaster` pre-seeded from a `dict[address, value]`. Documented as **alpha** — the eventual goal is RDL side-effect simulation, but today it is just a convenience constructor over `MockMaster`.
- `soc.trace()` swaps the SoC's master for a `RecordingMaster` for the duration of a `with` block, yielding a `Trace` with `.events`, `.save(...)`, and a pretty-printing `__str__`. `attach_trace(soc)` is the integration helper.

## Coordination notes
- Sibling-dep on Unit 1 (`runtime/_registry.register_post_create`) is wrapped in a try/except. When Unit 1 lands, every `MySoc.create()` will auto-attach `soc.trace()` via the post-create hook; until then callers must call `attach_trace(soc)` explicitly. No code change needed once Unit 1 merges.
- Sibling-dep on Unit 2 (`BusError`) was deliberately not used. `ReplayMismatchError` is a logical mismatch (the script diverged from the recording), not a bus failure, so it lives as a plain `Exception` inside `recording_replay.py`.

## Test plan
- [x] `pytest tests/runtime/test_trace.py -v` — 25 tests passing locally
- [x] `RecordingMaster`: 3 reads + 2 writes captured in event list, `.save("trace.json")` produces valid JSON, NDJSON streaming round-trips
- [x] `ReplayMaster.from_file(...)` replays reads matching the recording
- [x] Strict-mode mismatch on op-swap, address mismatch, write-value mismatch, exhaustion all raise `ReplayMismatchError`
- [x] Loose mode serves matching reads, returns 0 for unknown addresses
- [x] `with soc.trace() as t:` captures events, `t.save(...)` round-trips, `str(t)` pretty-prints, master is restored on normal exit and on exception
- [x] `SimMaster` initialises from state, defends the seed dict from caller mutation, and round-trips writes
- [x] `ruff check` clean for all new files
- [x] No regressions in existing `tests/` suite