### PR TITLE
feat(exporter): interrupt/alias detection + schema.json + stubs (Unit 23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ docs = [
 benchmark = ["pytest >= 7.4.4", "pytest-benchmark >= 5.1.0", "build >= 1.0.0"]
 test = [
     "hypothesis>=6.151.9",
+    "peakrdl-cli>=1.2.3",
     "pytest >= 7.4.4",
     "pytest-cov >= 4.1.0",
 ]

--- a/src/peakrdl_pybind11/__peakrdl__.py
+++ b/src/peakrdl_pybind11/__peakrdl__.py
@@ -107,6 +107,18 @@ class Exporter(ExporterSubcommandPlugin):
                 "with clear hierarchical structure."
             ),
         )
+        arg_group.add_argument(
+            "--interrupt-pattern",
+            dest="interrupt_pattern",
+            metavar="REGEX",
+            default=None,
+            help=(
+                "Override the regex used by the feature_detection plugin to identify "
+                "interrupt state registers (default matches INTR_STATE / intr_status / "
+                "*_INT_STATUS). The pattern is matched against the register's inst_name "
+                "with re.fullmatch."
+            ),
+        )
 
     def do_export(self, top_node: "AddrmapNode", options: "argparse.Namespace") -> None:
         """Execute the export"""
@@ -121,6 +133,7 @@ class Exporter(ExporterSubcommandPlugin):
         gen_pyi = getattr(options, "gen_pyi", True)
         split_bindings = getattr(options, "split_bindings", 100)
         split_by_hierarchy = getattr(options, "split_by_hierarchy", False)
+        interrupt_pattern = getattr(options, "interrupt_pattern", None)
 
         exporter.export(
             top_node,
@@ -130,4 +143,5 @@ class Exporter(ExporterSubcommandPlugin):
             gen_pyi=gen_pyi,
             split_bindings=split_bindings,
             split_by_hierarchy=split_by_hierarchy,
+            interrupt_pattern=interrupt_pattern,
         )

--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -197,6 +197,7 @@ class Pybind11Exporter:
         gen_pyi: bool = True,
         split_bindings: int = 100,
         split_by_hierarchy: bool = False,
+        interrupt_pattern: object | None = None,
     ) -> None:
         """
         Export SystemRDL to PyBind11 modules
@@ -213,6 +214,9 @@ class Pybind11Exporter:
             split_by_hierarchy: When True, split bindings by addrmap/regfile hierarchy instead of
                                by register count. This keeps related registers together and provides
                                more logical grouping. Default: False
+            interrupt_pattern: Optional override for the interrupt-state-register matcher used by
+                               the feature_detection exporter plugin. Accepts a regex string,
+                               compiled ``re.Pattern``, or a callable ``(name: str) -> bool``.
         """
         self.top_node = top_node.top if isinstance(top_node, RootNode) else top_node
         self.output_dir = Path(output_dir)
@@ -220,6 +224,7 @@ class Pybind11Exporter:
         self.soc_version = soc_version
         self.split_bindings = split_bindings
         self.split_by_hierarchy = split_by_hierarchy
+        self.interrupt_pattern = interrupt_pattern
 
         # Sanitize soc_name for use as identifier
         self.soc_name = self._sanitize_identifier(self.soc_name)
@@ -246,6 +251,33 @@ class Pybind11Exporter:
         # Generate .pyi stub files if requested
         if gen_pyi:
             self._generate_pyi_stubs(nodes)
