### PR TITLE
feat(runtime): bus policies (barrier/cache/retry) (Unit 17)

### DIFF
--- a/src/peakrdl_pybind11/masters/base.py
+++ b/src/peakrdl_pybind11/masters/base.py
@@ -75,3 +75,17 @@ class MasterBase(ABC):
         """Batched write. Default impl loops single-op :meth:`write`."""
         for op in ops:
             self.write(op.address, op.value, op.width)
+
+    def barrier(self) -> None:
+        """Drain any in-flight writes on this master.
+
+        Default implementation is a no-op: most masters issue writes
+        synchronously and have nothing to drain. Bus backends that
+        post writes asynchronously (e.g. write FIFOs, RDMA-style
+        engines) override this to wait for completion.
+
+        This is the seam used by :mod:`peakrdl_pybind11.runtime.bus_policies`
+        to implement :meth:`Soc.barrier`, the auto-barrier policy, and
+        per-subtree barriers.
+        """
+        return None

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,14 @@
+"""Runtime support for the planned PeakRDL-pybind11 API.
+
+This sub-package collects the host-side machinery that wraps masters with
+policies (barriers, caching, retries) and routes calls through the seams
+defined in :mod:`peakrdl_pybind11.masters.base`.
+
+The modules here are part of the API overhaul described in
+``docs/IDEAL_API_SKETCH.md``. They are intentionally additive to keep each
+unit independently mergeable; sibling units (``_errors``, ``_registry``,
+``info``) provide the same names as cooperating shims here until they are
+unified by the umbrella PR.
+"""
+
+from __future__ import annotations

--- a/src/peakrdl_pybind11/runtime/_errors.py
+++ b/src/peakrdl_pybind11/runtime/_errors.py
@@ -1,0 +1,101 @@
+"""Error types used by the bus policy machinery.
+
+This module is a sibling to Unit 2's ``runtime.errors``. It defines the
+exact subset Unit 17 needs so the bus policies can be imported, exercised,
+and reviewed independently. The umbrella PR is responsible for unifying
+this shim with Unit 2's broader error hierarchy; the public names exported
+here (``BusError``, ``NotSupportedError``, ``TransportError``,
+``TimeoutError``, ``NackError``, ``DisconnectError``) are stable.
+
+Sketch reference: §13.5 (bus error recovery) and §19 (error model).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..masters.base import MasterBase
+
+
+class NotSupportedError(Exception):
+    """Operation is not supported by the selected master or register.
+
+    Raised, for example, when ``cache_for(...)`` is attached to a register
+    whose exporter metadata flags ``info.is_volatile`` or ``info.on_read``
+    (see sketch §13.4): caching a side-effecting read would silently lie
+    to the caller.
+    """
+
+
+class TransportError(Exception):
+    """Base class for bus-level transport failures.
+
+    Carries an optional ``kind`` tag — one of ``"timeout"``, ``"nack"``,
+    ``"disconnect"`` — so retry policies can match on the failure mode
+    without depending on the concrete exception class produced by a
+    particular master backend.
+    """
+
+    def __init__(self, message: str = "", *, kind: str | None = None) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+class TimeoutError(TransportError):
+    """Bus transaction timed out before completing.
+
+    Note: shadows the builtin ``TimeoutError``. The sketch's `on=("timeout", ...)`
+    vocabulary is the source of truth for this naming.
+    """
+
+    def __init__(self, message: str = "bus timeout") -> None:
+        super().__init__(message, kind="timeout")
+
+
+class NackError(TransportError):
+    """Bus target signalled a negative acknowledgement (NACK)."""
+
+    def __init__(self, message: str = "bus nack") -> None:
+        super().__init__(message, kind="nack")
+
+
+class DisconnectError(TransportError):
+    """Master lost its transport-level connection to the target."""
+
+    def __init__(self, message: str = "transport disconnected") -> None:
+        super().__init__(message, kind="disconnect")
+
+
+class BusError(Exception):
+    """Transaction failed after the configured retry policy gave up.
+
+    Carries enough context to triage a CI failure without re-instrumenting:
+
+    * ``addr`` — absolute address of the failing transaction.
+    * ``op`` — ``"read"`` or ``"write"``.
+    * ``master`` — the master object that raised.
+    * ``retries`` — number of retries actually performed before giving up.
+    * ``underlying`` — the last exception observed from the master.
+
+    Sketch §13.5: "BusError carries the failed transaction, the retry
+    count, and the underlying exception".
+    """
+
+    def __init__(
+        self,
+        addr: int,
+        op: str,
+        master: MasterBase,
+        retries: int,
+        underlying: BaseException | None,
+    ) -> None:
+        msg = f"bus {op} @0x{addr:08x} failed after {retries} retr{'y' if retries == 1 else 'ies'}"
+        if underlying is not None:
+            msg += f": {type(underlying).__name__}: {underlying}"
+        super().__init__(msg)
+        self.addr = addr
+        self.op = op
+        self.master = master
+        self.retries = retries
+        self.underlying = underlying

--- a/src/peakrdl_pybind11/runtime/_registry.py
+++ b/src/peakrdl_pybind11/runtime/_registry.py
@@ -1,0 +1,68 @@
+"""Master extension registry.
+
+Sibling to Unit 1's seam in :mod:`peakrdl_pybind11.masters.base`. A "master
+extension" is a callable that wraps a :class:`MasterBase` instance, replacing
+its ``read`` and ``write`` methods with policy-enforcing versions. Bus
+policies (barriers, caching, retries) all attach this way so the seam is
+single and testable.
+
+The registry is opt-in: callers explicitly enable an extension on a master
+via :func:`register_master_extension`. The registry is global by name so
+extensions can be discovered and toggled from configuration, but each
+``Master`` instance carries its own per-extension state through the wrapper
+objects returned at registration time.
+
+Sketch §13: bus-layer composition.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ..masters.base import MasterBase
+
+#: Factory takes a master and returns an object that wraps ``read`` /
+#: ``write`` (and, optionally, additional surface). The factory is responsible
+#: for monkey-patching the master's ``read`` / ``write`` to delegate to itself
+#: so that the wrapping is transparent to callers that already hold a reference
+#: to the master.
+ExtensionFactory = Callable[[MasterBase], object]
+
+_FACTORIES: dict[str, ExtensionFactory] = {}
+
+
+def register_master_extension(name: str, factory: ExtensionFactory) -> None:
+    """Register a named master-extension factory.
+
+    Args:
+        name: Stable identifier (e.g. ``"barrier"``, ``"cache"``, ``"retry"``).
+        factory: Callable invoked once per master to install the extension.
+            See :data:`ExtensionFactory`.
+
+    Re-registering an existing name overrides the previous factory, which
+    keeps test setup ergonomic. Production code should pick names that do
+    not collide with built-in policies.
+    """
+    _FACTORIES[name] = factory
+
+
+def get_master_extension_factory(name: str) -> ExtensionFactory | None:
+    """Return the registered factory for ``name``, or ``None`` if missing."""
+    return _FACTORIES.get(name)
+
+
+def attach_master_extension(name: str, master: MasterBase) -> object:
+    """Install the extension named ``name`` onto ``master`` and return it.
+
+    Raises:
+        KeyError: if no factory is registered under ``name``.
+    """
+    factory = _FACTORIES.get(name)
+    if factory is None:
+        raise KeyError(f"no master extension registered under {name!r}")
+    return factory(master)
+
+
+def clear_master_extensions() -> None:
+    """Remove every registered factory. Intended for test setup/teardown."""
+    _FACTORIES.clear()

