### PR TITLE
feat(runtime): async session dual surface (Unit 22)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,4 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+"""

--- a/src/peakrdl_pybind11/runtime/async_session.py
+++ b/src/peakrdl_pybind11/runtime/async_session.py
@@ -1,0 +1,386 @@
+"""Async dual surface (Unit 22).
+
+Implements the *async session* described in ``docs/IDEAL_API_SKETCH.md``
+§13.8. The sketch (§22.3) explicitly resolves the sync-vs-async tradeoff
+in favor of *sync first*: there are **no native async transports**. Async
+is therefore a thin wrapper around the existing sync surface, dispatching
+each call to a :class:`concurrent.futures.ThreadPoolExecutor` via
+``loop.run_in_executor``.
+
+Design notes
+------------
+* :class:`AsyncSession` is itself the dual surface. Entering the
+  ``async with`` returns the session, and attribute access lazily mirrors
+  the wrapped SoC's tree as :class:`_AsyncNode` proxies. Lazy is the spec
+  -- a 10k-node design must not pay for an unused subtree.
+* Each proxy exposes ``aread`` / ``awrite`` / ``amodify`` / ``aiowait``
+  async methods. They forward ``*args, **kwargs`` to their sync
+  counterparts and return whatever the sync call returns.
+* Executor ownership is tracked: a session that *creates* its executor
+  shuts it down on ``__aexit__``; one that *received* an executor leaves
+  it alone (the caller's lifecycle wins).
+* ``register_post_create(soc, ...)`` is the seam Unit 1 uses to install
+  the feature on every generated SoC. Calling it binds
+  ``soc.async_session`` to a zero-argument callable returning a fresh
+  :class:`AsyncSession`. Idempotent.
+
+The implementation is intentionally pure-Python and self-contained: it
+doesn't depend on the generated module's internals and can be exercised
+with any duck-typed object that exposes ``read`` / ``write`` / ``modify``
+/ ``wait`` callables on its accessor nodes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+__all__ = [
+    "AsyncSession",
+    "register_post_create",
+]
+
+
+# Async-to-sync method mapping for the four canonical bus operations.
+# Order is preserved for ``__dir__``-style introspection so REPL completion
+# lists the methods in their familiar (read/write/modify/wait) sequence.
+_ASYNC_TO_SYNC: dict[str, str] = {
+    "aread": "read",
+    "awrite": "write",
+    "amodify": "modify",
+    "aiowait": "wait",
+}
+
+
+class AsyncSession:
+    """Async dual of a synchronous SoC.
+
+    Wraps an existing ``soc`` and exposes a parallel namespace where every
+    node has ``aread`` / ``awrite`` / ``amodify`` / ``aiowait`` async
+    methods. Calls dispatch to a thread-pool executor; concurrency is
+    therefore bounded by the executor's worker count (default 1).
+
+    Use as an async context manager::
+
+        async with soc.async_session() as s:
+            v = await s.uart.control.aread()
+            await s.uart.control.awrite(0x42)
+
+    Or take ownership of the executor lifecycle yourself::
+
+        executor = ThreadPoolExecutor(max_workers=4)
+        async with soc.async_session(executor=executor) as s:
+            ...
+        # caller owns ``executor``; AsyncSession does not shut it down
+
+    The session lazily mirrors the SoC's tree -- accessing
+    ``s.uart.control`` walks one attribute deep on the wrapped SoC and
+    wraps the result in an :class:`_AsyncNode`. No traversal happens up
+    front, and only the path you touch becomes a proxy.
+    """
+
+    __slots__ = ("_executor", "_node_cache", "_owns_executor", "_soc")
+
+    def __init__(
+        self,
+        soc: object,
+        executor: ThreadPoolExecutor | None = None,
+    ) -> None:
+        self._soc = soc
+        if executor is None:
+            # Default to a single worker; the sketch §22.3 specifies that
+            # the dual surface is "sync wrapped in an executor" -- the
+            # primary win is async ergonomics, not parallelism. Callers
+            # that want concurrent bus ops pass their own pool.
+            self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="peakrdl-async-session")
+            self._owns_executor = True
+        else:
+            self._executor = executor
+            self._owns_executor = False
+        self._node_cache: dict[str, _AsyncNode] = {}
+
+    # ------------------------------------------------------------------
+    # Async context manager protocol
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> AsyncSession:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> None:
+        if self._owns_executor:
+            # Hand off the blocking shutdown to a thread so we don't stall
+            # the event loop on an active worker. ``wait=True`` ensures
+            # any in-flight bus op finishes cleanly before the executor
+            # disappears.
+            loop = asyncio.get_running_loop()
+            executor = self._executor
+            self._owns_executor = False  # one-shot guard; idempotent close
+            await loop.run_in_executor(None, lambda: executor.shutdown(wait=True))
+
+    # ------------------------------------------------------------------
+    # Lazy mirror of the SoC's tree
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        # ``Any`` because the dual mirrors a generated tree whose
+        # accessors aren't visible to the type checker at this level;
+        # consumers wanting strict typing use the generated ``.pyi``.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        cache = self._node_cache
+        cached = cache.get(name)
+        if cached is not None:
+            return cached
+        try:
+            sync_value = getattr(self._soc, name)
+        except AttributeError:
+            raise AttributeError(f"{type(self._soc).__name__!s} has no attribute {name!r}") from None
+        # Wrap regfiles/addrmaps even when they don't themselves expose
+        # ``read`` -- they contain registers that do. Primitives on the
+        # SoC (version strings, scalar config) flow through so consumers
+        # can read them without await ceremony.
+        if _is_primitive(sync_value):
+            return sync_value
+        proxy = _AsyncNode(sync_value, self._executor)
+        cache[name] = proxy
+        return proxy
+
+    def __dir__(self) -> list[str]:
+        # Mirrors the SoC for tab-completion. Public attrs only -- the
+        # dual surface should not advertise private state.
+        sync_attrs = [a for a in dir(self._soc) if not a.startswith("_")]
+        own = [a for a in type(self).__dict__ if not a.startswith("_")]
+        return sorted(set(sync_attrs) | set(own))
+
+    @property
+    def soc(self) -> Any:  # noqa: ANN401
+        """The wrapped synchronous SoC. Useful for falling back to sync."""
+        return self._soc
+
+    @property
+    def executor(self) -> ThreadPoolExecutor:
+        """The executor backing async dispatch."""
+        return self._executor
+
+
+class _AsyncNode:
+    """Lazy async proxy around a sync accessor node.
+
+    Holds a strong reference to the underlying ``sync_node`` and the
+    executor. Attribute access produces child proxies on demand, sharing
+    the same executor; method access produces async wrappers for the four
+    canonical bus operations (``aread`` / ``awrite`` / ``amodify`` /
+    ``aiowait``) and falls back to plain attribute lookup for everything
+    else (so users can still inspect ``.path``, ``.address``, etc.).
+    """
+
+    __slots__ = ("_child_cache", "_executor", "_forwarder_cache", "_sync_node")
+
+    def __init__(self, sync_node: object, executor: ThreadPoolExecutor) -> None:
+        self._sync_node = sync_node
+        self._executor = executor
+        self._child_cache: dict[str, _AsyncNode] = {}
+        # Forwarders are stable per (node, async-name): caching lets a
+        # tight poll loop reuse the same closure rather than rebuild it
+        # on every ``s.uart.control.aread()`` access.
+        self._forwarder_cache: dict[str, Callable[..., Any]] = {}
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        if name.startswith("_"):
+            # Pickling, ``hasattr('__getstate__')``, and similar dunder
+            # probes must not spin up bogus proxies.
+            raise AttributeError(name)
+
+        sync_name = _ASYNC_TO_SYNC.get(name)
+        if sync_name is not None:
+            return self._async_forwarder(name, sync_name)
+
+        cache = self._child_cache
+        cached = cache.get(name)
+        if cached is not None:
+            return cached
+
+        try:
+            value = getattr(self._sync_node, name)
+        except AttributeError:
+            raise AttributeError(f"{type(self._sync_node).__name__!s} has no attribute {name!r}") from None
+
+        if _is_node_like(value):
+            proxy = _AsyncNode(value, self._executor)
+            cache[name] = proxy
+            return proxy
+        return value
+
+    def __dir__(self) -> list[str]:
+        sync_attrs = [a for a in dir(self._sync_node) if not a.startswith("_")]
+        return sorted(set(sync_attrs) | _ASYNC_TO_SYNC.keys())
+
+    @property
+    def sync(self) -> Any:  # noqa: ANN401
+        """The wrapped sync node, for callers that want to drop back."""
+        return self._sync_node
+
+    # ------------------------------------------------------------------
+    # Async dispatch
+    # ------------------------------------------------------------------
+
+    def _async_forwarder(self, async_name: str, sync_name: str) -> Callable[..., Any]:
+        cached = self._forwarder_cache.get(async_name)
+        if cached is not None:
+            return cached
+        forwarder = self._build_async_forwarder(async_name, sync_name)
+        self._forwarder_cache[async_name] = forwarder
+        return forwarder
+
+    def _build_async_forwarder(self, async_name: str, sync_name: str) -> Callable[..., Any]:
+        sync_node = self._sync_node
+        executor = self._executor
+
+        try:
+            sync_callable = getattr(sync_node, sync_name)
+        except AttributeError:
+            # Mirrors how the sync surface would behave if a node simply
+            # doesn't support an op (e.g. a write-only register has no
+            # ``read``).
+            raise AttributeError(
+                f"{type(sync_node).__name__!s}.{async_name}: underlying node has no {sync_name!r} method"
+            ) from None
+
+        if not callable(sync_callable):
+            raise TypeError(
+                f"{type(sync_node).__name__!s}.{sync_name} is not callable; cannot expose as {async_name!r}"
+            )
+
+        async def _forward(*args: object, **kwargs: object) -> Any:  # noqa: ANN401
+            # ``Any`` return because the wrapped op may produce a
+            # ``RegisterValue``, an int, an ndarray, ``None`` for writes,
+            # or any caller-defined value.
+            loop = asyncio.get_running_loop()
+
+            def _call() -> object:
+                return sync_callable(*args, **kwargs)
+
+            return await loop.run_in_executor(executor, _call)
+
+        # Stamp metadata so ``inspect.signature`` and ``help()`` see the
+        # underlying op, not the generic forwarder.
+        _forward.__name__ = async_name
+        try:
+            _forward.__signature__ = inspect.signature(sync_callable)  # type: ignore[attr-defined]
+        except (TypeError, ValueError):
+            # Some C-extension callables don't expose a signature.
+            pass
+        sync_doc = getattr(sync_callable, "__doc__", None)
+        if sync_doc:
+            _forward.__doc__ = (
+                f"Async wrapper around {type(sync_node).__name__}."
+                f"{sync_name}; runs on the session's thread pool.\n\n"
+                f"{sync_doc}"
+            )
+        return _forward
+
+
+_PRIMITIVE_TYPES: tuple[type, ...] = (
+    int,
+    float,
+    str,
+    bytes,
+    bytearray,
+    bool,
+    complex,
+    list,
+    tuple,
+    dict,
+    set,
+    frozenset,
+)
+
+
+def _is_primitive(value: object) -> bool:
+    """Return ``True`` if ``value`` is a leaf attribute the dual should
+    return as-is rather than wrap.
+
+    Used at the *session* layer, where the SoC may carry both registers
+    (which we want to wrap) and bare configuration (path strings,
+    version ints, callables). Anything that satisfies this predicate
+    flows through unchanged.
+    """
+    if value is None:
+        return True
+    if isinstance(value, _PRIMITIVE_TYPES):
+        return True
+    if callable(value):
+        return True
+    return False
+
+
+def _is_node_like(value: object) -> bool:
+    """Return ``True`` if ``value`` should be wrapped as a child proxy.
+
+    Used at the *node* layer, where we want a stricter test: an
+    attribute that exposes one of the canonical bus methods is a child
+    accessor; anything else (a path string, an int address, a metadata
+    dict) flows through unchanged.
+
+    Errs on the side of *not* wrapping: a false negative just means the
+    attribute is returned as-is, which is the safe behavior for anything
+    the runtime doesn't recognize.
+    """
+    if _is_primitive(value):
+        return False
+    # Any of the canonical bus methods is enough to flag a node-like
+    # object. Keeps the heuristic tight without enumerating every
+    # generated class type.
+    return any(callable(getattr(value, sync_name, None)) for sync_name in _ASYNC_TO_SYNC.values())
+
+
+# ---------------------------------------------------------------------------
+# Wiring helper (the seam used by Unit 1's ``_registry``)
+# ---------------------------------------------------------------------------
+#
+# The runtime registry (sibling Unit 1) calls ``register_post_create`` on
+# every generated SoC during construction. This module's contribution is
+# a single attribute: ``soc.async_session`` -- a zero-argument callable
+# that returns a fresh :class:`AsyncSession`. Sessions are short-lived
+# (the executor lifecycle ties to ``async with``), so we don't cache on
+# the SoC; each call returns a new session.
+#
+# The helper is pure-Python and self-contained: it doesn't import from
+# ``_registry``, so this module compiles cleanly on branches where Unit
+# 1 has not yet landed.
+
+
+def register_post_create(soc: object) -> object:
+    """Attach :class:`AsyncSession` factory to ``soc.async_session``.
+
+    Sets ``soc.async_session`` to a zero-argument callable that returns a
+    fresh :class:`AsyncSession` wrapping ``soc``. Returns ``soc`` for
+    chaining.
+
+    Idempotent: re-registering rebinds the factory but keeps existing
+    sessions alive. Generated modules call this once per SoC instance
+    via Unit 1's seam; tests can invoke it directly on any duck-typed
+    object.
+    """
+
+    def _factory(executor: ThreadPoolExecutor | None = None) -> AsyncSession:
+        return AsyncSession(soc, executor=executor)
+
+    _factory.__name__ = "async_session"
+    _factory.__qualname__ = f"{type(soc).__name__}.async_session"
+    _factory.__doc__ = (
+        "Return a new :class:`AsyncSession` wrapping this SoC.\n\n"
+        "Use as an async context manager::\n\n"
+        "    async with soc.async_session() as s:\n"
+        "        v = await s.uart.control.aread()\n"
+    )
+    soc.async_session = _factory  # type: ignore[attr-defined]
+    return soc