+
+        # Run post-export plugins (interrupt detection, schema, etc.).
+        # Plugins are best-effort: a plugin failure must not stop the
+        # main exporter from declaring success.
+        self._run_post_export_plugins(nodes)
+
+    def _run_post_export_plugins(self, nodes: "Nodes") -> None:
+        from .exporter_plugins import PluginContext, run_post_export
+
+        assert self.top_node is not None
+        assert self.output_dir is not None
+        assert self.soc_name is not None
+
+        ctx = PluginContext(
+            exporter=self,
+            top_node=self.top_node,
+            output_dir=self.output_dir,
+            soc_name=self.soc_name,
+            nodes=nodes,
+            options={"interrupt_pattern": self.interrupt_pattern},
+        )
+        try:
+            run_post_export(ctx)
+        except Exception:  # pragma: no cover - defensive
+            import logging
+
+            logging.getLogger(__name__).exception("post_export plugin failed")
 
     def _sanitize_identifier(self, name: str) -> str:
         """Sanitize a name to be a valid Python/C++ identifier.

--- a/src/peakrdl_pybind11/exporter_plugins/__init__.py
+++ b/src/peakrdl_pybind11/exporter_plugins/__init__.py
@@ -1,0 +1,111 @@
+"""Exporter plugin discovery seam.
+
+This is the minimal scaffolding for sibling Unit 1; once that lands it will
+replace this module with a richer registry. The contract a plugin must
+satisfy:
+
+* Provide a callable ``register(exporter)`` that hooks any state it needs
+  onto the exporter instance, **or**
+* Subclass :class:`ExporterPlugin` and implement ``post_export(context)``,
+  which is invoked after the core export has finished writing files.
+
+Plugins are discovered by importing every module in this package and
+collecting the modules that expose a ``register`` callable. Future Unit 1
+will likely swap to entry-point discovery, but per-module registration
+keeps this contract stable for in-tree plugins.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from systemrdl.node import AddrmapNode
+
+    from peakrdl_pybind11.exporter import Nodes, Pybind11Exporter
+
+
+@dataclass
+class PluginContext:
+    """State handed to each plugin's ``post_export`` hook.
+
+    A small read-only snapshot of what the core exporter just produced.
+    Plugins use this to write supplementary artifacts into ``output_dir``
+    (and ``output_dir / soc_name``).
+    """
+
+    exporter: Pybind11Exporter
+    top_node: AddrmapNode
+    output_dir: Path
+    soc_name: str
+    nodes: Nodes
+    options: dict[str, Any]
+
+
+class ExporterPlugin(Protocol):
+    """Plugin interface. Implementations may be modules or callables."""
+
+    def post_export(self, ctx: PluginContext) -> None: ...
+
+
+# Optional plugin instances registered programmatically via ``register_plugin``.
+_REGISTERED: list[ExporterPlugin] = []
+
+
+def register_plugin(plugin: ExporterPlugin) -> None:
+    """Register an externally-constructed plugin instance."""
+    if plugin not in _REGISTERED:
+        _REGISTERED.append(plugin)
+
+
+def discover_plugins() -> list[ExporterPlugin]:
+    """Return every plugin known at the time of the call.
+
+    Plugins are sourced from two places:
+
+    * Modules under ``peakrdl_pybind11.exporter_plugins`` that expose a
+      callable ``register(exporter_module)``. The returned object (or the
+      module itself if ``register`` returns None) is the plugin.
+    * Anything passed to :func:`register_plugin`.
+    """
+    plugins: list[ExporterPlugin] = list(_REGISTERED)
+    pkg_path = Path(__file__).parent
+    for mod_info in pkgutil.iter_modules([str(pkg_path)]):
+        if mod_info.name.startswith("_"):
+            continue
+        full_name = f"{__name__}.{mod_info.name}"
+        try:
+            module = importlib.import_module(full_name)
+        except Exception:  # pragma: no cover - defensive
+            continue
+        register: Callable[[Any], ExporterPlugin | None] | None = getattr(module, "register", None)
+        if register is None:
+            continue
+        instance = register(module)
+        plugin: ExporterPlugin = instance if instance is not None else module  # type: ignore[assignment]
+        if plugin not in plugins:
+            plugins.append(plugin)
+    return plugins
+
+
+def run_post_export(ctx: PluginContext) -> None:
+    """Invoke ``post_export`` on every discovered plugin."""
+    for plugin in discover_plugins():
+        hook = getattr(plugin, "post_export", None)
+        if hook is None:
+            continue
+        hook(ctx)
+
+
+__all__ = [
+    "ExporterPlugin",
+    "PluginContext",
+    "discover_plugins",
+    "register_plugin",
+    "run_post_export",
+]

