### PR TITLE
feat(runtime): soc.reload() + policy (Unit 16)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,13 @@
+"""Runtime support utilities for PeakRDL-pybind11 generated SoC modules.
+
+This subpackage holds pure-Python helpers that are imported (or invoked)
+by both the host-side runtime and the generated bindings:
+
+* ``hot_reload`` — ``soc.reload()``, generation/staleness tracking, and the
+  active-context guard used by transaction-style context managers.
+
+The submodule layout intentionally avoids cycles: each module is independently
+importable and only depends on the standard library.
+"""
+
+from __future__ import annotations

--- a/src/peakrdl_pybind11/runtime/hot_reload.py
+++ b/src/peakrdl_pybind11/runtime/hot_reload.py
@@ -1,0 +1,350 @@
+"""Python-side hot-reload support for generated SoC modules.
+
+Implements the runtime contract described in ``IDEAL_API_SKETCH.md`` §21
+(``--watch`` + ``soc.reload``) and §22.6 (decision log: opt-in, loud,
+invalidate handles, refuse during context managers, preserve bus state):
+
+* ``soc.reload()`` re-imports the generated module, bumps a global
+  generation counter so outstanding ``RegisterValue``/``Snapshot`` handles
+  raise ``StaleHandleError`` on use, refuses to swap the tree while a
+  context manager is active, and reattaches the existing master to the
+  freshly built tree. Hardware bus state is untouched — only the host-side
+  bindings get replaced.
+* The reload policy is controlled by the module-level ``policy`` attribute,
+  which is either ``"warn"`` (the default) or ``"fail"``.
+
+Cross-unit seams
+----------------
+* Other units (``RegisterValue`` / ``Snapshot``) capture
+  :func:`current_generation` at construction time and call
+  :func:`check_generation` before any operation that might observe stale
+  state. The contract is intentionally narrow and lives in this module so
+  every consumer sees the same counter.
+* Transaction / write-only / no-side-effects context managers register
+  themselves via :func:`register_context` and unregister on exit. Reload
+  refuses to swap the tree while at least one is active.
+* :func:`attach_reload` binds the entry point as ``soc.reload`` on a
+  freshly constructed SoC; Unit 1's ``register_post_create`` seam (when
+  present) calls it during ``Soc.create``. The attachment also works
+  standalone for tests and direct host-side use.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import types
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+# Soc instances are dynamically built (one Python module per chip), so the
+# host-side helpers can only reason about them through duck typing. The type
+# alias makes the intent explicit at every call site without forcing each
+# function to opt out of ANN401 individually.
+_Soc = Any
+
+__all__ = [
+    "attach_reload",
+    "check_generation",
+    "current_generation",
+    "policy",
+    "register_context",
+    "reload",
+    "unregister_context",
+]
+
+
+# ---------------------------------------------------------------------------
+# Public configuration
+# ---------------------------------------------------------------------------
+
+#: Reload policy, mirrored under ``peakrdl.reload.policy`` for the user-facing
+#: documented surface. ``"warn"`` (default) emits ``UserWarning`` and
+#: invalidates outstanding handles; ``"fail"`` raises :class:`RuntimeError`
+#: instead of swapping the tree.
+policy: str = "warn"
+
+_VALID_POLICIES: frozenset[str] = frozenset({"warn", "fail"})
+
+
+# ---------------------------------------------------------------------------
+# Generation counter — drives ``RegisterValue`` / ``Snapshot`` staleness
+# ---------------------------------------------------------------------------
+
+# Monotonic counter; bumped on each successful reload. Long handles snapshot
+# the value at creation and compare on use. We use a ``threading.Lock`` so
+# concurrent reloads in the same process serialise — reloads are rare,
+# correctness wins over throughput.
+_generation_lock = threading.Lock()
+_generation: int = 0
+
+
+def current_generation() -> int:
+    """Return the current global handle generation.
+
+    Other units (``RegisterValue``, ``Snapshot``) capture this value when
+    constructed and feed it back into :func:`check_generation` before every
+    operation that could expose stale state.
+    """
+
+    return _generation
+
+
+def check_generation(captured: int) -> None:
+    """Raise ``StaleHandleError`` if ``captured`` is not the current generation.
+
+    The error class lives in ``peakrdl_pybind11.errors`` (Unit 2). We import
+    lazily to avoid a hard dependency on the sibling unit's import order; if
+    the canonical class is unavailable we fall back to a locally-defined
+    placeholder that subclasses ``RuntimeError`` so the user-facing behaviour
+    is preserved.
+    """
+
+    if captured == _generation:
+        return
+    raise _resolve_stale_handle_class()(
+        f"handle from generation {captured} used after reload "
+        f"(current generation {_generation}); soc.reload() invalidates "
+        "outstanding RegisterValue/Snapshot instances"
+    )
+
+
+def _resolve_stale_handle_class() -> type[Exception]:
+    """Return the canonical ``StaleHandleError`` if Unit 2 has landed."""
+
+    try:
+        from peakrdl_pybind11 import errors as _errors
+    except ImportError:
+        return _LocalStaleHandleError
+    cls = getattr(_errors, "StaleHandleError", None)
+    if isinstance(cls, type) and issubclass(cls, Exception):
+        return cls
+    return _LocalStaleHandleError
+
+
+class _LocalStaleHandleError(RuntimeError):
+    """Fallback ``StaleHandleError`` used until Unit 2 ships ``errors``."""
+
+
+# ---------------------------------------------------------------------------
+# Active-context tracking — reload refuses while any context manager is open
+# ---------------------------------------------------------------------------
+
+# §22.6 specifies thread-local tracking: each thread's transactions /
+# write-only blocks are scoped to that thread, and ``soc.reload()`` should
+# refuse on the same thread that owns the open context. Cross-thread reload
+# coordination is a higher-level concern and not part of this seam.
+_active_contexts = threading.local()
+
+
+def _thread_contexts() -> set[object]:
+    """Return the calling thread's set of active contexts, lazily allocated."""
+
+    contexts = getattr(_active_contexts, "contexts", None)
+    if contexts is None:
+        contexts = set()
+        _active_contexts.contexts = contexts
+    return contexts
+
+
+def register_context(ctx: object) -> None:
+    """Mark ``ctx`` as an active context manager (transaction, write-only, …).
+
+    Idempotent: re-registering the same object is a no-op. Callers should
+    pair every successful registration with :func:`unregister_context` in a
+    ``finally`` block.
+    """
+
+    _thread_contexts().add(ctx)
+
+
+def unregister_context(ctx: object) -> None:
+    """Remove ``ctx`` from the active set; tolerates missing entries."""
+
+    _thread_contexts().discard(ctx)
+
+
+def _has_active_contexts() -> bool:
+    return bool(getattr(_active_contexts, "contexts", None))
+
+
+# ---------------------------------------------------------------------------
+# Reload entry point
+# ---------------------------------------------------------------------------
+
+
+def reload(soc: _Soc) -> None:
+    """Re-import the generated module backing ``soc`` and rebind the tree.
+
+    Steps, in order:
+
+    1. Refuse if any context manager is still active — the staged work
+       belongs to the *old* tree and we cannot guarantee a sane swap.
+       Checked **before** the policy gate so users see the real cause.
+    2. Honour ``policy = "fail"`` by raising ``RuntimeError`` and leaving
+       the world untouched.
+    3. Resolve the generated module from ``soc`` (``__module__`` of the
+       SoC class, falling back to a ``_module_name`` attribute) and call
+       :func:`importlib.reload` on it.
+    4. Build a fresh SoC by calling the new module's factory and reattach
+       the existing master so hardware bus state is preserved.
+    5. Bump the generation counter — *after* a successful reload so a
+       failed import does not strand handles in a useless state.
+    6. Emit a ``UserWarning`` so the loud-by-default contract is honoured.
+    """
+
+    if _has_active_contexts():
+        raise RuntimeError(
+            "soc.reload() refused: a context manager is still active "
+            "(transaction, write-only, etc.) — exit it before reloading"
+        )
+
+    if policy == "fail":
+        raise RuntimeError("soc.reload() blocked by policy='fail'")
+    if policy not in _VALID_POLICIES:
+        raise RuntimeError(
+            f"unknown peakrdl.reload.policy={policy!r}; expected one of {sorted(_VALID_POLICIES)!r}"
+        )
+
+    module = _resolve_module(soc)
+    reloaded = importlib.reload(module)
+    _rebind_soc(soc, reloaded)
+
+    # Bump on success only — a failed reload leaves outstanding handles
+    # bound to the still-live old tree.
+    global _generation
+    with _generation_lock:
+        _generation += 1
+
+    warnings.warn(
+        "soc reloaded; outstanding RegisterValue/Snapshot are now stale",
+        category=UserWarning,
+        stacklevel=2,
+    )
+
+
+def _resolve_module(soc: _Soc) -> types.ModuleType:
+    """Return the module object backing ``soc``.
+
+    Generated modules expose ``Soc.create(master=...)`` and live at the
+    package's top level. We first honour an explicit ``_module_name`` hint,
+    then fall back to ``type(soc).__module__`` — both routes resolve via
+    ``sys.modules``/``importlib`` so any aliasing (e.g. ``mychip._native``
+    re-exported through ``mychip``) lands on the same module object.
+    """
+
+    name = getattr(soc, "_module_name", None) or type(soc).__module__
+    if not name or name == "__main__":
+        raise RuntimeError(
+            "soc.reload() cannot determine the generated module to reload; "
+            "set soc._module_name or define the SoC class in an importable module"
+        )
+    return importlib.import_module(name)
+
+
+def _rebind_soc(soc: _Soc, reloaded_module: types.ModuleType) -> None:
+    """Reconstruct the SoC tree from ``reloaded_module`` and graft it onto ``soc``.
+
+    The exact factory varies between generated modules; we look for the
+    documented entry points in priority order. Whatever shape the new soc
+    takes, the *old* master is moved across so bus state is preserved.
+    """
+
+    factory = _find_factory(reloaded_module)
+    if factory is None:
+        raise RuntimeError(
+            f"reloaded module {reloaded_module.__name__!r} exposes no "
+            "create()/Soc.create() factory; cannot rebind tree"
+        )
+
+    master = getattr(soc, "master", None)
+    new_soc = factory(master=master)
+
+    # Re-bind: we keep the identity of ``soc`` (callers' references stay
+    # valid) but its internals are wholesale replaced by the new tree.
+    # ``reload`` is reattached afterwards so the bound method is a clean
+    # closure over the new state.
+    new_dict = getattr(new_soc, "__dict__", None)
+    if new_dict is None:
+        raise RuntimeError("reloaded SoC has no __dict__; cannot rebind onto existing instance")
+    soc.__dict__.clear()
+    soc.__dict__.update(new_dict)
+
+    # Bus state preservation contract: even if the new factory built a
+    # different master object (or none), the original master continues to
+    # drive hardware. The §22.6 decision is unconditional on this point.
+    if master is not None:
+        soc.master = master
+
+    # ``soc.__dict__.clear()`` removed the previous bound ``reload``; rebind.
+    attach_reload(soc)
+
+
+def _find_factory(module: types.ModuleType) -> Callable[..., object] | None:
+    """Locate a SoC factory on ``module``.
+
+    Order:
+    1. ``module.create`` — the generated package's documented entry point.
+    2. ``module.Soc.create`` — the class-bound classmethod form.
+    """
+
+    direct = getattr(module, "create", None)
+    if callable(direct):
+        return direct
+    soc_cls = getattr(module, "Soc", None)
+    if soc_cls is not None:
+        cls_create = getattr(soc_cls, "create", None)
+        if callable(cls_create):
+            return cls_create
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Wiring — attach to a soc instance, optionally via Unit 1's seam
+# ---------------------------------------------------------------------------
+
+
+def attach_reload(soc: _Soc) -> None:
+    """Bind ``soc.reload`` so the documented user surface works.
+
+    Calling ``soc.reload()`` is forwarded to :func:`reload` with ``soc``
+    captured. We also surface :func:`register_context` and
+    :func:`unregister_context` as private hooks on the SoC for sibling
+    units that wish to call them through the soc handle rather than
+    importing this module directly.
+    """
+
+    soc.reload = lambda: reload(soc)
+    soc._register_context = register_context
+    soc._unregister_context = unregister_context
+
+
+# Wire into Unit 1's ``register_post_create`` seam if it has shipped. The
+# seam is best-effort: when Unit 1 is absent, callers can invoke
+# :func:`attach_reload` directly (e.g. inside the generated runtime).
+def _install_post_create_hook() -> None:
+    try:
+        from peakrdl_pybind11 import _registry
+    except ImportError:
+        return
+    register_post_create = getattr(_registry, "register_post_create", None)
+    if not callable(register_post_create):
+        return
+    register_post_create(attach_reload)
+
+
+_install_post_create_hook()
+
+
+def __getattr__(name: str) -> type[Exception]:
+    """Expose ``StaleHandleError`` for symmetry with sibling units.
+
+    The canonical class lives in ``peakrdl_pybind11.errors`` once Unit 2
+    has shipped. This proxy lets ``from peakrdl_pybind11.runtime.hot_reload
+    import StaleHandleError`` succeed regardless of import order.
+    """
+
+    if name == "StaleHandleError":
+        return _resolve_stale_handle_class()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``peakrdl_pybind11.runtime`` (Python-side runtime helpers)."""

--- a/tests/runtime/test_hot_reload.py
+++ b/tests/runtime/test_hot_reload.py
@@ -1,0 +1,371 @@
+"""Tests for ``peakrdl_pybind11.runtime.hot_reload``.
+
+These tests stand on their own — they fake the generated SoC module rather
+than depending on Units 1/2/3/8 having shipped. The behaviours under test
+are exactly those promised by ``IDEAL_API_SKETCH.md`` §21 and §22.6:
+
+* ``soc.reload()`` invalidates outstanding ``RegisterValue`` / ``Snapshot``
+  handles.
+* It refuses while any context manager is active.
+* ``policy = "fail"`` aborts instead of warning.
+* Hardware bus state — represented here by the master object — survives.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import warnings
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime import hot_reload
+
+# ---------------------------------------------------------------------------
+# Fakes — a generated-module shape thin enough to drive every code path
+# ---------------------------------------------------------------------------
+
+
+class _FakeMaster:
+    """Stand-in for a bus master. Holds bus state we want preserved."""
+
+    def __init__(self) -> None:
+        self.read_count = 0
+        self.write_count = 0
+        # Identity sentinel: lets tests assert "the same master survives".
+        self.id_token = object()
+
+
+class _FakeSoc:
+    """Minimal SoC with the seams ``hot_reload`` expects."""
+
+    def __init__(self, master: _FakeMaster | None = None) -> None:
+        self.master = master
+        # Tag instances so we can tell pre-/post-reload trees apart.
+        self.build_token = object()
+
+
+class _FakeSnapshot:
+    """Behaves like Unit 8's ``Snapshot`` for staleness purposes only."""
+
+    def __init__(self) -> None:
+        self._generation = hot_reload.current_generation()
+
+    def diff(self, other: _FakeSnapshot) -> dict[str, Any]:
+        hot_reload.check_generation(self._generation)
+        hot_reload.check_generation(other._generation)
+        return {}
+
+
+class _FakeRegisterValue:
+    """Behaves like Unit 3's ``RegisterValue`` for staleness purposes only."""
+
+    def __init__(self, raw: int) -> None:
+        self._generation = hot_reload.current_generation()
+        self._raw = raw
+
+    def __int__(self) -> int:
+        hot_reload.check_generation(self._generation)
+        return self._raw
+
+
+# ---------------------------------------------------------------------------
+# Module installer — registers a fake generated package with ``Soc.create``
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_module(name: str) -> types.ModuleType:
+    """Create + register a synthetic generated module under ``name``.
+
+    The module exposes ``create(master=...)`` returning a fresh ``_FakeSoc``.
+    Tests pair this with the ``patch_importlib_reload`` autouse fixture so
+    ``importlib.reload`` re-executes the install function rather than going
+    through the normal finder/loader machinery (which can't see our purely
+    in-memory module).
+    """
+
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+
+    def create(master: _FakeMaster | None = None) -> _FakeSoc:
+        return _FakeSoc(master=master)
+
+    module.create = create  # type: ignore[attr-defined]
+    return module
+
+
+def _silent_reload(soc: _FakeSoc) -> None:
+    """Run ``soc.reload()`` while suppressing the expected UserWarning.
+
+    Most tests don't care about the warning itself — they're checking
+    side effects of a successful reload. The dedicated warning test
+    asserts the warning is emitted in the default policy.
+    """
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        soc.reload()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_importlib_reload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``importlib.reload`` reinstall our fake modules in place.
+
+    ``importlib.reload`` normally consults the import machinery to find a
+    spec for the module. Synthetic modules registered straight into
+    ``sys.modules`` (the cheapest way to mock a generated package) have no
+    finder, so the real ``reload`` raises ``ModuleNotFoundError``. Tests
+    only need the *behaviour* of ``reload`` — module dict refreshed in
+    place — so we substitute a small stand-in that mirrors that behaviour.
+    """
+
+    def fake_reload(module: types.ModuleType) -> types.ModuleType:
+        name = module.__name__
+        if name not in sys.modules:
+            raise ImportError(f"module {name!r} not in sys.modules")
+        # Reinstall using the same name; the helper preserves identity by
+        # mutating the existing module object's namespace.
+        return _install_fake_module(name)
+
+    import importlib
+
+    monkeypatch.setattr(importlib, "reload", fake_reload)
+
+
+@pytest.fixture
+def fake_module(request: pytest.FixtureRequest) -> types.ModuleType:
+    """Provide a uniquely-named fake generated module per test, auto-cleaned."""
+
+    name = f"_peakrdl_hot_reload_fake_{request.node.name}"
+    module = _install_fake_module(name)
+    yield module
+    sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def soc(fake_module: types.ModuleType) -> _FakeSoc:
+    """Build a soc instance bound to ``fake_module`` and attach reload."""
+
+    master = _FakeMaster()
+    instance = fake_module.create(master=master)  # type: ignore[attr-defined]
+    # Mirror what ``register_post_create`` would do for a real generated SoC.
+    instance.__class__.__module__ = fake_module.__name__
+    hot_reload.attach_reload(instance)
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _reset_hot_reload_state() -> None:
+    """Keep state tidy between tests — policy, contexts, generation counter."""
+
+    saved_policy = hot_reload.policy
+    saved_generation = hot_reload._generation
+    yield
+    hot_reload.policy = saved_policy
+    hot_reload._generation = saved_generation
+    # Drain anything tests forgot to clean up. ``_thread_contexts`` lazily
+    # creates the per-thread set, so reach in directly.
+    hot_reload._thread_contexts().clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_reload_invalidates_outstanding_snapshot(soc: _FakeSoc) -> None:
+    """Old snapshots raise StaleHandleError after reload."""
+
+    snap_before = _FakeSnapshot()
+    snap_concurrent = _FakeSnapshot()
+
+    _silent_reload(soc)
+
+    with pytest.raises(hot_reload.StaleHandleError):
+        snap_before.diff(snap_concurrent)
+
+
+def test_reload_invalidates_outstanding_register_value(soc: _FakeSoc) -> None:
+    """RegisterValue handles raise StaleHandleError after reload."""
+
+    value = _FakeRegisterValue(0x1234)
+    assert int(value) == 0x1234  # Pre-reload uses are fine.
+
+    _silent_reload(soc)
+
+    with pytest.raises(hot_reload.StaleHandleError):
+        int(value)
+
+
+def test_reload_emits_loud_warning_by_default(soc: _FakeSoc) -> None:
+    """Default policy ('warn') emits a UserWarning naming the consequences."""
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        soc.reload()
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert user_warnings, "expected a UserWarning from soc.reload()"
+    assert "stale" in str(user_warnings[0].message).lower()
+
+
+def test_reload_blocked_by_active_context_manager(soc: _FakeSoc) -> None:
+    """An open context manager makes reload raise RuntimeError."""
+
+    sentinel = object()
+    hot_reload.register_context(sentinel)
+    try:
+        with pytest.raises(RuntimeError, match="context manager"):
+            soc.reload()
+    finally:
+        hot_reload.unregister_context(sentinel)
+
+    # Once the context exits, reload works again — proving the block is gated
+    # on *active* contexts and not a permanent latch.
+    _silent_reload(soc)
+
+
+def test_reload_active_context_check_precedes_policy_fail(soc: _FakeSoc) -> None:
+    """When both conditions hit, the user sees the context-manager error first."""
+
+    hot_reload.policy = "fail"
+    sentinel = object()
+    hot_reload.register_context(sentinel)
+    try:
+        with pytest.raises(RuntimeError, match="context manager"):
+            soc.reload()
+    finally:
+        hot_reload.unregister_context(sentinel)
+
+
+def test_reload_policy_fail_blocks_reload(soc: _FakeSoc) -> None:
+    """policy='fail' raises a RuntimeError that mentions the policy."""
+
+    hot_reload.policy = "fail"
+    starting_generation = hot_reload.current_generation()
+
+    with pytest.raises(RuntimeError, match=r"policy='fail'"):
+        soc.reload()
+
+    # Generation must NOT advance on a policy-fail (no handles invalidated).
+    assert hot_reload.current_generation() == starting_generation
+
+
+def test_reload_invalid_policy_is_a_clear_error(soc: _FakeSoc) -> None:
+    """A typo in ``policy`` should not silently fall through to 'warn'."""
+
+    hot_reload.policy = "loud"
+
+    with pytest.raises(RuntimeError, match=r"unknown peakrdl\.reload\.policy"):
+        soc.reload()
+
+
+def test_reload_preserves_master_identity(soc: _FakeSoc) -> None:
+    """The bus master survives reload unchanged — bus state is untouched."""
+
+    master_before = soc.master
+    assert master_before is not None
+    token = master_before.id_token
+
+    _silent_reload(soc)
+
+    assert soc.master is master_before, "master identity must be preserved"
+    assert soc.master.id_token is token, "bus state must not be reset"
+
+
+def test_reload_generation_advances_on_success(soc: _FakeSoc) -> None:
+    """Generation counter increases monotonically on successful reload."""
+
+    g0 = hot_reload.current_generation()
+    _silent_reload(soc)
+    g1 = hot_reload.current_generation()
+    _silent_reload(soc)
+    g2 = hot_reload.current_generation()
+
+    assert g1 == g0 + 1
+    assert g2 == g1 + 1
+
+
+def test_check_generation_passes_for_current() -> None:
+    """``check_generation`` is a no-op when the captured value is current."""
+
+    hot_reload.check_generation(hot_reload.current_generation())
+
+
+def test_check_generation_raises_for_stale_value(soc: _FakeSoc) -> None:
+    """``check_generation`` raises when the captured value is stale."""
+
+    captured = hot_reload.current_generation()
+    _silent_reload(soc)
+
+    with pytest.raises(hot_reload.StaleHandleError):
+        hot_reload.check_generation(captured)
+
+
+def test_register_unregister_context_round_trip() -> None:
+    """register_context and unregister_context round-trip cleanly."""
+
+    sentinel = object()
+    hot_reload.register_context(sentinel)
+    # Idempotent: re-registering does not duplicate.
+    hot_reload.register_context(sentinel)
+    hot_reload.unregister_context(sentinel)
+    # Tolerates double-unregister.
+    hot_reload.unregister_context(sentinel)
+
+
+def test_attach_reload_binds_method_on_soc(fake_module: types.ModuleType) -> None:
+    """attach_reload installs ``soc.reload`` and the private context hooks."""
+
+    instance = fake_module.create(master=_FakeMaster())  # type: ignore[attr-defined]
+    instance.__class__.__module__ = fake_module.__name__
+    assert not hasattr(instance, "reload")
+
+    hot_reload.attach_reload(instance)
+
+    assert callable(instance.reload)
+    assert instance._register_context is hot_reload.register_context
+    assert instance._unregister_context is hot_reload.unregister_context
+
+
+def test_reload_rebinds_to_new_tree(soc: _FakeSoc) -> None:
+    """After reload, soc internals point at the freshly-built tree."""
+
+    token_before = soc.build_token
+
+    _silent_reload(soc)
+
+    assert soc.build_token is not token_before, (
+        "reload should rebuild the internal tree (build_token must change)"
+    )
+
+
+def test_reload_method_survives_reload(soc: _FakeSoc) -> None:
+    """Calling reload twice in a row works — the bound method is reattached."""
+
+    _silent_reload(soc)
+    assert callable(soc.reload)
+    _silent_reload(soc)
+
+
+def test_module_level_stale_handle_error_alias_exists() -> None:
+    """``hot_reload.StaleHandleError`` resolves even before Unit 2 ships."""
+
+    cls = hot_reload.StaleHandleError
+    assert isinstance(cls, type)
+    assert issubclass(cls, Exception)
+
+
+def test_unknown_module_attribute_still_raises() -> None:
+    """The proxy on ``hot_reload`` does not swallow real lookup failures."""
+
+    with pytest.raises(AttributeError):
+        hot_reload.this_attribute_does_not_exist  # noqa: B018


### PR DESCRIPTION
## Summary

Implements Unit 16 (hot reload, §21 + §22.6 of the sketch) as a pure-Python runtime helper:

- `soc.reload()` re-imports the generated module, invalidates outstanding `RegisterValue`/`Snapshot` handles via a global generation counter, refuses while any context manager is active, and reattaches the existing master so hardware bus state is preserved.
- `peakrdl.reload.policy = "warn" | "fail"` controls the behaviour. `"warn"` (default) emits a `UserWarning` and invalidates handles. `"fail"` raises `RuntimeError("soc.reload() blocked by policy='fail'")` and does not advance the generation counter.
- Active-context check precedes the policy gate so users see the real cause first; generation only bumps on a successful reload so failed imports never strand handles.

## Cross-unit seams

- `current_generation()` / `check_generation(captured)` — staleness contract that `RegisterValue` (Unit 3) and `Snapshot` (Unit 8) will call.
- `register_context(ctx)` / `unregister_context(ctx)` — thread-local set per §22.6, called from transaction (Unit 2), write-only (Unit 5), etc.
- `attach_reload(soc)` — binds `soc.reload` and private hooks; wires through Unit 1's `register_post_create` seam at import time when present; falls back to direct invocation otherwise.
- `StaleHandleError` resolves to Unit 2's canonical class when available; otherwise falls back to a module-private `RuntimeError` subclass so behaviour is preserved before sibling units land.

## Files

- `src/peakrdl_pybind11/runtime/__init__.py` (new package)
- `src/peakrdl_pybind11/runtime/hot_reload.py`
- `tests/runtime/__init__.py`
- `tests/runtime/test_hot_reload.py` (17 tests covering all four required cases plus extras)

## Test plan

- [x] `pytest tests/runtime/test_hot_reload.py -v` — 17 passed
- [x] Full suite (`pytest tests/`) — 93 passed, 27 skipped, no regressions
- [x] `ruff check` clean on `src/peakrdl_pybind11/runtime/` and `tests/runtime/`
- [x] `ty check` clean on `src/peakrdl_pybind11/runtime/`

Tests fake the generated SoC module with a synthetic `_FakeSoc` exposing `master` + `create(master=...)` so this unit lands without blocking on Units 1/2/3/8. `importlib.reload` is monkeypatched in the autouse fixture because purely in-memory modules have no spec and the real reload would `ModuleNotFoundError`.

## Required behaviours (all covered)

- [x] Old `Snapshot.diff(...)` raises `StaleHandleError` after reload.
- [x] Outstanding `RegisterValue` raises `StaleHandleError` after reload.
- [x] Reload during active context manager raises `RuntimeError`.
- [x] `peakrdl.reload.policy = "fail"` causes reload to raise.
- [x] Master identity preserved; bus state untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)