### PR TITLE
feat(runtime): Transaction objects + batch (Unit 18)

### DIFF
--- a/src/peakrdl_pybind11/__init__.py
+++ b/src/peakrdl_pybind11/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .exporter import Pybind11Exporter
     from .int_types import FieldInt, RegisterInt, RegisterIntEnum, RegisterIntFlag
+    from .runtime.transactions import Burst, Read, Write
 
 try:
     __version__ = version("peakrdl-pybind11")
@@ -18,7 +19,16 @@ except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 
-__all__ = ["FieldInt", "Pybind11Exporter", "RegisterInt", "RegisterIntEnum", "RegisterIntFlag"]
+__all__ = [
+    "Burst",
+    "FieldInt",
+    "Pybind11Exporter",
+    "Read",
+    "RegisterInt",
+    "RegisterIntEnum",
+    "RegisterIntFlag",
+    "Write",
+]
 
 
 def __getattr__(name: str) -> type:
@@ -42,4 +52,8 @@ def __getattr__(name: str) -> type:
         from .int_types import FieldInt
 
         return FieldInt
+    if name in ("Read", "Write", "Burst"):
+        from .runtime.transactions import Burst, Read, Write
+
+        return {"Read": Read, "Write": Write, "Burst": Burst}[name]
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,24 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+
+This package houses sibling-unit modules that wire themselves into the
+generated runtime via the registry seam in :mod:`._registry`. Each
+sibling unit imports ``_registry`` and decorates its hook callables
+(register enhancements, post-create hooks, master extensions, lazy node
+attributes); the generated ``runtime.py`` fires those hooks at the
+appropriate points.
+
+Importing this package eagerly imports :mod:`._registry` and the bundled
+sibling-unit modules so all registration happens at runtime-package load
+time, before the generated module touches its register/field classes.
+"""
+
+from __future__ import annotations
+
+from . import _registry, transactions  # noqa: F401  (side-effecting imports register hooks)
+
+__all__ = [
+    "_registry",
+    "transactions",
+]

--- a/src/peakrdl_pybind11/runtime/_registry.py
+++ b/src/peakrdl_pybind11/runtime/_registry.py
@@ -1,0 +1,272 @@
+"""
+Central runtime hook registry.
+
+This module is the **stable seam** that every sibling unit of the API
+overhaul plugs into. Sibling units register callables here and the
+generated runtime fires them at well-defined points; nothing in
+``runtime.py.jinja`` (the per-SoC generated module) needs to know which
+units are present.
+
+Five registries live here:
+
+* ``_register_enhancements`` — wrap/extend a generated **register** class
+  with ``apply(cls, fields_spec)``.
+* ``_field_enhancements`` — same idea for generated **field** classes.
+  (Split from register enhancements because the existing template uses
+  different per-field metadata; sibling units almost always target one or
+  the other, not both.)
+* ``_post_create_hooks`` — fire after ``soc = MySoc.create(...)``.
+* ``_master_extensions`` — fire when a master is attached to a SoC.
+* ``_node_attributes`` — lazy attribute factories attached to the node
+  base class. Each factory returns the value for the attribute on first
+  access; later units add ``.info``, ``.snapshot``, ``.watch`` etc.
+
+All registration is thread-safe: a single ``threading.Lock`` guards each
+mutation. Callable invocation is *not* serialized — the caller is
+expected to hold any cross-cutting locks.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable
+
+logger = logging.getLogger("peakrdl_pybind11.runtime.registry")
+
+# ---------------------------------------------------------------------------
+# Type aliases. Kept loose so sibling units can register callables that take
+# extra optional kwargs without breaking the registry.
+# ---------------------------------------------------------------------------
+
+RegisterEnhancement = Callable[[type, dict], None]
+FieldEnhancement = Callable[[type], None]
+PostCreateHook = Callable[[Any], None]
+MasterExtension = Callable[[Any], None]
+NodeAttributeFactory = Callable[[Any], Any]
+
+# ---------------------------------------------------------------------------
+# Internal registries. Lists preserve registration order so siblings can
+# reason about composition: defaults register first, sibling units extend.
+# ---------------------------------------------------------------------------
+
+_register_enhancements: list[RegisterEnhancement] = []
+_field_enhancements: list[FieldEnhancement] = []
+_post_create_hooks: list[PostCreateHook] = []
+_master_extensions: list[MasterExtension] = []
+_node_attributes: dict[str, NodeAttributeFactory] = {}
+
+# Identity sets so re-registration of the same callable is idempotent.
+# Without these, importing a sibling module twice (rare, but happens with
+# ``importlib.reload`` and the test harness) would double-register hooks.
+_seen_register_enhancements: set[int] = set()
+_seen_field_enhancements: set[int] = set()
+_seen_post_create_hooks: set[int] = set()
+_seen_master_extensions: set[int] = set()
+
+_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Decorator API
+# ---------------------------------------------------------------------------
+
+
+def register_register_enhancement(fn: RegisterEnhancement) -> RegisterEnhancement:
+    """Register ``fn`` to be called for every generated register class.
+
+    The callable receives ``(cls, fields_spec)`` where ``fields_spec`` is
+    the per-register ``{field_name: (lsb, width)}`` dict produced by the
+    template. Idempotent on identity: re-registering the same function
+    is a no-op.
+    """
+    with _lock:
+        if id(fn) in _seen_register_enhancements:
+            return fn
+        _seen_register_enhancements.add(id(fn))
+        _register_enhancements.append(fn)
+    return fn
+
+
+def register_field_enhancement(fn: FieldEnhancement) -> FieldEnhancement:
+    """Register ``fn`` to be called for every generated field class.
+
+    The callable receives the class. Use this for field-only behaviour
+    (typed read return value, raw accessors, etc.).
+    """
+    with _lock:
+        if id(fn) in _seen_field_enhancements:
+            return fn
+        _seen_field_enhancements.add(id(fn))
+        _field_enhancements.append(fn)
+    return fn
+
+
+def register_post_create(fn: PostCreateHook) -> PostCreateHook:
+    """Register ``fn`` to fire after a SoC instance is created.
+
+    Sibling units use this to attach observers, snapshot tooling,
+    interrupt detection, etc.
+    """
+    with _lock:
+        if id(fn) in _seen_post_create_hooks:
+            return fn
+        _seen_post_create_hooks.add(id(fn))
+        _post_create_hooks.append(fn)
+    return fn
+
+
+def register_master_extension(fn: MasterExtension) -> MasterExtension:
+    """Register ``fn`` to fire when a master attaches to a SoC.
+
+    Sibling units use this to wire bus policies (retry, cache,
+    barriers, tracing) into the master.
+    """
+    with _lock:
+        if id(fn) in _seen_master_extensions:
+            return fn
+        _seen_master_extensions.add(id(fn))
+        _master_extensions.append(fn)
+    return fn
+
+
+def register_node_attribute(name: str) -> Callable[[NodeAttributeFactory], NodeAttributeFactory]:
+    """Decorator factory that registers a lazy node attribute.
+
+    The decorated function is called with the node instance the first
+    time the attribute is accessed; the result is cached on the instance.
+    Re-registering the same name silently overwrites the previous factory
+    (the new sibling unit "wins"). A debug log records the replacement.
+    """
+
+    def decorator(fn: NodeAttributeFactory) -> NodeAttributeFactory:
+        with _lock:
+            if name in _node_attributes and _node_attributes[name] is not fn:
+                logger.debug("node attribute %r being overwritten by %r", name, fn)
+            _node_attributes[name] = fn
+        return fn
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Apply API — the generated runtime.py imports and calls these.
+# ---------------------------------------------------------------------------
+
+
+def apply_register_enhancements(cls: type, metadata: dict) -> None:
+    """Run every registered register enhancement against ``cls``."""
+    # Snapshot under the lock so a long-running enhancement doesn't block
+    # later registrations from sibling units imported on demand.
+    with _lock:
+        funcs = list(_register_enhancements)
+    for fn in funcs:
+        try:
+            fn(cls, metadata)
+        except Exception:
+            logger.exception("register enhancement %r raised on %r", fn, cls)
+            raise
+
+
+def apply_field_enhancements(cls: type) -> None:
+    """Run every registered field enhancement against ``cls``."""
+    with _lock:
+        funcs = list(_field_enhancements)
+    for fn in funcs:
+        try:
+            fn(cls)
+        except Exception:
+            logger.exception("field enhancement %r raised on %r", fn, cls)
+            raise
+
+
+def fire_post_create_hooks(soc: Any) -> None:
+    """Fire every registered post-create hook against ``soc``."""
+    with _lock:
+        hooks = list(_post_create_hooks)
+    for fn in hooks:
+        try:
+            fn(soc)
+        except Exception:
+            logger.exception("post-create hook %r raised on %r", fn, soc)
+            raise
+
+
+def fire_master_extensions(master: Any) -> None:
+    """Fire every registered master extension against ``master``."""
+    with _lock:
+        funcs = list(_master_extensions)
+    for fn in funcs:
+        try:
+            fn(master)
+        except Exception:
+            logger.exception("master extension %r raised on %r", fn, master)
+            raise
+
+
+def attach_node_attributes(node_class: type | None) -> None:
+    """Wire registered lazy attributes onto ``node_class``.
+
+    If ``node_class`` is ``None`` (no shared base in the generated module
+    yet — the current state during early API-overhaul units), this is a
+    no-op so siblings can call it safely.
+    """
+    if node_class is None:
+        return
+
+    with _lock:
+        attrs = dict(_node_attributes)
+
+    for name, factory in attrs.items():
+        # Skip if the class already defines the attribute (sibling unit
+        # explicitly defined it on the class, factory is a fallback).
+        if name in node_class.__dict__:
+            continue
+
+        def _make_property(fn: NodeAttributeFactory, attr_name: str) -> property:
+            cache_key = f"_node_attr_cache_{attr_name}"
+
+            def getter(self: Any) -> Any:
+                cached = self.__dict__.get(cache_key)
+                if cached is not None:
+                    return cached
+                value = fn(self)
+                self.__dict__[cache_key] = value
+                return value
+
+            return property(getter)
+
+        setattr(node_class, name, _make_property(factory, name))
+
+
+# ---------------------------------------------------------------------------
+# Test / introspection helpers. Sibling units do **not** depend on these;
+# they exist so the registry test module can verify behaviour without
+# reaching into private state.
+# ---------------------------------------------------------------------------
+
+
+def _reset_for_tests() -> None:
+    """Clear every registry. Test-only; do **not** call from production."""
+    with _lock:
+        _register_enhancements.clear()
+        _field_enhancements.clear()
+        _post_create_hooks.clear()
+        _master_extensions.clear()
+        _node_attributes.clear()
+        _seen_register_enhancements.clear()
+        _seen_field_enhancements.clear()
+        _seen_post_create_hooks.clear()
+        _seen_master_extensions.clear()
+
+
+def _snapshot() -> dict[str, Any]:
+    """Return a shallow snapshot of every registry. Test-only."""
+    with _lock:
+        return {
+            "register_enhancements": list(_register_enhancements),
+            "field_enhancements": list(_field_enhancements),
+            "post_create_hooks": list(_post_create_hooks),
+            "master_extensions": list(_master_extensions),
+            "node_attributes": dict(_node_attributes),
+        }