--- a/src/peakrdl_pybind11/exporter_plugins/feature_detection.py
+++ b/src/peakrdl_pybind11/exporter_plugins/feature_detection.py
@@ -1,0 +1,674 @@
+"""Feature-detection exporter plugin.
+
+Bundles four post-export passes that consume the elaborated RDL tree and
+write supplementary artifacts next to the generated module:
+
+* **Interrupt detection** -> ``interrupts_detected.py`` -- pairs a state
+  register (``INTR_STATE`` / ``intr_status`` / ``*_INT_STATUS``) with its
+  ``_ENABLE`` / ``_MASK`` / ``_TEST`` / ``_RAW`` siblings and matches
+  fields by name across the trio. (Sketch §9.4)
+
+* **Alias detection** -> ``aliases.py`` -- mapping of every aliased
+  register's path to its primary's path. (Sketch §10)
+
+* **schema.json emission** -> a JSON serialisation of the full node tree,
+  the canonical artifact other tooling (web register browser, search,
+  GUIs) consumes without reparsing RDL. (Sketch §20)
+
+* **Stubs enrichment** -> rewrites the generated ``__init__.pyi`` to add
+  ``Unpack[TypedDict]`` overloads for ``write_fields(**fields)`` per
+  register, ``Literal[...]`` for enum-encoded fields, and
+  ``Annotated[int, Range(0, max)]`` for bounded fields. The Jinja
+  template is left untouched -- this is a string post-process so the
+  template stays small. (Sketch §17)
+
+The plugin is configured via attributes on the :class:`Pybind11Exporter`
+instance (``interrupt_pattern``); the CLI in ``__peakrdl__.py`` plumbs
+the ``--interrupt-pattern`` flag through.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pprint
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from systemrdl.node import (
+    AddrmapNode,
+    FieldNode,
+    MemNode,
+    Node,
+    RegfileNode,
+    RegNode,
+)
+
+if TYPE_CHECKING:
+    from peakrdl_pybind11.exporter_plugins import PluginContext
+
+LOGGER = logging.getLogger(__name__)
+
+# Default state-register matcher: matches names like ``INTR_STATE``,
+# ``intr_status``, ``*_INT_STATUS``. Anchored to the full inst_name; case
+# is normalised to upper before the check to keep the mental model simple.
+DEFAULT_STATE_PATTERN = re.compile(r"(?:INTR[_]?STAT(?:E|US)|.+_INT_STATUS)\Z")
+
+# Suffixes we look for to identify the partner registers in a trio. The
+# order matters: a state register named ``INTR_STATE`` -> partners are
+# ``INTR_ENABLE`` / ``INTR_MASK`` / ``INTR_TEST`` / ``INTR_RAW``. We match
+# them with the same case-insensitive comparison the state regex uses.
+PARTNER_SUFFIXES: tuple[tuple[str, str], ...] = (
+    ("enable_reg", "ENABLE"),
+    ("mask_reg", "MASK"),
+    ("test_reg", "TEST"),
+    ("raw_reg", "RAW"),
+)
+
+
+@dataclass(frozen=True)
+class InterruptGroup:
+    """Detected interrupt trio. Serialised into ``interrupts_detected.py``."""
+
+    path: str
+    state_reg: str
+    enable_reg: str | None
+    test_reg: str | None
+    mask_reg: str | None = None
+    raw_reg: str | None = None
+    sources: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "state_reg": self.state_reg,
+            "enable_reg": self.enable_reg,
+            "test_reg": self.test_reg,
+            "mask_reg": self.mask_reg,
+            "raw_reg": self.raw_reg,
+            "sources": list(self.sources),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Interrupt detection
+# ---------------------------------------------------------------------------
+
+
+def _normalise_pattern(
+    pattern: object | None,
+) -> Callable[[str], bool]:
+    """Coerce the user-supplied ``--interrupt-pattern`` into a predicate."""
+    if pattern is None:
+        return _default_state_predicate
+    if callable(pattern) and not isinstance(pattern, re.Pattern):
+        return pattern  # type: ignore[return-value]
+    if isinstance(pattern, re.Pattern):
+        return lambda name, _p=pattern: bool(_p.fullmatch(name))
+    if isinstance(pattern, str):
+        compiled = re.compile(pattern)
+        return lambda name, _p=compiled: bool(_p.fullmatch(name))
+    raise TypeError(f"interrupt_pattern must be a regex/str/callable, got {type(pattern).__name__}")
+
+
+def _default_state_predicate(name: str) -> bool:
+    upper = name.upper()
+    return bool(DEFAULT_STATE_PATTERN.fullmatch(upper))
+
+
+def _state_stem(name: str) -> str | None:
+    """Strip a trailing ``STATE`` / ``STATUS`` token. Returns the stem."""
+    upper = name.upper()
+    for tail in ("_STATE", "_STATUS", "STATE", "STATUS"):
+        if upper.endswith(tail):
+            stem = upper[: -len(tail)]
+            return stem.rstrip("_")
+    return None
+
+
+def _all_fields_intr(reg: RegNode) -> bool:
+    """A register qualifies for trio search only if every field carries
+    the ``intr`` builtin property. Intentionally strict: a status reg with
+    a mix of intr and non-intr fields probably isn't an interrupt status
+    in the §9.4 sense."""
+    fields = list(reg.fields())
+    if not fields:
+        return False
+    for f in fields:
+        try:
+            if not f.get_property("intr"):
+                return False
+        except LookupError:
+            return False
+    return True
+
+
+def _siblings(state: RegNode) -> dict[str, RegNode]:
+    """Return ``{upper_inst_name: RegNode}`` for every sibling of ``state``
+    that lives in the same parent."""
+    parent = state.parent
+    out: dict[str, RegNode] = {}
+    if parent is None:
+        return out
+    for child in parent.children():
+        if isinstance(child, RegNode) and child is not state:
+            out[child.inst_name.upper()] = child
+    return out
+
+
+def _match_partner(
+    siblings: Mapping[str, RegNode],
+    state_name: str,
+    suffix: str,
+) -> RegNode | None:
+    """Look for ``<stem>_<SUFFIX>`` or ``<stem><SUFFIX>`` in ``siblings``."""
+    stem = _state_stem(state_name)
+    if stem is None:
+        # No recognisable suffix on the state name; fall back to swapping
+        # the trailing token wholesale (e.g. ``INTR_STATE`` -> ``INTR_<S>``).
+        upper = state_name.upper()
+        for tail in ("_STATE", "_STATUS"):
+            if upper.endswith(tail):
+                candidate = upper[: -len(tail)] + "_" + suffix
+                if candidate in siblings:
+                    return siblings[candidate]
+        return None
+    candidates = (
+        f"{stem}_{suffix}" if stem else suffix,
+        f"{stem}{suffix}",
+    )
+    for cand in candidates:
+        if cand in siblings:
+            return siblings[cand]
+    return None
+
+
+def _shared_field_names(*regs: RegNode | None) -> list[str]:
+    """Field names present (case-sensitive) on every supplied register.
+
+    Iteration order follows the state register so the JSON output is
+    stable.
+    """
+    state, *partners = [r for r in regs if r is not None]
+    state_fields = [f.inst_name for f in state.fields()]
+    common: set[str] = set(state_fields)
+    for partner in partners:
+        common &= {f.inst_name for f in partner.fields()}
+    return [name for name in state_fields if name in common]
+
+
+def detect_interrupt_groups(
+    top_node: AddrmapNode,
+    pattern: object | None = None,
+) -> list[InterruptGroup]:
+    """Walk ``top_node`` and return every detected interrupt trio."""
+    predicate = _normalise_pattern(pattern)
+    groups: list[InterruptGroup] = []
+    for node in top_node.descendants():
+        if not isinstance(node, RegNode):
+            continue
+        if not predicate(node.inst_name):
+            continue
+        if not _all_fields_intr(node):
+            continue
+
+        siblings = _siblings(node)
+        partners: dict[str, RegNode | None] = {}
+        for attr, suffix in PARTNER_SUFFIXES:
+            partners[attr] = _match_partner(siblings, node.inst_name, suffix)
+
+        sources = _shared_field_names(
+            node,
+            partners.get("enable_reg"),
+            partners.get("test_reg"),
+        )
+        if not sources:
+            # No fields shared with any partner -- treat as the state
+            # register on its own, with field names from the state.
+            sources = [f.inst_name for f in node.fields()]
+
+        groups.append(
+            InterruptGroup(
+                path=node.parent.get_path() if node.parent is not None else node.get_path(),
+                state_reg=node.get_path(),
+                enable_reg=_path_or_none(partners.get("enable_reg")),
+                test_reg=_path_or_none(partners.get("test_reg")),
+                mask_reg=_path_or_none(partners.get("mask_reg")),
+                raw_reg=_path_or_none(partners.get("raw_reg")),
+                sources=tuple(sources),
+            )
+        )
+    return groups
+
+
+def _path_or_none(reg: RegNode | None) -> str | None:
+    return reg.get_path() if reg is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Alias detection
+# ---------------------------------------------------------------------------
+
+
+def detect_aliases(top_node: AddrmapNode) -> dict[str, str]:
+    """Return ``{alias_path: primary_path}`` for every aliased register."""
+    aliases: dict[str, str] = {}
+    for node in top_node.descendants():
+        if not isinstance(node, RegNode):
+            continue
+        if not getattr(node, "is_alias", False):
+            continue
+        try:
+            primary = node.alias_primary
+        except ValueError:
+            continue
+        if primary is None:
+            continue
+        aliases[node.get_path()] = primary.get_path()
+    return aliases
+
+
+# ---------------------------------------------------------------------------
+# schema.json
+# ---------------------------------------------------------------------------
+
+# RDL property names whose values we serialise. Limited to JSON-safe
+# scalars; ``encode``/``onread`` etc. carry enum or class objects that
+# don't round-trip through ``json.dumps``.
+_REG_PROPS: tuple[str, ...] = (
+    "name",
+    "desc",
+    "regwidth",
+    "accesswidth",
+    "addressing",
+    "alignment",
+)
+
+_FIELD_PROPS: tuple[str, ...] = (
+    "name",
+    "desc",
+    "intr",
+    "singlepulse",
+    "sticky",
+    "stickybit",
+    "paritycheck",
+    "hwclr",
+    "hwset",
+    "anded",
+    "ored",
+    "xored",
+)
+
+_MEM_PROPS: tuple[str, ...] = (
+    "name",
+    "desc",
+    "mementries",
+    "memwidth",
+)
+
+
+def _safe_property(node: Node, name: str) -> Any | None:  # noqa: ANN401 - RDL props are heterogeneous
+    try:
+        value = node.get_property(name)
+    except LookupError:
+        return None
+    return _to_jsonable(value)
+
+
+def _to_jsonable(value: Any) -> Any:  # noqa: ANN401 - polymorphic by design
+    """Coerce a value into something ``json.dumps`` can handle.
+
+    Falls back to ``str()`` for anything exotic (RDL enum members, class
+    references, etc.).
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    name = getattr(value, "__name__", None)
+    if name is not None:
+        return name
+    return str(value)
+
+
+def _udp_dict(node: Node) -> dict[str, Any]:
+    """Dump every UDP attached to ``node`` as JSON-friendly values."""
+    udps: dict[str, Any] = {}
+    # The systemrdl public API exposes user-defined properties via the
+    # node's ``list_properties(only_udp=True)``; fall back gracefully for
+    # older versions.
+    list_props = getattr(node, "list_properties", None)
+    if not callable(list_props):
+        return udps
+    try:
+        names = list_props(only_udp=True)
+    except TypeError:  # pragma: no cover - older systemrdl versions
+        names = ()
+    for name in names:
+        udps[name] = _safe_property(node, name)
+    return udps
+
+
+def _field_to_dict(field_node: FieldNode) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "kind": "field",
+        "inst_name": field_node.inst_name,
+        "path": field_node.get_path(),
+        "lsb": field_node.lsb,
+        "msb": field_node.msb,
+        "low": field_node.low,
+        "high": field_node.high,
+        "width": field_node.width,
+        "is_sw_readable": field_node.is_sw_readable,
+        "is_sw_writable": field_node.is_sw_writable,
+        "is_hw_readable": field_node.is_hw_readable,
+        "is_hw_writable": field_node.is_hw_writable,
+        "reset": _safe_property(field_node, "reset"),
+    }
+    for prop in _FIELD_PROPS:
+        out[prop] = _safe_property(field_node, prop)
+    udps = _udp_dict(field_node)
+    if udps:
+        out["udps"] = udps
+    return out
+
+
+def _reg_to_dict(reg: RegNode) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "kind": "reg",
+        "inst_name": reg.inst_name,
+        "path": reg.get_path(),
+        "absolute_address": reg.absolute_address,
+        "size": reg.size,
+        "is_alias": getattr(reg, "is_alias", False),
+        "fields": [_field_to_dict(f) for f in reg.fields()],
+    }
+    if out["is_alias"]:
+        try:
+            primary = reg.alias_primary
+        except ValueError:
+            primary = None
+        out["alias_primary"] = primary.get_path() if primary is not None else None
+    for prop in _REG_PROPS:
+        out[prop] = _safe_property(reg, prop)
+    udps = _udp_dict(reg)
+    if udps:
+        out["udps"] = udps
+    return out
+
+
+def _mem_to_dict(mem: MemNode) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "kind": "mem",
+        "inst_name": mem.inst_name,
+        "path": mem.get_path(),
+        "absolute_address": mem.absolute_address,
+        "size": mem.size,
+        "children": [_node_to_dict(c) for c in mem.children()],
+    }
+    for prop in _MEM_PROPS:
+        out[prop] = _safe_property(mem, prop)
+    return out
+
+
+def _container_to_dict(node: AddrmapNode | RegfileNode) -> dict[str, Any]:
+    return {
+        "kind": "addrmap" if isinstance(node, AddrmapNode) else "regfile",
+        "inst_name": node.inst_name,
+        "path": node.get_path(),
+        "absolute_address": node.absolute_address,
+        "size": node.size,
+        "name": _safe_property(node, "name"),
+        "desc": _safe_property(node, "desc"),
+        "children": [_node_to_dict(c) for c in node.children()],
+    }
+
+
+def _node_to_dict(node: Node) -> dict[str, Any]:
+    if isinstance(node, FieldNode):
+        return _field_to_dict(node)
+    if isinstance(node, RegNode):
+        return _reg_to_dict(node)
+    if isinstance(node, MemNode):
+        return _mem_to_dict(node)
+    if isinstance(node, (AddrmapNode, RegfileNode)):
+        return _container_to_dict(node)
+    return {
+        "kind": type(node).__name__,
+        "inst_name": getattr(node, "inst_name", None),
+        "path": node.get_path() if hasattr(node, "get_path") else None,
+    }
+
+
+def build_schema(top_node: AddrmapNode) -> dict[str, Any]:
+    """Return the JSON-serialisable schema for ``top_node``."""
+    return {
+        "version": 1,
+        "soc": _container_to_dict(top_node),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stubs enrichment
+# ---------------------------------------------------------------------------
+
+# Marker we splice into the generated stubs file so a second run replaces
+# our additions instead of stacking duplicates.
+_STUBS_BEGIN = "# --- BEGIN feature_detection ----------------------------------------"
+_STUBS_END = "# --- END   feature_detection ----------------------------------------"
+
+
+def _typed_dict_block_for_reg(reg: RegNode, pybind_name: str) -> str:
+    """Generate the ``TypedDict`` + ``write_fields`` overload for one reg."""
+    fields = list(reg.fields())
+    td_name = f"_{pybind_name}_Fields"
+    lines: list[str] = [f"class {td_name}(TypedDict, total=False):"]
+    if not fields:
+        lines.append("    pass")
+    for fld in fields:
+        lines.append(f"    {fld.inst_name}: {_field_annotation(fld)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _field_annotation(fld: FieldNode) -> str:
+    """Pick the most specific type annotation for ``fld``.
+
+    Ordering: ``Literal[...]`` for enum-encoded fields; ``Annotated[int,
+    Range(0, max)]`` for plain bounded fields.
+    """
+    try:
+        encode = fld.get_property("encode")
+    except LookupError:
+        encode = None
+    if encode is not None:
+        members = getattr(encode, "__members__", None)
+        if members:
+            literal_values = ", ".join(str(int(v)) for v in members.values())
+            if literal_values:
+                return f"Literal[{literal_values}]"
+
+    width = fld.width
+    if width <= 0:
+        return "int"
+    max_value = (1 << width) - 1
+    return f"Annotated[int, Range(0, {max_value})]"
+
+
+def enrich_stubs(stubs_path: Path, regs: Iterable[RegNode], pybind_name_for: Callable[[Node], str]) -> None:
+    """Rewrite ``__init__.pyi`` to add typed ``write_fields`` overloads.
+
+    Idempotent: a previous block delimited by ``_STUBS_BEGIN`` /
+    ``_STUBS_END`` is removed before the new one is appended.
+    """
+    if not stubs_path.exists():
+        return
+
+    text = stubs_path.read_text(encoding="utf-8")
+    text = _strip_existing_block(text)
+
+    # Build the block: imports + per-register TypedDicts + injected
+    # overloads. We add the overloads as standalone classes that subclass
+    # the existing register class -- a "view" type alias would be cleaner,
+    # but mypy/pyright accept the subclass form for autocomplete on
+    # ``reg.write_fields(...)``.
+    typed_dicts: list[str] = []
+    overloads: list[str] = []
+    reg_list = list(regs)
+    if not reg_list:
+        return
+
+    for reg in reg_list:
+        py_name = pybind_name_for(reg)
+        typed_dicts.append(_typed_dict_block_for_reg(reg, py_name))
+
+    # The runtime ``write_fields`` exists on RegisterBase already; we
+    # republish a typed signature per register class so IDEs surface
+    # field-name autocomplete.
+    for reg in reg_list:
+        py_name = pybind_name_for(reg)
+        td_name = f"_{py_name}_Fields"
+        overloads.append(
+            "\n".join(
+                [
+                    f"class {py_name}_typed({py_name}_t):",
+                    f"    def write_fields(self, **fields: Unpack[{td_name}]) -> None: ...",
+                    "",
+                ]
+            )
+        )
+
+    block_lines: list[str] = [
+        _STUBS_BEGIN,
+        "from typing import Annotated, Literal, TypedDict",
+        "try:",
+        "    from typing import Unpack  # type: ignore[attr-defined]",
+        "except ImportError:  # pragma: no cover - Python < 3.11",
+        "    from typing_extensions import Unpack",
+        "",
+        "class Range:",
+        '    """Marker used inside ``Annotated[int, Range(low, high)]``."""',
+        "    def __init__(self, low: int, high: int) -> None: ...",
+        "",
+    ]
+    block_lines.extend(typed_dicts)
+    block_lines.extend(overloads)
+    block_lines.append(_STUBS_END)
+
+    new_text = text.rstrip() + "\n\n" + "\n".join(block_lines) + "\n"
+    stubs_path.write_text(new_text, encoding="utf-8")
+
+
+def _strip_existing_block(text: str) -> str:
+    if _STUBS_BEGIN not in text or _STUBS_END not in text:
+        return text
+    pre, _, rest = text.partition(_STUBS_BEGIN)
+    _, _, post = rest.partition(_STUBS_END)
+    return pre.rstrip() + "\n" + post.lstrip()
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+def _format_python_literal(value: Any) -> str:  # noqa: ANN401 - emitted JSON-shaped literal
+    """Render ``value`` as Python source. ``json.dumps`` would emit
+    ``null`` / ``true`` / ``false`` which aren't valid Python."""
+    return pprint.pformat(value, indent=2, width=88, sort_dicts=False)
+
+
+def _write_interrupts(path: Path, groups: Iterable[InterruptGroup]) -> None:
+    payload = [g.to_dict() for g in groups]
+    text = (
+        '"""Auto-generated by peakrdl_pybind11.exporter_plugins.feature_detection."""\n\n'
+        "from __future__ import annotations\n\n"
+        f"interrupt_groups: list[dict] = {_format_python_literal(payload)}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_aliases(path: Path, aliases: Mapping[str, str]) -> None:
+    text = (
+        '"""Auto-generated by peakrdl_pybind11.exporter_plugins.feature_detection."""\n\n'
+        "from __future__ import annotations\n\n"
+        f"aliases: dict[str, str] = {_format_python_literal(dict(aliases))}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_schema(path: Path, schema: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(schema, indent=2, default=str), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry points
+# ---------------------------------------------------------------------------
+
+
+class FeatureDetectionPlugin:
+    """The actual plugin object registered with the exporter."""
+
+    def post_export(self, ctx: PluginContext) -> None:
+        top = ctx.top_node
+        # The exporter writes the runtime + stubs into both
+        # ``output_dir/`` and ``output_dir/<soc_name>/``; we mirror that
+        # so consumers (and the E2E ls check) can find these files at
+        # the package root.
+        targets = _output_targets(ctx.output_dir, ctx.soc_name)
+
+        pattern = ctx.options.get("interrupt_pattern")
+        groups = detect_interrupt_groups(top, pattern)
+        aliases = detect_aliases(top)
+        schema = build_schema(top)
+
+        for target in targets:
+            target.mkdir(parents=True, exist_ok=True)
+            _write_interrupts(target / "interrupts_detected.py", groups)
+            _write_aliases(target / "aliases.py", aliases)
+            _write_schema(target / "schema.json", schema)
+
+        # Stubs enrichment: rewrite both copies of ``__init__.pyi``.
+        try:
+            regs = ctx.nodes["regs"]
+        except (KeyError, TypeError):
+            regs = []
+        if regs:
+            for stubs_dir in targets:
+                enrich_stubs(
+                    stubs_dir / "__init__.pyi",
+                    regs,
+                    pybind_name_for=ctx.exporter._pybind_name_from_node,  # type: ignore[arg-type]
+                )
+
+        LOGGER.info(
+            "feature_detection: %d interrupt group(s), %d alias(es), schema written to %s",
+            len(groups),
+            len(aliases),
+            ctx.output_dir,
+        )
+
+
+def _output_targets(output_dir: Path, soc_name: str) -> list[Path]:
+    return [output_dir, output_dir / soc_name]
+
+
+def register(_module: object) -> FeatureDetectionPlugin:
+    """Discovery entry point: invoked by ``exporter_plugins.discover_plugins``."""
+    return FeatureDetectionPlugin()
+
+
+__all__ = [
+    "FeatureDetectionPlugin",
+    "InterruptGroup",
+    "build_schema",
+    "detect_aliases",
+    "detect_interrupt_groups",
+    "enrich_stubs",
+    "register",
+]

--- a/tests/runtime/test_feature_detection.py
+++ b/tests/runtime/test_feature_detection.py
@@ -1,0 +1,322 @@
+"""Tests for the feature_detection exporter plugin (Unit 23)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from systemrdl import RDLCompiler
+
+try:
+    from peakrdl_pybind11 import Pybind11Exporter
+    from peakrdl_pybind11.exporter_plugins import feature_detection
+except ImportError:  # pragma: no cover
+    pytest.skip("peakrdl_pybind11 not installed", allow_module_level=True)
+
+
+INTR_RDL = """
+addrmap intr_soc {
+    name = "Interrupt SoC";
+
+    reg {
+        name = "Interrupt status";
+        field { sw=rw; hw=w; intr; } tx_done[0:0];
+        field { sw=rw; hw=w; intr; } rx_overflow[1:1];
+        field { sw=rw; hw=w; intr; } error[2:2];
+    } INTR_STATE @ 0x0;
+
+    reg {
+        name = "Interrupt enable";
+        field { sw=rw; hw=r; } tx_done[0:0];
+        field { sw=rw; hw=r; } rx_overflow[1:1];
+        field { sw=rw; hw=r; } error[2:2];
+    } INTR_ENABLE @ 0x4;
+
+    reg {
+        name = "Interrupt test";
+        field { sw=rw; hw=r; } tx_done[0:0];
+        field { sw=rw; hw=r; } rx_overflow[1:1];
+        field { sw=rw; hw=r; } error[2:2];
+    } INTR_TEST @ 0x8;
+};
+"""
+
+ALIAS_RDL = """
+addrmap alias_soc {
+    reg ctrl_t {
+        field { sw=rw; hw=r; } enable[0:0];
+        field { sw=rw; hw=r; } mode[2:1];
+    };
+    ctrl_t control @ 0x0;
+    alias control ctrl_t control_alt @ 0x10;
+};
+"""
+
+SCHEMA_RDL = """
+addrmap schema_soc {
+    name = "Schema SoC";
+    desc = "Drives schema.json shape tests";
+    regfile uart {
+        reg {
+            name = "Control";
+            field { sw=rw; hw=r; } enable[0:0];
+            field { sw=rw; hw=r; } baudrate[3:1];
+        } control @ 0x00;
+        reg {
+            name = "Status";
+            field { sw=r; hw=w; } tx_ready[0:0];
+        } status @ 0x04;
+    } uart @ 0x1000;
+};
+"""
+
+NO_TRIO_RDL = """
+addrmap empty_soc {
+    reg {
+        field { sw=rw; hw=r; } enable[0:0];
+    } control @ 0x0;
+};
+"""
+
+LOWERCASE_INTR_RDL = """
+addrmap lower_soc {
+    reg {
+        field { sw=rw; hw=w; intr; } a[0:0];
+        field { sw=rw; hw=w; intr; } b[1:1];
+    } intr_status @ 0x0;
+    reg {
+        field { sw=rw; hw=r; } a[0:0];
+        field { sw=rw; hw=r; } b[1:1];
+    } intr_enable @ 0x4;
+    reg {
+        field { sw=rw; hw=r; } a[0:0];
+        field { sw=rw; hw=r; } b[1:1];
+    } intr_test @ 0x8;
+};
+"""
+
+
+def _compile(rdl_src: str) -> object:
+    """Compile RDL source from a string and return the elaborated root."""
+    rdl = RDLCompiler()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".rdl", delete=False) as f:
+        f.write(rdl_src)
+        fn = f.name
+    try:
+        rdl.compile_file(fn)
+        return rdl.elaborate()
+    finally:
+        os.unlink(fn)
+
+
+def _export(rdl_src: str, soc_name: str, **kw: object) -> Path:
+    """Export ``rdl_src`` into a fresh temp dir and return its path."""
+    root = _compile(rdl_src)
+    tmpdir = Path(tempfile.mkdtemp(prefix="feat_detect_"))
+    Pybind11Exporter().export(root.top, str(tmpdir), soc_name=soc_name, **kw)
+    return tmpdir
+
+
+def _load_module(path: Path, name: str) -> object:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# detect_interrupt_groups
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptDetection:
+    def test_detects_full_trio(self) -> None:
+        out = _export(INTR_RDL, "intr_soc")
+        intr_path = out / "interrupts_detected.py"
+        assert intr_path.exists()
+        module = _load_module(intr_path, "intr_emit")
+        groups = module.interrupt_groups
+        assert len(groups) == 1
+        g = groups[0]
+        assert g["state_reg"].endswith("INTR_STATE")
+        assert g["enable_reg"].endswith("INTR_ENABLE")
+        assert g["test_reg"].endswith("INTR_TEST")
+        assert sorted(g["sources"]) == ["error", "rx_overflow", "tx_done"]
+
+    def test_detects_lowercase_trio(self) -> None:
+        out = _export(LOWERCASE_INTR_RDL, "lower_soc")
+        module = _load_module(out / "interrupts_detected.py", "lower_emit")
+        groups = module.interrupt_groups
+        assert len(groups) == 1
+        g = groups[0]
+        assert g["state_reg"].endswith("intr_status")
+        assert g["enable_reg"].endswith("intr_enable")
+        assert g["test_reg"].endswith("intr_test")
+        assert sorted(g["sources"]) == ["a", "b"]
+
+    def test_emits_empty_list_when_no_trio(self) -> None:
+        out = _export(NO_TRIO_RDL, "empty_soc")
+        module = _load_module(out / "interrupts_detected.py", "empty_emit")
+        assert module.interrupt_groups == []
+
+    def test_pattern_string_override(self) -> None:
+        # A status register that doesn't match the default pattern but
+        # we override with --interrupt-pattern.
+        rdl_src = """
+        addrmap custom_soc {
+            reg {
+                field { sw=rw; hw=w; intr; } x[0:0];
+            } MY_FLAGS @ 0x0;
+            reg {
+                field { sw=rw; hw=r; } x[0:0];
+            } MY_ENABLE @ 0x4;
+        };
+        """
+        out = _export(rdl_src, "custom_soc", interrupt_pattern=r"MY_FLAGS")
+        module = _load_module(out / "interrupts_detected.py", "custom_emit")
+        groups = module.interrupt_groups
+        # ``MY_FLAGS`` doesn't end in STATE/STATUS so partner-matching
+        # falls back; we still report the group with the state register
+        # alone if no partners match. Sources come from the state reg.
+        assert len(groups) == 1
+        assert groups[0]["state_reg"].endswith("MY_FLAGS")
+
+    def test_invalid_pattern_type_raises(self) -> None:
+        with pytest.raises(TypeError):
+            feature_detection._normalise_pattern(123)
+
+    def test_pattern_callable_override(self) -> None:
+        out = _export(
+            INTR_RDL,
+            "intr_soc",
+            interrupt_pattern=lambda name: name == "INTR_STATE",
+        )
+        module = _load_module(out / "interrupts_detected.py", "intr_callable_emit")
+        assert len(module.interrupt_groups) == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_aliases
+# ---------------------------------------------------------------------------
+
+
+class TestAliasDetection:
+    def test_records_alias(self) -> None:
+        out = _export(ALIAS_RDL, "alias_soc")
+        aliases_path = out / "aliases.py"
+        assert aliases_path.exists()
+        module = _load_module(aliases_path, "alias_emit")
+        aliases = module.aliases
+        assert len(aliases) == 1
+        (alt_path, target_path), = aliases.items()
+        assert alt_path.endswith("control_alt")
+        assert target_path.endswith("control")
+        assert "control_alt" not in target_path  # primary, not the alias itself
+
+    def test_empty_aliases_when_none(self) -> None:
+        out = _export(SCHEMA_RDL, "schema_soc")
+        module = _load_module(out / "aliases.py", "noalias_emit")
+        assert module.aliases == {}
+
+
+# ---------------------------------------------------------------------------
+# schema.json
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_schema_has_expected_paths_and_addresses(self) -> None:
+        out = _export(SCHEMA_RDL, "schema_soc")
+        schema_path = out / "schema.json"
+        assert schema_path.exists()
+        data = json.loads(schema_path.read_text())
+        assert data["version"] == 1
+        soc = data["soc"]
+        assert soc["kind"] == "addrmap"
+        assert soc["inst_name"] == "schema_soc"
+
+        # Walk the tree to find the uart.control register.
+        def _find(node: dict, path: str) -> dict | None:
+            if node.get("path") == path:
+                return node
+            for child in node.get("children", []) or []:
+                hit = _find(child, path)
+                if hit is not None:
+                    return hit
+            return None
+
+        ctrl = _find(soc, "schema_soc.uart.control")
+        assert ctrl is not None
+        assert ctrl["kind"] == "reg"
+        assert ctrl["absolute_address"] == 0x1000
+        field_names = [f["inst_name"] for f in ctrl["fields"]]
+        assert "enable" in field_names
+        assert "baudrate" in field_names
+
+    def test_schema_round_trips(self) -> None:
+        out = _export(INTR_RDL, "intr_soc")
+        # Should be valid JSON parsable end-to-end.
+        data = json.loads((out / "schema.json").read_text())
+        assert isinstance(data, dict)
+
+
+# ---------------------------------------------------------------------------
+# stubs enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestStubsEnrichment:
+    def test_stubs_contain_typed_dict_and_unpack(self) -> None:
+        out = _export(INTR_RDL, "intr_soc")
+        stubs = (out / "__init__.pyi").read_text()
+        assert "TypedDict" in stubs
+        assert "Unpack[" in stubs
+        # Field-level Annotated[int, Range(0, ...)] for bounded fields.
+        assert "Annotated[int, Range(" in stubs
+        # The block delimiters are present.
+        assert "BEGIN feature_detection" in stubs
+        assert "END   feature_detection" in stubs
+
+    def test_stubs_idempotent(self) -> None:
+        out = _export(INTR_RDL, "intr_soc")
+        path = out / "__init__.pyi"
+        first = path.read_text()
+        # Re-run plugin manually; should produce identical output
+        # (our block strip-and-replace is idempotent).
+        from peakrdl_pybind11.exporter_plugins import feature_detection as fd
+
+        rdl_root = _compile(INTR_RDL)
+        # Re-export to populate exporter state, then call plugin again.
+        exporter = Pybind11Exporter()
+        exporter.export(rdl_root.top, str(out), soc_name="intr_soc")
+        second = path.read_text()
+        # Counts of begin markers stay at exactly one.
+        assert first.count(fd._STUBS_BEGIN) == 1
+        assert second.count(fd._STUBS_BEGIN) == 1
+
+
+# ---------------------------------------------------------------------------
+# Output layout
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_appear_in_package_dir_too() -> None:
+    out = _export(INTR_RDL, "intr_soc")
+    pkg = out / "intr_soc"
+    assert (pkg / "interrupts_detected.py").exists()
+    assert (pkg / "aliases.py").exists()
+    assert (pkg / "schema.json").exists()
+
+
+def test_plugin_discovery_includes_feature_detection() -> None:
+    from peakrdl_pybind11.exporter_plugins import discover_plugins
+
+    plugins = discover_plugins()
+    assert any(
+        type(p).__name__ == "FeatureDetectionPlugin" for p in plugins
+    ), [type(p).__name__ for p in plugins]

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "peakrdl-pybind11"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -534,6 +534,7 @@ docs = [
 ]
 test = [
     { name = "hypothesis" },
+    { name = "peakrdl-cli" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -563,6 +564,7 @@ docs = [
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.151.9" },
+    { name = "peakrdl-cli", specifier = ">=1.2.3" },
     { name = "pytest", specifier = ">=7.4.4" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
 ]


### PR DESCRIPTION
## Summary

Adds an exporter plugin seam under `peakrdl_pybind11.exporter_plugins` plus a `FeatureDetectionPlugin` that runs after the core export and emits:

- **`interrupts_detected.py`** — interrupt trios paired by `INTR_STATE` / `intr_status` / `*_INT_STATUS` plus `_ENABLE` / `_MASK` / `_TEST` / `_RAW` siblings, with field-name matching across the trio (sketch §9.4). Matcher configurable via `--interrupt-pattern` (regex string or callable).
- **`aliases.py`** — mapping of each aliased register path to its primary (sketch §10).
- **`schema.json`** — JSON serialisation of the elaborated node tree (sketch §20).
- **Enriched `__init__.pyi`** — per-register `TypedDict` + `write_fields(**Unpack[...])`, `Literal[...]` for enum-encoded fields, `Annotated[int, Range(0, max)]` for plain bounded fields (sketch §17). Implemented as an idempotent post-process; the Jinja template is untouched.

The plugin discovery seam is the minimal scaffolding sibling Unit 1 will replace/extend; plugins are invoked through a small `PluginContext` and wrapped in a best-effort `try/except` so a plugin failure cannot break the core export.

## Test plan

- [x] `pytest tests/runtime/test_feature_detection.py -v` (14/14 pass)
- [x] Full `pytest tests/` (90 pass, 27 skipped — pre-existing skips for native-master integration)
- [x] Smoke E2E: `peakrdl pybind11 examples/example.rdl -o /tmp/feat --soc-name FeatSoC` → `schema.json`, `interrupts_detected.py`, `aliases.py` present and parseable.
- [x] `ruff check` and `ruff format` clean across changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)