--- a/src/peakrdl_pybind11/runtime/bus_policies.py
+++ b/src/peakrdl_pybind11/runtime/bus_policies.py
@@ -1,0 +1,616 @@
+"""Bus policies — barriers, cache, retry — attached to masters as a unit.
+
+This module implements §13.3 (barriers), §13.4 (cache) and §13.5 (retry)
+of ``docs/IDEAL_API_SKETCH.md``. The three policies share a single seam
+(:func:`register_master_extension` from :mod:`._registry`) so they wrap
+``MasterBase.read`` / ``MasterBase.write`` once, in a defined order, and
+without each policy having to know about the others.
+
+Wrapper order (innermost first, which is also the order the user-facing
+``read``/``write`` traverses):
+
+  user call → cache lookup → retry loop → barrier ordering → master.read
+
+* The cache short-circuits a read if a fresh value is on hand.
+* The retry loop catches transport errors from the underlying master and
+  re-issues the call, draining a barrier between attempts.
+* The barrier policy fences before reads/writes per its mode and tracks
+  the "last op was a write" bit so ``auto`` mode can fence read-after-write.
+
+Each policy exposes a small object users compose against the SoC tree:
+
+* :class:`BarrierPolicy` — ``set_barrier_policy``, ``barrier`` (per-master,
+  per-subtree, SoC-wide), ``global_barrier``.
+* :class:`CachePolicy` — ``cache_for``, ``invalidate_cache``,
+  ``cached(window=...)`` block-scope.
+* :class:`RetryPolicy` — ``set_retry_policy``, ``on_disconnect``, plus a
+  per-call ``retries=`` override on ``read`` / ``write``.
+
+The umbrella generated SoC binds these onto ``soc``, ``soc.master``, and
+each register node so the public surface in the sketch resolves to the
+methods on these policies.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import time
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Literal
+
+from ..masters.base import MasterBase
+from ._errors import BusError, NotSupportedError, TransportError
+from ._registry import register_master_extension
+
+_logger = logging.getLogger("peakrdl_pybind11.runtime.bus_policies")
+
+
+# ---------------------------------------------------------------------------
+# Per-call override carrier
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CallOverride:
+    """Per-call overrides plumbed through wrapped read/write.
+
+    Bus policies accept keyword overrides on individual calls (e.g.
+    ``reg.read(retries=10)``). The register-node layer collects those into a
+    :class:`CallOverride` and forwards it to the wrapped master through the
+    ``_pe_override`` keyword. Policy wrappers pop it off; native masters
+    never see it.
+    """
+
+    retries: int | None = None
+    bypass_cache: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Barrier policy (§13.3)
+# ---------------------------------------------------------------------------
+
+
+BarrierMode = Literal["auto", "none", "strict", "auto-global"]
+_BARRIER_MODES: tuple[str, ...] = ("auto", "none", "strict", "auto-global")
+
+
+class BarrierPolicy:
+    """Per-master barrier state and policy.
+
+    The default policy is ``"auto"``: a barrier fires before any read that
+    follows a write *on the same master*. ``"strict"`` fences before every
+    transaction; ``"none"`` opts out (and ``master.barrier()`` only runs on
+    explicit user calls); ``"auto-global"`` extends auto-mode across every
+    master attached to the parent context.
+
+    A ``BarrierPolicy`` keeps track of the master(s) it's attached to and
+    a "last op was a write" bit; the SoC layer instantiates one per master
+    (and a façade that fans out to every attached master for the SoC-wide
+    surface).
+    """
+
+    def __init__(self, master: MasterBase) -> None:
+        self.master = master
+        self.mode: BarrierMode = "auto"
+        # Peers participate in scope="all" / auto-global barriers; the SoC
+        # layer keeps these consistent across attach_master calls.
+        self._peers: list[MasterBase] = [master]
+        # True if any write has fired since the last barrier on this master.
+        self._dirty: bool = False
+        self._lock = RLock()
+
+    # -- Configuration -----------------------------------------------------
+
+    def set_mode(self, mode: BarrierMode) -> None:
+        if mode not in _BARRIER_MODES:
+            raise ValueError(f"barrier policy must be one of {_BARRIER_MODES!r}, got {mode!r}")
+        self.mode = mode
+
+    def attach_peer(self, master: MasterBase) -> None:
+        """Add ``master`` to the peer set used by ``scope='all'`` barriers."""
+        with self._lock:
+            if master not in self._peers:
+                self._peers.append(master)
+
+    # -- User-facing surface ----------------------------------------------
+
+    def barrier(self, scope: Literal["self", "all"] = "self") -> None:
+        """Drain in-flight writes.
+
+        Args:
+            scope: ``"self"`` (default) only barriers this master;
+                ``"all"`` fences every peer master in turn.
+        """
+        with self._lock:
+            if scope == "all":
+                for m in self._peers:
+                    self._do_barrier(m)
+            else:
+                self._do_barrier(self.master)
+            self._dirty = False
+
+    def global_barrier(self) -> None:
+        """Alias for :meth:`barrier` with ``scope='all'`` — reads better in scripts."""
+        self.barrier(scope="all")
+
+    # -- Internal hooks invoked by the read/write wrappers ----------------
+
+    def before_read(self) -> None:
+        """Called by the wrapped master before issuing a read."""
+        if self.mode == "strict":
+            self._do_barrier(self.master)
+        elif self.mode == "auto" and self._dirty:
+            self._do_barrier(self.master)
+            self._dirty = False
+        elif self.mode == "auto-global" and self._dirty:
+            for m in self._peers:
+                self._do_barrier(m)
+            self._dirty = False
+
+    def before_write(self) -> None:
+        """Called by the wrapped master before issuing a write."""
+        if self.mode == "strict":
+            self._do_barrier(self.master)
+
+    def after_write(self) -> None:
+        """Called by the wrapped master immediately after a successful write."""
+        if self.mode in ("auto", "auto-global"):
+            self._dirty = True
+
+    @staticmethod
+    def _do_barrier(master: MasterBase) -> None:
+        # `barrier` is a no-op default on MasterBase; backends that buffer
+        # writes override it. We tolerate masters that pre-date the seam
+        # by checking attribute presence.
+        fn = getattr(master, "barrier", None)
+        if callable(fn):
+            fn()
+
+
+# ---------------------------------------------------------------------------
+# Cache policy (§13.4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CacheEntry:
+    """Per-address cache slot."""
+
+    ttl: float
+    value: int = 0
+    expiry: float = 0.0  # monotonic timestamp; 0 means "no fresh value"
+
+
+class CachePolicy:
+    """Per-master read cache.
+
+    Sketch §13.4. A register's :meth:`cache_for` attaches a TTL slot for its
+    absolute address; subsequent reads within the TTL return the last value
+    without re-issuing the bus transaction. Side-effecting reads (registers
+    where ``info.is_volatile`` is set or ``info.on_read`` is non-``None``)
+    are refused at attach time with :class:`NotSupportedError`.
+
+    A :meth:`cached_window` block-scope mirrors the sketch's
+    ``with soc.cached(window=10e-3): ...``. Inside the block, every read
+    that does not already have its own ``cache_for`` slot is treated as if
+    it had one with the given TTL.
+    """
+
+    def __init__(self, master: MasterBase) -> None:
+        self.master = master
+        # Slots attached explicitly via cache_for(). Keyed by absolute address
+        # (a register's cache is independent of access width).
+        self._slots: dict[int, _CacheEntry] = {}
+        # Stack of active cached_window() TTLs; nesting takes the innermost.
+        self._window_stack: list[float] = []
+        # Implicit slots populated under a cached_window for addresses that
+        # have no explicit cache_for; cleared when the outermost window exits.
+        self._block_slots: dict[int, _CacheEntry] = {}
+        self._lock = RLock()
+
+    # -- Slot management ---------------------------------------------------
+
+    def attach_slot(self, address: int, ttl: float, info: object | None = None) -> None:
+        """Attach a TTL cache slot for ``address``.
+
+        Args:
+            address: Absolute address of the register being cached.
+            ttl: Time-to-live in seconds.
+            info: Optional exporter info object. If present and
+                ``info.is_volatile`` or ``info.on_read`` is truthy, raises
+                :class:`NotSupportedError`. Typed as ``object`` so this code
+                does not depend on the (sibling unit's) info schema; the
+                check is duck-typed via :func:`getattr`.
+        """
+        if ttl <= 0:
+            raise ValueError(f"cache_for(ttl) must be > 0, got {ttl!r}")
+        if info is not None:
+            is_volatile = bool(getattr(info, "is_volatile", False))
+            on_read = getattr(info, "on_read", None)
+            if is_volatile or on_read is not None:
+                raise NotSupportedError(
+                    f"cannot cache @0x{address:08x}: register has read side effects "
+                    f"(is_volatile={is_volatile}, on_read={on_read!r})"
+                )
+        with self._lock:
+            self._slots[address] = _CacheEntry(ttl=ttl)
+
+    def detach_slot(self, address: int) -> None:
+        """Remove the explicit cache slot for ``address``, if any."""
+        with self._lock:
+            self._slots.pop(address, None)
+            self._block_slots.pop(address, None)
+
+    def invalidate(self, address: int | None = None) -> None:
+        """Invalidate one slot (``address``) or every slot (``address=None``)."""
+        with self._lock:
+            if address is None:
+                for slot in self._slots.values():
+                    slot.expiry = 0.0
+                self._block_slots.clear()
+            else:
+                slot = self._slots.get(address)
+                if slot is not None:
+                    slot.expiry = 0.0
+                self._block_slots.pop(address, None)
+
+    # -- Block-scope window ------------------------------------------------
+
+    @contextmanager
+    def cached_window(self, window: float) -> Iterator[None]:
+        """Treat every read inside the ``with`` block as if it had ``cache_for(window)``."""
+        if window <= 0:
+            raise ValueError(f"cached(window=) must be > 0, got {window!r}")
+        with self._lock:
+            self._window_stack.append(window)
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._window_stack.pop()
+                # Discard implicit slots only when the outermost window exits;
+                # nested windows share the same hit set.
+                if not self._window_stack:
+                    self._block_slots.clear()
+
+    # -- Internal hooks invoked by the wrapped master ---------------------
+
+    def before_read(self, address: int, width: int) -> tuple[bool, int]:
+        """Probe the cache for ``(address, width)``.
+
+        Returns ``(hit, value)``. Caller skips the bus on a hit.
+        """
+        now = time.monotonic()
+        with self._lock:
+            slot = self._slots.get(address)
+            if slot is not None and slot.expiry > now:
+                return True, slot.value
+            if self._window_stack:
+                bslot = self._block_slots.get(address)
+                if bslot is not None and bslot.expiry > now:
+                    return True, bslot.value
+        return False, 0
+
+    def after_read(self, address: int, width: int, value: int) -> None:
+        """Refresh the cache slot for ``(address, width)`` after a real read."""
+        now = time.monotonic()
+        with self._lock:
+            slot = self._slots.get(address)
+            if slot is not None:
+                slot.value = value
+                slot.expiry = now + slot.ttl
+            elif self._window_stack:
+                ttl = self._window_stack[-1]
+                self._block_slots[address] = _CacheEntry(ttl=ttl, value=value, expiry=now + ttl)
+
+    def after_write(self, address: int, width: int) -> None:
+        """Invalidate any cached value at ``address`` after a write hits the bus."""
+        with self._lock:
+            slot = self._slots.get(address)
+            if slot is not None:
+                slot.expiry = 0.0
+            self._block_slots.pop(address, None)
+
+
+# ---------------------------------------------------------------------------
+# Retry policy (§13.5)
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_KINDS: tuple[str, ...] = ("timeout", "nack")
+
+
+def _kind_of(exc: BaseException) -> str | None:
+    """Best-effort retrieval of the transport-error tag for ``exc``.
+
+    Looks at an explicit ``kind`` attribute first (set by every
+    :class:`TransportError` subclass), then falls back to type sniffing for
+    bare builtin exceptions a native master might raise.
+    """
+    kind = getattr(exc, "kind", None)
+    if isinstance(kind, str):
+        return kind
+    if isinstance(exc, builtins.TimeoutError):
+        return "timeout"
+    if isinstance(exc, TransportError):
+        return exc.kind
+    return None
+
+
+@dataclass
+class _RetryConfig:
+    retries: int = 3
+    backoff: float = 0.05
+    on: tuple[str, ...] = _DEFAULT_KINDS
+    on_giveup: Literal["raise", "log", "panic"] = "raise"
+
+
+class RetryPolicy:
+    """Per-master retry policy.
+
+    Sketch §13.5. Wraps ``read`` / ``write`` with exponential-backoff retries
+    on tagged transport errors, an optional ``on_disconnect`` chain that
+    fires when the master raises a ``"disconnect"``-tagged exception, and a
+    ``BusError`` envelope for the give-up path.
+
+    Per-call ``retries=`` overrides come through the :class:`CallOverride`
+    forwarded by the register node.
+    """
+
+    def __init__(self, master: MasterBase) -> None:
+        self.master = master
+        self._cfg = _RetryConfig()
+        self._disconnect_callbacks: list[Callable[[MasterBase], object]] = []
+        # Captured so tests can stub backoff sleeps without monkey-patching
+        # the time module.
+        self._sleep: Callable[[float], None] = time.sleep
+        self._lock = RLock()
+        # Number of retries actually performed on the most recent call. Read
+        # by tests to confirm fast-path retry behavior.
+        self.last_retry_count: int = 0
+
+    # -- Configuration -----------------------------------------------------
+
+    def configure(
+        self,
+        *,
+        retries: int | None = None,
+        backoff: float | None = None,
+        on: Iterable[str] | None = None,
+        on_giveup: Literal["raise", "log", "panic"] | None = None,
+    ) -> None:
+        with self._lock:
+            cfg = self._cfg
+            if retries is not None:
+                if retries < 0:
+                    raise ValueError(f"retries must be >= 0, got {retries!r}")
+                cfg.retries = retries
+            if backoff is not None:
+                if backoff < 0:
+                    raise ValueError(f"backoff must be >= 0, got {backoff!r}")
+                cfg.backoff = backoff
+            if on is not None:
+                cfg.on = tuple(on)
+            if on_giveup is not None:
+                if on_giveup not in ("raise", "log", "panic"):
+                    raise ValueError(f"on_giveup must be 'raise', 'log', or 'panic', got {on_giveup!r}")
+                cfg.on_giveup = on_giveup
+
+    def add_disconnect_callback(self, cb: Callable[[MasterBase], object]) -> None:
+        with self._lock:
+            self._disconnect_callbacks.append(cb)
+
+    # Test-only: replace the sleep function so backoffs don't slow CI.
+    def _set_sleep(self, fn: Callable[[float], None]) -> None:
+        self._sleep = fn
+
+    # -- Internal -- the actual retry loop --------------------------------
+
+    def run(
+        self,
+        op_name: str,
+        addr: int,
+        fn: Callable[[], int | None],
+        *,
+        override_retries: int | None = None,
+    ) -> int | None:
+        """Invoke ``fn``. Retry on configured kinds. Wrap the give-up path.
+
+        Args:
+            op_name: ``"read"`` or ``"write"``.
+            addr: Absolute address (carried in ``BusError``).
+            fn: Zero-arg callable that performs the actual master operation.
+            override_retries: Per-call override for the configured retries.
+
+        Returns:
+            Whatever ``fn`` returns on success.
+
+        Raises:
+            BusError: If retries are exhausted and ``on_giveup="raise"``.
+        """
+        cfg = self._cfg
+        retries = cfg.retries if override_retries is None else override_retries
+        if retries < 0:
+            raise ValueError(f"retries must be >= 0, got {retries!r}")
+        attempt = 0
+        while True:
+            try:
+                result = fn()
+            except BaseException as exc:
+                kind = _kind_of(exc)
+                if kind == "disconnect":
+                    self._fire_disconnect()
+                retryable = kind is not None and kind in cfg.on
+                if not retryable or attempt >= retries:
+                    self.last_retry_count = attempt
+                    return self._giveup(op_name, addr, attempt, exc)
+                self._sleep(cfg.backoff * (2**attempt))
+                attempt += 1
+                continue
+            self.last_retry_count = attempt
+            return result
+
+    def _giveup(
+        self,
+        op_name: str,
+        addr: int,
+        attempt: int,
+        exc: BaseException,
+    ) -> int | None:
+        cfg = self._cfg
+        bus_err = BusError(addr, op_name, self.master, attempt, exc)
+        if cfg.on_giveup == "raise":
+            raise bus_err from exc
+        if cfg.on_giveup == "log":
+            # "log" mode swallows the failure: read returns 0, write returns
+            # None. Users who pick it accept that the wire state is unknown.
+            _logger.error("%s", bus_err)
+            return 0 if op_name == "read" else None
+        # "panic" — escalate by firing the disconnect chain, then raise.
+        self._fire_disconnect()
+        raise bus_err from exc
+
+    def _fire_disconnect(self) -> None:
+        with self._lock:
+            callbacks = list(self._disconnect_callbacks)
+        for cb in callbacks:
+            try:
+                cb(self.master)
+            except BaseException:
+                # A failing reconnect callback must not mask the original bus
+                # failure; record at debug and move on.
+                _logger.debug("on_disconnect callback raised", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Combined policy bundle — registered via the master-extension seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BusPolicies:
+    """Container that wraps a single :class:`MasterBase`.
+
+    The wrapping is monkey-patch style: instantiating a :class:`BusPolicies`
+    replaces the master's ``read`` and ``write`` with delegations that route
+    through cache → retry → barrier → master. This keeps the seam single
+    and matches sketch §13.1's "every read and write goes through the
+    master" claim.
+
+    The original methods are preserved on the policy bundle as
+    :attr:`_inner_read` / :attr:`_inner_write`; tests, traces, and replay
+    masters can use the policies' own ``inner_*`` to bypass the policy
+    chain.
+    """
+
+    master: MasterBase
+    barriers: BarrierPolicy = field(init=False)
+    cache: CachePolicy = field(init=False)
+    retry: RetryPolicy = field(init=False)
+    _inner_read: Callable[..., int] = field(init=False, repr=False)
+    _inner_write: Callable[..., None] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.barriers = BarrierPolicy(self.master)
+        self.cache = CachePolicy(self.master)
+        self.retry = RetryPolicy(self.master)
+        self._inner_read = self.master.read
+        self._inner_write = self.master.write
+        # Replace public methods so any pre-existing reference to
+        # `master.read` picks up the policy chain transparently.
+        self.master.read = self._wrapped_read  # type: ignore[method-assign]
+        self.master.write = self._wrapped_write  # type: ignore[method-assign]
+
+    # -- Wrapped surface --------------------------------------------------
+
+    def _wrapped_read(
+        self,
+        address: int,
+        width: int,
+        _pe_override: CallOverride | None = None,
+    ) -> int:
+        bypass_cache = bool(_pe_override and _pe_override.bypass_cache)
+
+        if not bypass_cache:
+            hit, cached = self.cache.before_read(address, width)
+            if hit:
+                return cached
+
+        def do_read() -> int:
+            self.barriers.before_read()
+            return self._inner_read(address, width)
+
+        result = self.retry.run(
+            "read",
+            address,
+            do_read,
+            override_retries=(_pe_override.retries if _pe_override else None),
+        )
+        # `run` returns int | None; "log" giveup yields 0 for reads, never None.
+        value = 0 if result is None else int(result)
+
+        if not bypass_cache:
+            # TODO(umbrella PR): on `on_giveup="log"` this caches the
+            # default-zero return as a real read. Should skip the slot
+            # refresh when the call gave up. Out of scope for Unit 17.
+            self.cache.after_read(address, width, value)
+        return value
+
+    def _wrapped_write(
+        self,
+        address: int,
+        value: int,
+        width: int,
+        _pe_override: CallOverride | None = None,
+    ) -> None:
+        def do_write() -> None:
+            self.barriers.before_write()
+            self._inner_write(address, value, width)
+
+        self.retry.run(
+            "write",
+            address,
+            do_write,
+            override_retries=(_pe_override.retries if _pe_override else None),
+        )
+        self.barriers.after_write()
+        self.cache.after_write(address, width)
+
+
+# ---------------------------------------------------------------------------
+# Public convenience: install the unified bundle as the registered extension
+# ---------------------------------------------------------------------------
+
+
+_EXTENSION_NAME = "bus_policies"
+
+
+def install(master: MasterBase) -> BusPolicies:
+    """Wrap ``master`` with the combined bus policies and return the bundle.
+
+    Equivalent to calling the registered extension factory directly. Not
+    idempotent: a second :func:`install` on the same master double-wraps,
+    because :class:`BusPolicies` captures whatever ``master.read`` /
+    ``master.write`` already point at. Callers that need to re-install must
+    reconstruct the master first.
+    """
+    return BusPolicies(master=master)
+
+
+# Register the factory at import time so the SoC layer can rely on a
+# single, named seam rather than importing the class directly.
+register_master_extension(_EXTENSION_NAME, install)
+
+
+__all__ = [
+    "BarrierPolicy",
+    "BusPolicies",
+    "CachePolicy",
+    "CallOverride",
+    "RetryPolicy",
+    "install",
+]

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for peakrdl_pybind11.runtime.* modules."""

--- a/tests/runtime/test_bus_policies.py
+++ b/tests/runtime/test_bus_policies.py
@@ -1,0 +1,432 @@
+"""Tests for the bus-policy bundle (Unit 17).
+
+Covers §13.3 (barriers), §13.4 (cache) and §13.5 (retry) of
+``docs/IDEAL_API_SKETCH.md``. The tests build small, deterministic
+fixtures rather than depend on the generated SoC tree — the policy bundle
+is the unit under test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pytest
+
+from peakrdl_pybind11.masters.base import MasterBase
+from peakrdl_pybind11.runtime._errors import (
+    BusError,
+    DisconnectError,
+    NackError,
+    NotSupportedError,
+    TimeoutError,
+)
+from peakrdl_pybind11.runtime._registry import (
+    attach_master_extension,
+    get_master_extension_factory,
+)
+from peakrdl_pybind11.runtime.bus_policies import (
+    BusPolicies,
+    CallOverride,
+    install,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class CountingMaster(MasterBase):
+    """Mock master that records calls and lets tests script failure modes."""
+
+    def __init__(self) -> None:
+        self.reads: list[tuple[int, int]] = []
+        self.writes: list[tuple[int, int, int]] = []
+        self.barriers: int = 0
+        self._read_value: int = 0xDEAD_BEEF
+        # A queue of exceptions to raise on subsequent reads; once empty,
+        # reads succeed and return self._read_value.
+        self.read_failures: list[BaseException] = []
+        self.write_failures: list[BaseException] = []
+
+    def set_read_value(self, value: int) -> None:
+        self._read_value = value
+
+    def queue_read_failures(self, *excs: BaseException) -> None:
+        self.read_failures.extend(excs)
+
+    def queue_write_failures(self, *excs: BaseException) -> None:
+        self.write_failures.extend(excs)
+
+    def read(self, address: int, width: int) -> int:
+        if self.read_failures:
+            raise self.read_failures.pop(0)
+        self.reads.append((address, width))
+        return self._read_value
+
+    def write(self, address: int, value: int, width: int) -> None:
+        if self.write_failures:
+            raise self.write_failures.pop(0)
+        self.writes.append((address, value, width))
+
+    def barrier(self) -> None:
+        self.barriers += 1
+
+
+@dataclass
+class _Info:
+    """Stand-in for Unit 4's exporter info object (just the bits we need)."""
+
+    is_volatile: bool = False
+    on_read: Callable[..., int] | None = None
+
+
+@pytest.fixture
+def master() -> CountingMaster:
+    return CountingMaster()
+
+
+@pytest.fixture
+def policies(master: CountingMaster) -> BusPolicies:
+    p = install(master)
+    # Speed up the retry path so the suite never sleeps for real.
+    p.retry._set_sleep(lambda _delay: None)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Barriers (§13.3)
+# ---------------------------------------------------------------------------
+
+
+class TestBarrier:
+    def test_explicit_barrier_calls_master(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # The user-facing surface is `soc.barrier()`; here we exercise the
+        # policy directly. The policy calls master.barrier() once.
+        policies.barriers.barrier()
+        assert master.barriers == 1
+
+    def test_global_barrier_alias(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.barriers.global_barrier()
+        assert master.barriers == 1
+
+    def test_auto_mode_fences_read_after_write(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # Default policy is "auto": same-master barrier before any read
+        # that follows a write.
+        policies.master.write(0x1000, 0xAA, 4)
+        assert master.barriers == 0  # write did not fence
+        _ = policies.master.read(0x1000, 4)
+        # Exactly one barrier: the implicit fence before the read.
+        assert master.barriers == 1
+
+    def test_auto_mode_no_fence_for_consecutive_reads(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        _ = policies.master.read(0x1000, 4)
+        _ = policies.master.read(0x1004, 4)
+        # No write in between → no implicit barrier.
+        assert master.barriers == 0
+
+    def test_none_mode_disables_implicit_fences(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.barriers.set_mode("none")
+        policies.master.write(0x1000, 0xAA, 4)
+        _ = policies.master.read(0x1000, 4)
+        assert master.barriers == 0
+
+    def test_strict_mode_fences_every_op(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.barriers.set_mode("strict")
+        policies.master.write(0x1000, 0xAA, 4)
+        _ = policies.master.read(0x1000, 4)
+        # One fence before the write, one before the read.
+        assert master.barriers == 2
+
+    def test_invalid_mode_raises(self, policies: BusPolicies) -> None:
+        with pytest.raises(ValueError, match="barrier policy"):
+            policies.barriers.set_mode("bogus")  # type: ignore[arg-type]
+
+    def test_global_scope_fences_every_peer(self, master: CountingMaster, policies: BusPolicies) -> None:
+        peer = CountingMaster()
+        policies.barriers.attach_peer(peer)
+        policies.barriers.barrier(scope="all")
+        assert master.barriers == 1
+        assert peer.barriers == 1
+
+
+# ---------------------------------------------------------------------------
+# Cache (§13.4)
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    def test_cache_for_dedupes_consecutive_reads(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0x42)
+        policies.cache.attach_slot(0x4000, ttl=0.1)
+        # Two consecutive reads: only the first should hit the bus.
+        v1 = policies.master.read(0x4000, 4)
+        v2 = policies.master.read(0x4000, 4)
+        assert v1 == 0x42
+        assert v2 == 0x42
+        assert len(master.reads) == 1
+
+    def test_cache_for_rclr_raises_not_supported(self, policies: BusPolicies) -> None:
+        info = _Info(is_volatile=True)  # rclr is volatile by definition
+        with pytest.raises(NotSupportedError, match="read side effects"):
+            policies.cache.attach_slot(0x5000, ttl=0.1, info=info)
+
+    def test_cache_for_on_read_callback_raises(self, policies: BusPolicies) -> None:
+        info = _Info(on_read=lambda *_: 0)
+        with pytest.raises(NotSupportedError):
+            policies.cache.attach_slot(0x5000, ttl=0.1, info=info)
+
+    def test_cache_invalidate_forces_bus_read(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0x10)
+        policies.cache.attach_slot(0x4000, ttl=10.0)
+        _ = policies.master.read(0x4000, 4)
+        master.set_read_value(0x20)
+        policies.cache.invalidate(0x4000)
+        v = policies.master.read(0x4000, 4)
+        assert v == 0x20
+        assert len(master.reads) == 2
+
+    def test_write_invalidates_cache(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0x10)
+        policies.cache.attach_slot(0x4000, ttl=10.0)
+        _ = policies.master.read(0x4000, 4)
+        # Writes invalidate the cached value at the same address.
+        policies.master.write(0x4000, 0x55, 4)
+        master.set_read_value(0x55)
+        v = policies.master.read(0x4000, 4)
+        assert v == 0x55
+        assert len(master.reads) == 2
+
+    def test_block_scope_window(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0x77)
+        # No explicit slot; rely on the block window.
+        with policies.cache.cached_window(window=10.0):
+            _ = policies.master.read(0x4000, 4)
+            _ = policies.master.read(0x4000, 4)
+        assert len(master.reads) == 1
+        # After exiting the window, the next read goes through.
+        _ = policies.master.read(0x4000, 4)
+        assert len(master.reads) == 2
+
+    def test_invalidate_all(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0xA1)
+        policies.cache.attach_slot(0x1000, ttl=10.0)
+        policies.cache.attach_slot(0x2000, ttl=10.0)
+        _ = policies.master.read(0x1000, 4)
+        _ = policies.master.read(0x2000, 4)
+        assert len(master.reads) == 2
+        policies.cache.invalidate(None)  # all slots
+        _ = policies.master.read(0x1000, 4)
+        _ = policies.master.read(0x2000, 4)
+        assert len(master.reads) == 4
+
+    def test_zero_ttl_rejected(self, policies: BusPolicies) -> None:
+        with pytest.raises(ValueError, match="cache_for"):
+            policies.cache.attach_slot(0x1000, ttl=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Retry (§13.5)
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_one_retry_then_success(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.set_read_value(0x99)
+        master.queue_read_failures(TimeoutError())
+        v = policies.master.read(0x1000, 4)
+        assert v == 0x99
+        assert policies.retry.last_retry_count == 1
+
+    def test_retries_zero_raises_immediately(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.retry.configure(retries=0)
+        master.queue_read_failures(TimeoutError())
+        with pytest.raises(BusError) as ei:
+            policies.master.read(0x1000, 4)
+        err = ei.value
+        assert err.retries == 0
+        assert err.op == "read"
+        assert err.addr == 0x1000
+        assert isinstance(err.underlying, TimeoutError)
+
+    def test_per_call_retry_override(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # Default retries=3. Override per-call to retries=0 → first failure
+        # propagates as BusError.
+        master.queue_read_failures(TimeoutError())
+        with pytest.raises(BusError):
+            policies.master.read(0x1000, 4, _pe_override=CallOverride(retries=0))
+
+    def test_per_call_higher_retry_override(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # Configure default to 0 retries, then override on the call to 3.
+        policies.retry.configure(retries=0)
+        master.queue_read_failures(TimeoutError(), TimeoutError(), TimeoutError())
+        master.set_read_value(0xBE)
+        v = policies.master.read(0x1000, 4, _pe_override=CallOverride(retries=3))
+        assert v == 0xBE
+        assert policies.retry.last_retry_count == 3
+
+    def test_retry_exhaustion_raises_bus_error(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.retry.configure(retries=2, backoff=0.0)
+        master.queue_read_failures(TimeoutError(), TimeoutError(), TimeoutError())
+        with pytest.raises(BusError) as ei:
+            policies.master.read(0x1000, 4)
+        # 2 retries means 3 attempts; on the 3rd failure we give up at
+        # attempt index 2.
+        assert ei.value.retries == 2
+
+    def test_retry_skips_unmatched_kinds(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # Default `on=("timeout", "nack")`. A ValueError is not retryable.
+        master.queue_read_failures(ValueError("not a transport error"))
+        with pytest.raises(BusError) as ei:
+            policies.master.read(0x1000, 4)
+        # Zero retries actually performed because the kind never matched.
+        assert ei.value.retries == 0
+        assert isinstance(ei.value.underlying, ValueError)
+
+    def test_retry_on_nack(self, master: CountingMaster, policies: BusPolicies) -> None:
+        master.queue_read_failures(NackError())
+        master.set_read_value(0x55)
+        v = policies.master.read(0x1000, 4)
+        assert v == 0x55
+        assert policies.retry.last_retry_count == 1
+
+    def test_on_giveup_log_returns_default(self, master: CountingMaster, policies: BusPolicies) -> None:
+        policies.retry.configure(retries=0, on_giveup="log")
+        master.queue_read_failures(TimeoutError())
+        v = policies.master.read(0x1000, 4)
+        assert v == 0  # log mode swallows; read returns 0
+        assert policies.retry.last_retry_count == 0
+
+    def test_invalid_on_giveup_rejected(self, policies: BusPolicies) -> None:
+        with pytest.raises(ValueError, match="on_giveup"):
+            policies.retry.configure(on_giveup="abort")  # type: ignore[arg-type]
+
+    def test_invalid_retries_rejected(self, policies: BusPolicies) -> None:
+        with pytest.raises(ValueError, match="retries"):
+            policies.retry.configure(retries=-1)
+
+
+# ---------------------------------------------------------------------------
+# on_disconnect (§13.5)
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnect:
+    def test_on_disconnect_fires_on_disconnect_kind(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        seen: list[MasterBase] = []
+        policies.retry.add_disconnect_callback(lambda m: seen.append(m))
+        # disconnect is not in the default `on=` list, so the call still
+        # gives up — but the callback runs first.
+        master.queue_read_failures(DisconnectError())
+        with pytest.raises(BusError):
+            policies.master.read(0x1000, 4)
+        assert seen == [master]
+
+    def test_on_disconnect_does_not_fire_on_other_kinds(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        seen: list[MasterBase] = []
+        policies.retry.add_disconnect_callback(lambda m: seen.append(m))
+        master.queue_read_failures(TimeoutError())  # not a disconnect
+        master.set_read_value(0x10)
+        _ = policies.master.read(0x1000, 4)
+        assert seen == []
+
+    def test_disconnect_can_be_added_to_retry_set(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        # Users who want disconnects to retry add them to `on=`.
+        policies.retry.configure(on=("disconnect",))
+        master.queue_read_failures(DisconnectError())
+        master.set_read_value(0xAB)
+        v = policies.master.read(0x1000, 4)
+        assert v == 0xAB
+        assert policies.retry.last_retry_count == 1
+
+    def test_disconnect_callback_failure_does_not_mask_bus_error(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        def bad_cb(_m: MasterBase) -> None:
+            raise RuntimeError("reconnect failed")
+
+        policies.retry.add_disconnect_callback(bad_cb)
+        master.queue_read_failures(DisconnectError())
+        with pytest.raises(BusError):
+            policies.master.read(0x1000, 4)
+
+
+# ---------------------------------------------------------------------------
+# Registry seam — Unit 1's `register_master_extension` plumbs to us
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_extension_is_registered_at_import(self) -> None:
+        # The module registers the bundle factory under the "bus_policies"
+        # name at import time so the SoC layer can attach it without
+        # depending on the class.
+        factory = get_master_extension_factory("bus_policies")
+        assert factory is not None
+
+    def test_attach_master_extension_returns_bundle(self, master: CountingMaster) -> None:
+        bundle = attach_master_extension("bus_policies", master)
+        assert isinstance(bundle, BusPolicies)
+        # Read goes through the wrapped surface now.
+        bundle.retry._set_sleep(lambda _d: None)
+        master.set_read_value(0x77)
+        assert master.read(0x1000, 4) == 0x77
+
+
+# ---------------------------------------------------------------------------
+# Integration — multiple policies layered on the same call
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_cache_short_circuit_skips_retry_and_barrier(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        master.set_read_value(0xCAFE)
+        policies.cache.attach_slot(0x4000, ttl=10.0)
+        _ = policies.master.read(0x4000, 4)
+        # Force a write so the auto-barrier policy would normally fence.
+        policies.master.write(0x8000, 0x01, 4)
+        assert master.barriers == 0  # writes don't fence in auto mode
+        # The cached read at 0x4000 must not fence (cache short-circuits).
+        # But the write invalidated 0x8000, not 0x4000, so we still get a
+        # cache hit. The barrier count stays at zero.
+        master.set_read_value(0xBAD)
+        v = policies.master.read(0x4000, 4)
+        assert v == 0xCAFE  # cached
+        assert master.barriers == 0
+
+    def test_retry_fences_between_attempts(self, master: CountingMaster, policies: BusPolicies) -> None:
+        # In strict mode, every attempt fences before issuing the read.
+        # The retry loop should still surface the right BusError if every
+        # attempt fails.
+        policies.barriers.set_mode("strict")
+        policies.retry.configure(retries=1, backoff=0.0)
+        master.queue_read_failures(TimeoutError(), TimeoutError())
+        with pytest.raises(BusError):
+            policies.master.read(0x1000, 4)
+        # 2 attempts, both fenced, both raised before reaching `master.reads`.
+        assert master.barriers == 2
+
+    def test_write_followed_by_read_clears_cache_and_fences(
+        self, master: CountingMaster, policies: BusPolicies
+    ) -> None:
+        policies.cache.attach_slot(0x4000, ttl=10.0)
+        master.set_read_value(0x11)
+        _ = policies.master.read(0x4000, 4)
+        master.set_read_value(0x22)
+        policies.master.write(0x4000, 0x99, 4)
+        v = policies.master.read(0x4000, 4)
+        assert v == 0x22
+        # Cache miss → real read → barrier fired (auto mode: write→read).
+        assert len(master.reads) == 2
+        assert master.barriers == 1


### PR DESCRIPTION
## Summary

Implements Unit 17 of the API overhaul (`docs/IDEAL_API_SKETCH.md`):
the unified bus-policy bundle that wraps any `MasterBase` with
barriers, cache, and retry/disconnect handling. The whole surface
hangs off a single named seam (`register_master_extension("bus_policies", ...)`)
so the umbrella SoC layer can attach policies without coupling to
each policy's internals.

* §13.3 — `BarrierPolicy`. Modes `auto` (default, same-master read-after-write),
  `none`, `strict`, `auto-global`. Per-master, per-subtree, and `scope="all"` /
  `global_barrier()` shapes.
* §13.4 — `CachePolicy`. `cache_for(ttl)` per absolute address;
  `cached_window(window=...)` block-scope; explicit invalidate; **refuses**
  `attach_slot` with `NotSupportedError` when the exporter info marks
  `is_volatile` or `on_read`.
* §13.5 — `RetryPolicy`. Exponential backoff, per-call `retries=` override
  via `CallOverride`, `on=("timeout","nack",...)` tag matching against
  `TransportError.kind`, `on_giveup` ∈ `{raise, log, panic}`, plus
  `on_disconnect(cb)` chain. `BusError(addr, op, master, retries, underlying)`
  carries the failure context.

Sibling shims define the contracts that Units 1 and 2 will unify in the
umbrella PR:

* `runtime/_errors.py` — `BusError`, `NotSupportedError`, `TransportError`,
  `TimeoutError`, `NackError`, `DisconnectError`.
* `runtime/_registry.py` — `register_master_extension` /
  `attach_master_extension` / `get_master_extension_factory`.

`MasterBase.barrier()` is added as a no-op default so the auto-policy has
something to call on backends that don't buffer writes.

## Test plan

- [x] `uv sync --group test && pytest tests/runtime/test_bus_policies.py -v` — 35 pass
- [x] Full suite (`pytest tests/`) — 111 pass, 27 skipped (pre-existing)
- [x] `ruff check` clean on `src/peakrdl_pybind11/runtime/` and `masters/base.py`
- [x] `ruff format --check` clean

## Sibling/umbrella reconciliation TODOs

- `runtime/_errors.py` will be replaced/extended by Unit 2's broader hierarchy.
- `runtime/_registry.py` is a minimal contract; Unit 1's seam may flesh it out.
- The `cache.attach_slot(info=...)` parameter is duck-typed (`object`) so it
  will accept Unit 4's `info.is_volatile` / `info.on_read` as soon as that
  unit lands.
- One in-code TODO marks where `on_giveup="log"` currently caches the
  default-zero return; the umbrella PR should skip the slot refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)