--- a/src/peakrdl_pybind11/runtime/transactions.py
+++ b/src/peakrdl_pybind11/runtime/transactions.py
@@ -1,0 +1,261 @@
+"""Reified bus transactions and batched-write context manager.
+
+Implements the API described in ``docs/IDEAL_API_SKETCH.md`` §13.2:
+
+* :class:`Read`, :class:`Write`, :class:`Burst` — frozen dataclasses that
+  describe a single bus operation. Cheap to construct, hashable, and
+  intentionally light on validation so building lists of thousands of them
+  in a tight loop stays fast.
+* :func:`execute` — dispatches a sequence of those transactions against a
+  master, using ``read_many`` / ``write_many`` where the master provides
+  them. Returns the values produced by reads only; writes do not
+  contribute to the result list.
+* :func:`batch` — context manager that opens a cross-register
+  ``soc.transaction()`` so every write inside the ``with`` block is
+  staged and flushed in a single ``master.write_many`` call on exit.
+
+The module also wires itself into the runtime registry:
+
+* ``register_master_extension`` attaches :func:`execute` as a bound
+  ``master.execute(txns)`` method on every wrapped/extended master.
+* ``register_post_create`` attaches :func:`batch` as a bound
+  ``soc.batch()`` method on every freshly created SoC.
+
+Both attachments are best-effort: pybind11-generated classes without
+``py::dynamic_attr()`` reject ``setattr`` and we skip silently. Pure
+Python masters/SoCs (or wrapped ones) get the convenience methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from ..masters.base import AccessOp
+from . import _registry
+
+__all__ = [
+    "Burst",
+    "Read",
+    "Write",
+    "batch",
+    "execute",
+]
+
+logger = logging.getLogger("peakrdl_pybind11.runtime.transactions")
+
+
+# ---------------------------------------------------------------------------
+# Reified transaction dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Read:
+    """A single bus read.
+
+    ``addr`` is an absolute byte address. ``width`` is the access width in
+    bytes (default 4 for the common 32-bit register case). The dataclass
+    is frozen so a list of ``Read`` instances is safe to share across
+    threads or to use as dict keys.
+    """
+
+    addr: int
+    width: int = 4
+
+
+@dataclass(frozen=True, slots=True)
+class Write:
+    """A single bus write.
+
+    ``value`` is interpreted in register-space (no field shifting); the
+    master receives ``(addr, value, width)`` exactly as constructed.
+    """
+
+    addr: int
+    value: int
+    width: int = 4
+
+
+@dataclass(frozen=True, slots=True)
+class Burst:
+    """An N-element burst at consecutive ``width``-byte addresses.
+
+    ``op`` selects the direction:
+
+    * ``"read"`` issues ``count`` reads starting at ``addr``; ``values``
+      must be ``None``.
+    * ``"write"`` issues ``count`` writes; ``values`` must be a sequence
+      of ``count`` integers (one per element).
+
+    Validation runs in ``__post_init__`` so building an invalid burst
+    fails at construction time rather than at execute().
+    """
+
+    addr: int
+    count: int
+    op: Literal["read", "write"]
+    values: list[int] | None = None
+    width: int = 4
+
+    def __post_init__(self) -> None:
+        if self.op not in ("read", "write"):
+            raise ValueError(
+                f"Burst.op must be 'read' or 'write', got {self.op!r}"
+            )
+        if self.count < 0:
+            raise ValueError(f"Burst.count must be >= 0, got {self.count}")
+        if self.op == "read":
+            if self.values is not None:
+                raise ValueError("Burst(op='read') must not specify values")
+        else:  # "write"
+            if self.values is None:
+                raise ValueError("Burst(op='write') requires values=...")
+            if len(self.values) != self.count:
+                raise ValueError(
+                    f"Burst(op='write') values length {len(self.values)} "
+                    f"does not match count {self.count}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Execute: dispatch a sequence of transactions on a master
+# ---------------------------------------------------------------------------
+
+
+def _burst_ops(burst: Burst) -> list[AccessOp]:
+    """Materialize a Burst into the per-element :class:`AccessOp` list."""
+    if burst.op == "read":
+        return [
+            AccessOp(address=burst.addr + i * burst.width, value=0, width=burst.width)
+            for i in range(burst.count)
+        ]
+    # op == "write"; values is non-None per Burst.__post_init__.
+    assert burst.values is not None
+    return [
+        AccessOp(address=burst.addr + i * burst.width, value=v, width=burst.width)
+        for i, v in enumerate(burst.values)
+    ]
+
+
+def execute(master: Any, txns: Sequence[Read | Write | Burst]) -> list[int]:
+    """Execute ``txns`` against ``master``; return values from reads only.
+
+    Each :class:`Read` produces one value in the result list; each
+    :class:`Write` produces nothing; a :class:`Burst` with ``op="read"``
+    contributes ``count`` values; a :class:`Burst` with ``op="write"``
+    contributes nothing.
+
+    When the master exposes ``read_many`` / ``write_many`` (Unit 1's
+    batch interface), bursts use that single boundary cross. Single
+    Read/Write fall back to ``master.read`` / ``master.write`` directly
+    so the latency for one-off scripted txns stays minimal.
+
+    Transaction order is preserved: writes execute strictly before any
+    later reads, so the ``Write(addr, v); Read(addr)`` idiom returns
+    ``[v]`` even on masters that buffer writes asynchronously.
+    """
+    out: list[int] = []
+    read_many = getattr(master, "read_many", None)
+    write_many = getattr(master, "write_many", None)
+
+    for txn in txns:
+        if isinstance(txn, Read):
+            out.append(int(master.read(txn.addr, txn.width)))
+        elif isinstance(txn, Write):
+            master.write(txn.addr, txn.value, txn.width)
+        elif isinstance(txn, Burst):
+            ops = _burst_ops(txn)
+            if txn.op == "read":
+                if read_many is not None:
+                    out.extend(int(v) for v in read_many(ops))
+                else:
+                    out.extend(int(master.read(op.address, op.width)) for op in ops)
+            else:  # "write"
+                if write_many is not None:
+                    write_many(ops)
+                else:
+                    for op in ops:
+                        master.write(op.address, op.value, op.width)
+        else:
+            raise TypeError(
+                f"execute(): unsupported transaction type {type(txn).__name__!r}"
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Batch: cross-register write-staging context manager
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def batch(soc: Any) -> Iterator[Any]:
+    """Open a write-staging context that flushes on exit.
+
+    Equivalent to::
+
+        with soc.transaction():
+            yield soc
+
+    Inside the ``with`` block, every register write through ``soc``
+    accumulates in the active transaction; on clean exit the whole batch
+    is dispatched via a single ``master.write_many`` call. On exception
+    the queue is discarded (matches ``soc.transaction()`` semantics).
+
+    Yields ``soc`` itself — ``b is soc`` — because the existing
+    transaction machinery in C++ already routes writes through the
+    active transaction without needing a proxy tree.
+    """
+    transaction = getattr(soc, "transaction", None)
+    if transaction is None:
+        raise AttributeError(
+            "soc.batch() requires soc.transaction() — attach a master first"
+        )
+    with transaction():
+        yield soc
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+def _try_setattr(obj: Any, name: str, value: Any) -> None:
+    """``setattr`` that swallows the rejection from pybind11 classes.
+
+    pybind11 classes without ``py::dynamic_attr()`` raise ``AttributeError``
+    on ``setattr``; we treat that as "nothing to attach here" so the
+    registry hook stays a no-op for raw C++ master/SoC objects.
+    """
+    try:
+        setattr(obj, name, value)
+    except (AttributeError, TypeError) as exc:
+        logger.debug("could not attach %r to %r: %s", name, type(obj).__name__, exc)
+
+
+@_registry.register_master_extension
+def _attach_execute_to_master(master: Any) -> None:
+    """Attach a bound ``execute`` method to ``master``."""
+    if hasattr(master, "execute") and callable(master.execute):
+        return  # already attached or natively provided
+
+    def _bound_execute(txns: Sequence[Read | Write | Burst]) -> list[int]:
+        return execute(master, txns)
+
+    _try_setattr(master, "execute", _bound_execute)
+
+
+@_registry.register_post_create
+def _attach_batch_to_soc(soc: Any) -> None:
+    """Attach a bound ``batch`` method to ``soc``."""
+    if hasattr(soc, "batch") and callable(soc.batch):
+        return  # already attached
+
+    def _bound_batch() -> Any:
+        return batch(soc)
+
+    _try_setattr(soc, "batch", _bound_batch)

--- a/tests/runtime/test_transactions.py
+++ b/tests/runtime/test_transactions.py
@@ -1,0 +1,394 @@
+"""Tests for the reified transaction API (Unit 18, sketch §13.2).
+
+Pure-Python tests: no cmake, no generated module. The :class:`Read`,
+:class:`Write`, :class:`Burst` dataclasses are exercised directly, and
+``execute`` / ``batch`` are tested against ``peakrdl_pybind11.masters.mock``
+plus a hand-rolled fake SoC that implements just enough of the real
+``soc.transaction()`` contract to verify the batching behaviour.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import contextmanager
+from dataclasses import FrozenInstanceError
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.masters.base import AccessOp
+from peakrdl_pybind11.masters.mock import MockMaster
+from peakrdl_pybind11.runtime import _registry
+from peakrdl_pybind11.runtime.transactions import Burst, Read, Write, batch, execute
+
+# ---------------------------------------------------------------------------
+# Dataclass surface
+# ---------------------------------------------------------------------------
+
+
+class TestDataclasses:
+    """Frozen, slotted dataclasses with sensible defaults."""
+
+    def test_read_construct(self) -> None:
+        r = Read(0x1000)
+        assert r.addr == 0x1000
+        assert r.width == 4
+
+    def test_read_custom_width(self) -> None:
+        r = Read(0x1000, width=2)
+        assert r.width == 2
+
+    def test_read_is_frozen(self) -> None:
+        r = Read(0x1000)
+        with pytest.raises(FrozenInstanceError):
+            r.addr = 0x2000  # type: ignore[misc]
+
+    def test_write_construct(self) -> None:
+        w = Write(0x1004, 0x42)
+        assert w.addr == 0x1004
+        assert w.value == 0x42
+        assert w.width == 4
+
+    def test_write_is_frozen(self) -> None:
+        w = Write(0x1004, 0x42)
+        with pytest.raises(FrozenInstanceError):
+            w.value = 0  # type: ignore[misc]
+
+    def test_burst_read_construct(self) -> None:
+        b = Burst(0x2000, count=4, op="read")
+        assert b.addr == 0x2000
+        assert b.count == 4
+        assert b.op == "read"
+        assert b.values is None
+        assert b.width == 4
+
+    def test_burst_write_construct(self) -> None:
+        b = Burst(0x2000, count=4, op="write", values=[1, 2, 3, 4])
+        assert b.values == [1, 2, 3, 4]
+
+    def test_burst_is_frozen(self) -> None:
+        b = Burst(0x2000, count=4, op="read")
+        with pytest.raises(FrozenInstanceError):
+            b.count = 8  # type: ignore[misc]
+
+    def test_burst_invalid_op(self) -> None:
+        with pytest.raises(ValueError, match="op must be"):
+            Burst(0x2000, count=2, op="bogus")  # type: ignore[arg-type]
+
+    def test_burst_read_rejects_values(self) -> None:
+        with pytest.raises(ValueError, match="must not specify values"):
+            Burst(0x2000, count=2, op="read", values=[1, 2])
+
+    def test_burst_write_requires_values(self) -> None:
+        with pytest.raises(ValueError, match="requires values"):
+            Burst(0x2000, count=2, op="write")
+
+    def test_burst_write_values_length_mismatch(self) -> None:
+        with pytest.raises(ValueError, match="does not match count"):
+            Burst(0x2000, count=2, op="write", values=[1, 2, 3])
+
+    def test_top_level_imports(self) -> None:
+        """``from peakrdl_pybind11 import Read, Write, Burst`` works (sketch §13.2)."""
+        import peakrdl_pybind11
+
+        assert peakrdl_pybind11.Read is Read
+        assert peakrdl_pybind11.Write is Write
+        assert peakrdl_pybind11.Burst is Burst
+
+
+# ---------------------------------------------------------------------------
+# execute()
+# ---------------------------------------------------------------------------
+
+
+class _CountingMaster(MockMaster):
+    """MockMaster that counts read_many/write_many invocations.
+
+    Lets the tests assert that bursts collapse into a single batched call
+    instead of N single-op calls.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.read_many_calls = 0
+        self.write_many_calls = 0
+        self.read_calls = 0
+        self.write_calls = 0
+
+    def read(self, address: int, width: int) -> int:
+        self.read_calls += 1
+        return super().read(address, width)
+
+    def write(self, address: int, value: int, width: int) -> None:
+        self.write_calls += 1
+        super().write(address, value, width)
+
+    def read_many(self, ops: Sequence[AccessOp]) -> list[int]:
+        self.read_many_calls += 1
+        return super().read_many(ops)
+
+    def write_many(self, ops: Sequence[AccessOp]) -> None:
+        self.write_many_calls += 1
+        super().write_many(ops)
+
+
+class TestExecute:
+    def test_single_read(self) -> None:
+        m = _CountingMaster()
+        m.memory[0x1000] = 0xDEADBEEF
+        result = execute(m, [Read(0x1000)])
+        assert result == [0xDEADBEEF]
+        assert m.read_calls == 1
+        assert m.read_many_calls == 0
+
+    def test_single_write(self) -> None:
+        m = _CountingMaster()
+        result = execute(m, [Write(0x1000, 0x42)])
+        assert result == []  # writes do not contribute to result
+        assert m.memory[0x1000] == 0x42
+        assert m.write_calls == 1
+
+    def test_write_then_read(self) -> None:
+        m = _CountingMaster()
+        result = execute(m, [Write(0x1000, 0x42), Read(0x1000)])
+        assert result == [0x42]
+        assert m.memory[0x1000] == 0x42
+
+    def test_burst_read_uses_read_many(self) -> None:
+        m = _CountingMaster()
+        for i in range(4):
+            m.memory[0x2000 + i * 4] = 0x10 + i
+        result = execute(m, [Burst(0x2000, count=4, op="read")])
+        assert result == [0x10, 0x11, 0x12, 0x13]
+        assert m.read_many_calls == 1
+        assert m.read_calls == 0
+
+    def test_burst_write_uses_write_many(self) -> None:
+        m = _CountingMaster()
+        execute(m, [Burst(0x2000, count=4, op="write", values=[1, 2, 3, 4])])
+        for i, v in enumerate([1, 2, 3, 4]):
+            assert m.memory[0x2000 + i * 4] == v
+        assert m.write_many_calls == 1
+        assert m.write_calls == 0
+
+    def test_burst_read_falls_back_when_master_lacks_read_many(self) -> None:
+        """Masters without read_many still work — execute loops single ops."""
+
+        class NoBatchMaster:
+            def __init__(self) -> None:
+                self.read_calls = 0
+
+            def read(self, addr: int, width: int) -> int:
+                self.read_calls += 1
+                return addr  # echo the address
+
+            def write(self, addr: int, value: int, width: int) -> None:
+                pass
+
+        m = NoBatchMaster()
+        result = execute(m, [Burst(0x2000, count=3, op="read")])
+        assert result == [0x2000, 0x2004, 0x2008]
+        assert m.read_calls == 3
+
+    def test_burst_write_falls_back_when_master_lacks_write_many(self) -> None:
+        class NoBatchMaster:
+            def __init__(self) -> None:
+                self.writes: list[tuple[int, int, int]] = []
+
+            def read(self, addr: int, width: int) -> int:
+                return 0
+
+            def write(self, addr: int, value: int, width: int) -> None:
+                self.writes.append((addr, value, width))
+
+        m = NoBatchMaster()
+        execute(m, [Burst(0x2000, count=3, op="write", values=[10, 20, 30])])
+        assert m.writes == [
+            (0x2000, 10, 4),
+            (0x2004, 20, 4),
+            (0x2008, 30, 4),
+        ]
+
+    def test_burst_zero_count_is_a_noop(self) -> None:
+        m = _CountingMaster()
+        result = execute(m, [Burst(0x2000, count=0, op="read")])
+        assert result == []
+        # read_many is still called once with an empty op list; that's fine.
+
+    def test_unsupported_transaction_type(self) -> None:
+        m = _CountingMaster()
+        with pytest.raises(TypeError, match="unsupported transaction type"):
+            execute(m, ["not a transaction"])  # type: ignore[list-item]
+
+    def test_mixed_sequence_preserves_order(self) -> None:
+        """Reads, writes, and bursts interleave in submission order."""
+        m = _CountingMaster()
+        result = execute(
+            m,
+            [
+                Write(0x1000, 0xAA),
+                Read(0x1000),
+                Burst(0x2000, count=2, op="write", values=[1, 2]),
+                Burst(0x2000, count=2, op="read"),
+                Write(0x3000, 0xBB),
+                Read(0x3000),
+            ],
+        )
+        assert result == [0xAA, 1, 2, 0xBB]
+
+    def test_custom_widths(self) -> None:
+        m = _CountingMaster()
+        result = execute(m, [Write(0x100, 0xABCD, width=2), Read(0x100, width=2)])
+        assert result == [0xABCD]
+
+
+# ---------------------------------------------------------------------------
+# Master extension — execute() attached as a bound method
+# ---------------------------------------------------------------------------
+
+
+class TestMasterExtension:
+    def test_extension_attaches_execute_method(self) -> None:
+        m = MockMaster()
+        _registry.fire_master_extensions(m)
+        assert callable(m.execute)
+        m.memory[0x1000] = 0x55
+        assert m.execute([Read(0x1000)]) == [0x55]
+
+    def test_extension_is_idempotent(self) -> None:
+        """Firing the extension twice doesn't double-wrap."""
+        m = MockMaster()
+        _registry.fire_master_extensions(m)
+        first = m.execute
+        _registry.fire_master_extensions(m)
+        assert m.execute is first  # pre-existing callable is preserved
+
+    def test_extension_silently_skips_immutable_master(self) -> None:
+        """A master whose attribute set raises is left untouched (not crashed)."""
+
+        class FrozenMaster:
+            __slots__ = ("memory",)
+
+            def __init__(self) -> None:
+                self.memory: dict[int, int] = {}
+
+            def read(self, addr: int, width: int) -> int:
+                return self.memory.get(addr, 0)
+
+            def write(self, addr: int, value: int, width: int) -> None:
+                self.memory[addr] = value
+
+        m = FrozenMaster()
+        # Must not raise; just no convenience method gets attached.
+        _registry.fire_master_extensions(m)
+        assert not hasattr(m, "execute")
+        # Module-level execute() still works for the same master.
+        m.memory[0x100] = 0x77
+        assert execute(m, [Read(0x100)]) == [0x77]
+
+
+# ---------------------------------------------------------------------------
+# batch() context manager
+# ---------------------------------------------------------------------------
+
+
+class _FakeReg:
+    """Minimal register stand-in: writes route through the parent SoC."""
+
+    def __init__(self, soc: _FakeSoC, addr: int) -> None:
+        self._soc = soc
+        self.addr = addr
+
+    def write(self, value: int) -> None:
+        self._soc._dispatch_write(self.addr, value)
+
+
+class _FakeUart:
+    def __init__(self, soc: _FakeSoC) -> None:
+        self.control = _FakeReg(soc, 0x10)
+        self.data = _FakeReg(soc, 0x14)
+
+
+class _FakeSoC:
+    """Hand-rolled SoC fake with a ``transaction()`` cm and a uart subtree.
+
+    Mirrors the real generated SoC's transaction semantics: writes inside
+    the cm queue into a buffer and flush in one ``master.write_many`` on
+    clean exit; on exception the buffer is discarded.
+    """
+
+    def __init__(self) -> None:
+        self.master = _CountingMaster()
+        self._tx_ops: list[AccessOp] | None = None
+        self.uart = _FakeUart(self)
+
+    def _dispatch_write(self, addr: int, value: int, width: int = 4) -> None:
+        if self._tx_ops is not None:
+            self._tx_ops.append(AccessOp(address=addr, value=value, width=width))
+        else:
+            self.master.write(addr, value, width)
+
+    @contextmanager
+    def transaction(self) -> Any:
+        self._tx_ops = []
+        try:
+            yield self
+            ops, self._tx_ops = self._tx_ops, None
+            if ops:
+                self.master.write_many(ops)
+        except BaseException:
+            self._tx_ops = None
+            raise
+
+
+class TestBatch:
+    def test_batch_flushes_in_one_write_many(self) -> None:
+        soc = _FakeSoC()
+        with batch(soc) as b:
+            b.uart.control.write(1)
+            b.uart.data.write(0x55)
+            # Nothing has reached the master yet.
+            assert soc.master.write_calls == 0
+            assert soc.master.write_many_calls == 0
+        # Exactly one batched flush for both writes.
+        assert soc.master.write_many_calls == 1
+        assert soc.master.write_calls == 0
+        assert soc.master.memory[0x10] == 1
+        assert soc.master.memory[0x14] == 0x55
+
+    def test_batch_yields_soc_itself(self) -> None:
+        soc = _FakeSoC()
+        with batch(soc) as b:
+            assert b is soc
+
+    def test_batch_discards_on_exception(self) -> None:
+        soc = _FakeSoC()
+        with pytest.raises(RuntimeError):
+            with batch(soc) as b:
+                b.uart.control.write(0xAA)
+                raise RuntimeError("boom")
+        # No flush, master untouched.
+        assert soc.master.write_many_calls == 0
+        assert soc.master.write_calls == 0
+        assert 0x10 not in soc.master.memory
+
+    def test_batch_requires_transaction_method(self) -> None:
+        class NoTransactionSoC:
+            pass
+
+        with pytest.raises(AttributeError, match="requires soc.transaction"):
+            with batch(NoTransactionSoC()):
+                pass
+
+    def test_post_create_attaches_batch_method(self) -> None:
+        soc = _FakeSoC()
+        _registry.fire_post_create_hooks(soc)
+        assert callable(soc.batch)
+        with soc.batch() as b:
+            b.uart.control.write(0x77)
+        assert soc.master.write_many_calls == 1
+        assert soc.master.memory[0x10] == 0x77
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements the reified bus transaction API described in `docs/IDEAL_API_SKETCH.md` §13.2:

- `Read`, `Write`, `Burst` frozen dataclasses in `peakrdl_pybind11.runtime.transactions` (re-exported from the top-level package).
- `execute(master, txns)` dispatches a sequence of transactions; uses `read_many` / `write_many` when the master exposes Unit 1's batch interface, falls back to per-op loops otherwise. Returns the values produced by reads only; writes contribute nothing.
- `batch(soc)` context manager — thin wrapper over the existing C++ `soc.transaction()` so writes inside the `with` block flush via a single `master.write_many` on exit.
- Wired through Unit 1's registry seam (`register_master_extension` attaches `master.execute`; `register_post_create` attaches `soc.batch`); attachment is best-effort and silently no-ops for pybind11 classes without `py::dynamic_attr()`.

## Files

- `src/peakrdl_pybind11/runtime/transactions.py` (new)
- `src/peakrdl_pybind11/runtime/_registry.py` (new — minimal Unit 1 seam, kept here so the PR is self-contained until Unit 1 lands on `exp/api_overhaul`)
- `src/peakrdl_pybind11/runtime/__init__.py` (new)
- `src/peakrdl_pybind11/__init__.py` (re-export `Read`, `Write`, `Burst`)
- `tests/runtime/test_transactions.py` (new — 32 tests)
- `tests/runtime/__init__.py` (new)

## Test plan

- [x] `Read(0x1000)`, `Write(0x1004, 0x42)`, `Burst(0x2000, count=4, op="read")` instantiate (frozen).
- [x] `master.execute([Read(0x1000)])` returns `[value]`.
- [x] `master.execute([Write(0x1000, 0x42), Read(0x1000)])` returns `[0x42]`.
- [x] `Burst(op="write", values=[1,2,3,4])` issues a single `write_many` call.
- [x] `with soc.batch() as b: b.uart.control.write(1)` flushes in exactly one `master.write_many` call.
- [x] Burst falls back to single-op loops when master lacks `read_many` / `write_many`.
- [x] Master extension is idempotent and silently skips immutable masters.
- [x] `pytest tests/runtime/test_transactions.py -v` — 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)