--- a/tests/runtime/test_async_session.py
+++ b/tests/runtime/test_async_session.py
@@ -1,0 +1,427 @@
+"""Unit tests for ``peakrdl_pybind11.runtime.async_session`` (Unit 22).
+
+These tests exercise the async dual surface entirely with a Python
+``_FakeSoc``: a hand-rolled tree of accessor nodes whose sync ``read`` /
+``write`` / ``modify`` / ``wait`` methods record what they were called
+with. No generated module, no native master -- async is sync wrapped in
+a thread executor, so the dual is fully exercisable in pure Python.
+
+Coverage matches the task brief:
+
+1. ``async with soc.async_session() as s: await s.uart.control.aread()``
+   returns the same value as the sync ``read()``.
+2. ``await s.uart.control.awrite(0x42)`` issues a write.
+3. Multiple awaits run concurrently in the executor (verified with both
+   ``asyncio.gather`` against a single-worker default *and* a multi-
+   worker pool that overlaps ``time.sleep``).
+4. The thread pool is properly shut down on ``__aexit__``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime.async_session import (
+    AsyncSession,
+    register_post_create,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeReg:
+    """Minimal stand-in for a generated register accessor."""
+
+    def __init__(self, path: str, value: int = 0, *, work_seconds: float = 0.0) -> None:
+        self.path = path
+        self._value = value
+        self._work_seconds = work_seconds
+        self.read_calls = 0
+        self.write_calls: list[tuple[int, dict[str, Any]]] = []
+        self.modify_calls: list[dict[str, Any]] = []
+        self.wait_calls: list[dict[str, Any]] = []
+        self.read_threads: list[int] = []
+
+    # The four sync ops the dual mirrors, plus path/address introspection.
+    def read(self) -> int:
+        self.read_calls += 1
+        self.read_threads.append(threading.get_ident())
+        if self._work_seconds:
+            time.sleep(self._work_seconds)
+        return self._value
+
+    def write(self, value: int, *, mask: int | None = None) -> None:
+        self.write_calls.append((value, {"mask": mask}))
+        if mask is None:
+            self._value = value
+        else:
+            self._value = (self._value & ~mask) | (value & mask)
+
+    def modify(self, **fields: int) -> int:
+        self.modify_calls.append(dict(fields))
+        # Pretend each field is one bit; just OR them in for the test.
+        for v in fields.values():
+            self._value |= int(v)
+        return self._value
+
+    def wait(self, *, timeout: float = 0.0) -> bool:
+        self.wait_calls.append({"timeout": timeout})
+        return True
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+
+class _FakeUart:
+    """Container for a couple of registers; mimics a regfile."""
+
+    def __init__(self) -> None:
+        self.control = _FakeReg("uart.control", value=0x1234)
+        self.status = _FakeReg("uart.status", value=0xCAFE)
+
+
+class _FakeSoc:
+    """Minimal SoC analogue with two regfiles -- enough to chain."""
+
+    def __init__(self) -> None:
+        self.uart = _FakeUart()
+        self.spi = _FakeUart()
+        # A scalar attribute to confirm the dual passes primitives through
+        # without wrapping them as proxies.
+        self.name: str = "fake_soc"
+
+
+@pytest.fixture
+def soc() -> _FakeSoc:
+    return register_post_create(_FakeSoc())
+
+
+# ---------------------------------------------------------------------------
+# Wiring & context manager protocol
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPostCreate:
+    def test_attaches_async_session_factory(self, soc: _FakeSoc) -> None:
+        # The seam binds a callable named ``async_session``.
+        assert callable(soc.async_session)  # type: ignore[attr-defined]
+        session = soc.async_session()  # type: ignore[attr-defined]
+        assert isinstance(session, AsyncSession)
+
+    def test_factory_returns_a_new_session_each_call(self, soc: _FakeSoc) -> None:
+        s1 = soc.async_session()  # type: ignore[attr-defined]
+        s2 = soc.async_session()  # type: ignore[attr-defined]
+        assert s1 is not s2
+
+    def test_re_register_is_idempotent(self, soc: _FakeSoc) -> None:
+        # Re-binding shouldn't break or pile up state.
+        register_post_create(soc)
+        register_post_create(soc)
+        assert callable(soc.async_session)  # type: ignore[attr-defined]
+
+
+class TestContextManager:
+    def test_enter_returns_self(self, soc: _FakeSoc) -> None:
+        async def _run() -> None:
+            session = soc.async_session()  # type: ignore[attr-defined]
+            entered = await session.__aenter__()
+            try:
+                assert entered is session
+            finally:
+                await session.__aexit__(None, None, None)
+
+        asyncio.run(_run())
+
+    def test_async_with_yields_session(self, soc: _FakeSoc) -> None:
+        async def _run() -> AsyncSession:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return s
+
+        s = asyncio.run(_run())
+        assert isinstance(s, AsyncSession)
+
+
+# ---------------------------------------------------------------------------
+# Read / write / modify / wait forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestForwardedOps:
+    def test_aread_returns_same_value_as_sync_read(self, soc: _FakeSoc) -> None:
+        async def _run() -> int:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return await s.uart.control.aread()
+
+        result = asyncio.run(_run())
+        assert result == soc.uart.control.read()
+        # ``read()`` was called once via the dual and once just now.
+        assert soc.uart.control.read_calls == 2
+
+    def test_awrite_issues_write(self, soc: _FakeSoc) -> None:
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                await s.uart.control.awrite(0x42)
+
+        asyncio.run(_run())
+        assert soc.uart.control.write_calls == [(0x42, {"mask": None})]
+        assert soc.uart.control.value == 0x42
+
+    def test_awrite_passes_kwargs_through(self, soc: _FakeSoc) -> None:
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                await s.uart.control.awrite(0xFF, mask=0x0F)
+
+        asyncio.run(_run())
+        assert soc.uart.control.write_calls == [(0xFF, {"mask": 0x0F})]
+
+    def test_amodify_passes_kwargs_through(self, soc: _FakeSoc) -> None:
+        async def _run() -> int:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return await s.uart.control.amodify(enable=1, parity=2)
+
+        result = asyncio.run(_run())
+        assert soc.uart.control.modify_calls == [{"enable": 1, "parity": 2}]
+        # The fake's modify ORs each value into its register; result is
+        # the post-modify value the sync surface returns.
+        assert result == soc.uart.control.value
+
+    def test_aiowait_forwards_to_sync_wait(self, soc: _FakeSoc) -> None:
+        async def _run() -> bool:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return await s.uart.control.aiowait(timeout=0.5)
+
+        result = asyncio.run(_run())
+        assert result is True
+        assert soc.uart.control.wait_calls == [{"timeout": 0.5}]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_gather_collects_all_results_with_default_executor(
+        self, soc: _FakeSoc
+    ) -> None:
+        # Default executor is single-worker; ``gather`` still must not
+        # deadlock or drop results.
+        async def _run() -> tuple[int, int]:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return await asyncio.gather(  # type: ignore[return-value]
+                    s.uart.control.aread(),
+                    s.uart.status.aread(),
+                )
+
+        a, b = asyncio.run(_run())
+        assert a == soc.uart.control.value
+        assert b == soc.uart.status.value
+
+    def test_multi_worker_pool_overlaps_blocking_work(self) -> None:
+        # With four workers and a blocking sync sleep, two awaits should
+        # finish in roughly half the wall clock of running them serially.
+        # Relax the bound generously to keep CI happy.
+        soc = register_post_create(_FakeSoc())
+        soc.uart.control = _FakeReg("uart.control", value=1, work_seconds=0.1)  # type: ignore[attr-defined]
+        soc.uart.status = _FakeReg("uart.status", value=2, work_seconds=0.1)  # type: ignore[attr-defined]
+
+        executor = ThreadPoolExecutor(max_workers=4)
+
+        async def _run() -> tuple[float, list[int]]:
+            async with soc.async_session(executor=executor) as s:  # type: ignore[attr-defined]
+                start = time.monotonic()
+                values = await asyncio.gather(
+                    s.uart.control.aread(),
+                    s.uart.status.aread(),
+                )
+                elapsed = time.monotonic() - start
+                return elapsed, list(values)
+
+        try:
+            elapsed, values = asyncio.run(_run())
+        finally:
+            # We own ``executor``; the session must not have shut it
+            # down. (Asserted explicitly below.)
+            executor.shutdown(wait=True)
+        assert values == [1, 2]
+        # 0.10s * 2 serial vs ~0.10s parallel -> bound at 0.18s.
+        assert elapsed < 0.18, f"expected concurrent execution, got {elapsed:.3f}s"
+
+    def test_runs_on_executor_thread_not_event_loop_thread(
+        self, soc: _FakeSoc
+    ) -> None:
+        async def _run() -> int:
+            loop_thread = threading.get_ident()
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                await s.uart.control.aread()
+            return loop_thread
+
+        loop_thread = asyncio.run(_run())
+        assert soc.uart.control.read_threads, "read should have been recorded"
+        # Every recorded read must have happened off the event-loop thread.
+        assert all(t != loop_thread for t in soc.uart.control.read_threads)
+
+
+# ---------------------------------------------------------------------------
+# Executor lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorLifecycle:
+    def test_default_executor_is_shut_down_on_aexit(self, soc: _FakeSoc) -> None:
+        captured: dict[str, Any] = {}
+
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                captured["executor"] = s.executor
+                # Do at least one op so the worker thread is alive.
+                await s.uart.control.aread()
+
+        asyncio.run(_run())
+        executor: ThreadPoolExecutor = captured["executor"]
+        # ``submit`` raises ``RuntimeError`` once an executor has been
+        # shut down. (Confirmed on stdlib in 3.10+.)
+        with pytest.raises(RuntimeError):
+            executor.submit(lambda: None)
+
+    def test_caller_owned_executor_is_left_running(self, soc: _FakeSoc) -> None:
+        executor = ThreadPoolExecutor(max_workers=2)
+
+        async def _run() -> None:
+            async with soc.async_session(executor=executor) as s:  # type: ignore[attr-defined]
+                await s.uart.control.aread()
+
+        try:
+            asyncio.run(_run())
+            # Executor should still accept work after the session closes.
+            future = executor.submit(lambda: 42)
+            assert future.result(timeout=1.0) == 42
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_aexit_idempotent_on_repeat(self, soc: _FakeSoc) -> None:
+        # If a misbehaving caller manually invokes ``__aexit__`` twice,
+        # the second call must not re-shutdown a now-dead executor.
+        async def _run() -> None:
+            session = soc.async_session()  # type: ignore[attr-defined]
+            await session.__aenter__()
+            await session.__aexit__(None, None, None)
+            await session.__aexit__(None, None, None)
+
+        asyncio.run(_run())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Lazy mirror & introspection
+# ---------------------------------------------------------------------------
+
+
+class TestLazyMirror:
+    def test_attribute_chain_walks_lazily(self, soc: _FakeSoc) -> None:
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                # Touching ``uart`` shouldn't force ``spi`` to materialize.
+                node = s.uart
+                assert "spi" not in s._node_cache  # noqa: SLF001
+                # Subsequent access returns the same proxy.
+                assert s.uart is node
+
+        asyncio.run(_run())
+
+    def test_dir_mirrors_underlying_attrs(self, soc: _FakeSoc) -> None:
+        async def _run() -> list[str]:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return dir(s)
+
+        names = asyncio.run(_run())
+        assert "uart" in names
+        assert "spi" in names
+
+    def test_dir_on_node_includes_async_methods(self, soc: _FakeSoc) -> None:
+        async def _run() -> list[str]:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return dir(s.uart.control)
+
+        names = asyncio.run(_run())
+        assert {"aread", "awrite", "amodify", "aiowait"}.issubset(set(names))
+
+    def test_unknown_attribute_raises_attribute_error(
+        self, soc: _FakeSoc
+    ) -> None:
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                with pytest.raises(AttributeError):
+                    _ = s.does_not_exist
+
+        asyncio.run(_run())
+
+    def test_scalar_attribute_passes_through(self, soc: _FakeSoc) -> None:
+        # ``soc.name`` is a plain string; the proxy must not wrap it.
+        async def _run() -> Any:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return s.name
+
+        # ``name`` lives directly on the SoC, so the dual returns the str.
+        result = asyncio.run(_run())
+        assert result == "fake_soc"
+
+    def test_node_sync_property_returns_underlying(self, soc: _FakeSoc) -> None:
+        async def _run() -> Any:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return s.uart.control.sync
+
+        underlying = asyncio.run(_run())
+        assert underlying is soc.uart.control
+
+    def test_session_soc_property(self, soc: _FakeSoc) -> None:
+        async def _run() -> Any:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                return s.soc
+
+        assert asyncio.run(_run()) is soc
+
+    def test_missing_sync_method_surfaces_on_async(self, soc: _FakeSoc) -> None:
+        # If the underlying node doesn't have ``modify``, the async
+        # surface should report it cleanly rather than failing inside the
+        # executor.
+        class _NoModifyReg:
+            def read(self) -> int:
+                return 7
+
+        soc.special = _NoModifyReg()  # type: ignore[attr-defined]
+
+        async def _run() -> None:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                with pytest.raises(AttributeError, match="modify"):
+                    _ = s.special.amodify
+
+        asyncio.run(_run())
+
+    def test_async_forwarder_is_cached_per_node(self, soc: _FakeSoc) -> None:
+        # A poll loop calling ``s.uart.control.aread()`` 1000 times must
+        # not rebuild the forwarder on each access; reuse the cached
+        # closure so attribute-access cost stays O(1).
+        async def _run() -> tuple[Any, Any, Any, Any]:
+            async with soc.async_session() as s:  # type: ignore[attr-defined]
+                ctrl = s.uart.control
+                a1 = ctrl.aread
+                a2 = ctrl.aread
+                # Cross-method: each async name caches its own forwarder.
+                w1 = ctrl.awrite
+                w2 = ctrl.awrite
+                return a1, a2, w1, w2
+
+        a1, a2, w1, w2 = asyncio.run(_run())
+        assert a1 is a2
+        assert w1 is w2
+        assert a1 is not w1


### PR DESCRIPTION
## Summary
- Implements Unit 22 (`runtime/async_session.py`): an `AsyncSession` that wraps a sync soc and dispatches `aread` / `awrite` / `amodify` / `aiowait` calls through a `ThreadPoolExecutor` via `loop.run_in_executor`. Per `IDEAL_API_SKETCH.md` §13.8 / §22.3 there are no native async transports.
- Lazy mirror: `AsyncSession` + `_AsyncNode` wrap regfiles/registers on demand and cache forwarders per `(node, async-name)` so tight poll loops don't rebuild closures.
- `register_post_create(soc)` attaches the factory to `soc.async_session`, idempotent and self-contained so it compiles on branches where Unit 1's `_registry` hasn't landed yet.

## Test plan
- [x] `uv sync --group test`
- [x] `pytest tests/runtime/test_async_session.py -v` (25 passing)
- [x] `pytest tests/` (101 passing, 27 environment-skipped — no regressions)
- [x] `ruff check` and `ty check src/peakrdl_pybind11/runtime/async_session.py` clean

Coverage of the brief: `await s.uart.control.aread()` returns the same value as `read()`; `await s.uart.control.awrite(0x42)` issues a write; `asyncio.gather` of multiple awaits collects all results (single-worker default + multi-worker overlap test); executor is shut down on `__aexit__` for the owned case and left running for the caller-owned case.

Sibling deps: Unit 1 (`_registry`) — wired conventionally via the module-local `register_post_create(soc, ...)` pattern that other units (e.g. `observers.py`) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)