### PR TITLE
feat(runtime): counters/lock/specialized (Unit 14)

### DIFF
--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+"""
+
+from __future__ import annotations

--- a/src/peakrdl_pybind11/runtime/specialized.py
+++ b/src/peakrdl_pybind11/runtime/specialized.py
@@ -1,0 +1,880 @@
+"""Helpers for specialized SystemRDL register kinds.
+
+Implements §12 of ``docs/IDEAL_API_SKETCH.md``: counter wrappers, singlepulse
+``pulse()``, reset semantics (``reset_value`` / ``is_at_reset()`` /
+``reset_all()``), and lock-key sequences.
+
+Each helper is a tiny class or free-function that wraps an existing
+register / field node. Wrappers consume duck-typed objects -- anything with
+the standard ``read()`` / ``write()`` surface plus an ``info`` namespace --
+so they are unit-testable without generated bindings.
+
+Wiring into generated bindings happens via :func:`attach_specialized` (called
+from the seam :data:`peakrdl_pybind11.runtime._registry.register_register_enhancement`)
+and :func:`attach_post_create` (the SoC-level seam). Both use a graceful
+import: when Unit 1's ``_registry`` module is not available the helpers are
+still importable in isolation.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+# Graceful sibling-unit imports. ``runtime.errors`` and ``runtime.info`` may
+# not be merged into ``exp/api_overhaul`` yet; in that case we fall back to a
+# local definition that satisfies the same contract. Once those units land
+# the local fallback is shadowed by the canonical implementation.
+try:  # pragma: no cover - import shim
+    from peakrdl_pybind11.runtime.errors import NotSupportedError
+except ImportError:  # pragma: no cover - executed only when Unit 2 is absent
+
+    class NotSupportedError(Exception):  # type: ignore[no-redef]
+        """Raised when a feature is not implemented by the active master/transport.
+
+        Local fallback used until ``runtime.errors`` (Unit 2) is merged.
+        """
+
+        def __init__(self, message: str) -> None:
+            self.message = message
+            super().__init__(message)
+
+
+__all__ = [
+    "Counter",
+    "LockController",
+    "NotSupportedError",
+    "ResetMixin",
+    "attach_counter",
+    "attach_lock_controller",
+    "attach_post_create",
+    "attach_pulse",
+    "attach_regfile_reset_all",
+    "attach_reset_helpers",
+    "attach_soc_reset_all",
+    "attach_specialized",
+    "is_at_reset",
+    "pulse",
+    "register_post_create",
+    "register_register_enhancement",
+    "reset_all_regfile",
+    "reset_all_soc",
+    "reset_value",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across wrappers
+# ---------------------------------------------------------------------------
+
+
+class _EmptyTags:
+    """Permissive namespace returning ``None`` for any UDP attribute access."""
+
+    def __getattr__(self, name: str) -> object | None:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return None
+
+
+class _EmptyInfo:
+    """Stand-in for an ``Info`` instance when the host node has none."""
+
+    name: str = ""
+    path: str = ""
+    address: int = 0
+    reset: int | None = None
+    access: str | None = None
+    fields: dict[str, object] = {}  # noqa: RUF012 - shared empty mapping is intentional
+
+    def __init__(self) -> None:
+        self.tags = _EmptyTags()
+
+
+def _info_of(node: object) -> object:
+    """Return ``node.info`` if present, else an empty namespace.
+
+    Falling back to an empty namespace makes the wrappers work on stub /
+    mock objects in tests without forcing every test to construct an
+    ``Info`` explicitly.
+    """
+    return getattr(node, "info", _EmptyInfo())
+
+
+def _path_of(node: object) -> str:
+    """Best-effort dotted path for a node, used in error messages."""
+    info = _info_of(node)
+    path = getattr(info, "path", "") or getattr(info, "name", "")
+    return path or type(node).__name__
+
+
+# ---------------------------------------------------------------------------
+# Counter
+# ---------------------------------------------------------------------------
+
+
+class Counter:
+    """Wrap a counter register/field with the §12.1 counter API.
+
+    The wrapper is constructed with the host node (a register or field) and
+    a small spec that captures the RDL semantics relevant to software:
+
+    * ``can_increment`` / ``can_decrement`` — whether the counter exposes a
+      software increment / decrement path.
+    * ``saturate`` / ``threshold`` — whether ``incrsaturate`` /
+      ``incrthreshold`` are declared.
+    * ``incrvalue_field`` / ``decrvalue_field`` — the names of the fields to
+      write when increment / decrement is supported. ``None`` means the
+      hardware exposes a write-1-to-increment field (``host`` itself).
+    * ``threshold_value`` — the static threshold from the RDL
+      ``incrthreshold`` property, if any.
+    * ``saturate_value`` — the static saturation ceiling from
+      ``incrsaturate``, if any.
+
+    The host node must expose ``read()`` (returning an int-compatible value)
+    and ``write(value)``. ``reset()`` uses the host's ``write(0)`` path
+    unless ``reset_method`` is supplied.
+
+    Methods that require an absent capability raise :class:`NotSupportedError`
+    rather than silently no-op'ing -- per the sketch §12.1 contract that "a
+    typo in user code is an AttributeError at the call site". Generated code
+    can hide these methods entirely; this wrapper exists so the *Python*
+    runtime can still surface a clean error when the wrapper is constructed
+    by hand.
+    """
+
+    __slots__ = (
+        "_can_decrement",
+        "_can_increment",
+        "_decrvalue_field",
+        "_host",
+        "_incrvalue_field",
+        "_reset_method",
+        "_saturate",
+        "_saturate_value",
+        "_threshold",
+        "_threshold_value",
+    )
+
+    def __init__(
+        self,
+        host: object,
+        *,
+        can_increment: bool = False,
+        can_decrement: bool = False,
+        saturate: bool = False,
+        threshold: bool = False,
+        incrvalue_field: str | None = None,
+        decrvalue_field: str | None = None,
+        threshold_value: int | None = None,
+        saturate_value: int | None = None,
+        reset_method: Callable[[], None] | None = None,
+    ) -> None:
+        self._host = host
+        self._can_increment = can_increment
+        self._can_decrement = can_decrement
+        self._saturate = saturate
+        self._threshold = threshold
+        self._incrvalue_field = incrvalue_field
+        self._decrvalue_field = decrvalue_field
+        self._threshold_value = threshold_value
+        self._saturate_value = saturate_value
+        self._reset_method = reset_method
+
+    # ----- introspection ---------------------------------------------------
+
+    @property
+    def host(self) -> object:
+        """The wrapped register/field node."""
+        return self._host
+
+    def __repr__(self) -> str:
+        caps: list[str] = []
+        if self._can_increment:
+            caps.append("incr")
+        if self._can_decrement:
+            caps.append("decr")
+        if self._saturate:
+            caps.append("sat")
+        if self._threshold:
+            caps.append("thr")
+        cap_str = "|".join(caps) or "ro"
+        return f"<Counter {_path_of(self._host)} caps={cap_str}>"
+
+    # ----- ops --------------------------------------------------------------
+
+    def value(self) -> int:
+        """Return the current count (one bus read)."""
+        return int(self._host.read())
+
+    def reset(self) -> None:
+        """Clear the counter.
+
+        Uses ``reset_method`` when supplied (e.g. for ``wclr`` semantics that
+        require a specific value/mask). Otherwise writes ``0`` to the host
+        node, which corresponds to plain "reset value" semantics.
+        """
+        if self._reset_method is not None:
+            self._reset_method()
+            return
+        self._host.write(0)
+
+    def threshold(self) -> int:
+        """Return the configured ``incrthreshold``.
+
+        Raises :class:`NotSupportedError` when no threshold is declared.
+        """
+        if not self._threshold:
+            raise NotSupportedError(f"{_path_of(self._host)}: counter has no incrthreshold")
+        if self._threshold_value is None:
+            raise NotSupportedError(
+                f"{_path_of(self._host)}: incrthreshold is dynamic; read it via the field directly"
+            )
+        return int(self._threshold_value)
+
+    def is_saturated(self) -> bool:
+        """Return ``True`` when the counter has hit its saturation ceiling.
+
+        Raises :class:`NotSupportedError` when ``incrsaturate`` is not set.
+        """
+        if not self._saturate:
+            raise NotSupportedError(f"{_path_of(self._host)}: counter has no incrsaturate")
+        if self._saturate_value is None:
+            # No static ceiling — best-effort: compare against the largest
+            # representable value implied by regwidth, if known.
+            regwidth = getattr(_info_of(self._host), "regwidth", None)
+            if not isinstance(regwidth, int) or regwidth <= 0:
+                raise NotSupportedError(f"{_path_of(self._host)}: incrsaturate has no static ceiling")
+            ceiling = (1 << regwidth) - 1
+        else:
+            ceiling = int(self._saturate_value)
+        return int(self._host.read()) >= ceiling
+
+    def increment(self, by: int = 1) -> None:
+        """Increment the counter by ``by`` (writes the ``incrvalue`` field).
+
+        Raises :class:`NotSupportedError` when software increment is not
+        supported by the underlying RDL.
+        """
+        if not self._can_increment:
+            raise NotSupportedError(f"{_path_of(self._host)}: counter does not support software increment")
+        if by < 0:
+            raise ValueError("Counter.increment(by=...) requires a non-negative amount")
+        self._write_step(self._incrvalue_field, by)
+
+    def decrement(self, by: int = 1) -> None:
+        """Decrement the counter by ``by``.
+
+        Raises :class:`NotSupportedError` when software decrement is not
+        supported by the underlying RDL.
+        """
+        if not self._can_decrement:
+            raise NotSupportedError(f"{_path_of(self._host)}: counter does not support software decrement")
+        if by < 0:
+            raise ValueError("Counter.decrement(by=...) requires a non-negative amount")
+        self._write_step(self._decrvalue_field, by)
+
+    def _write_step(self, field_name: str | None, amount: int) -> None:
+        """Write ``amount`` either to a specific field or to the host directly.
+
+        When ``field_name`` is ``None`` the host node itself is the target
+        (e.g. a single-bit increment-strobe field). When the host exposes a
+        ``modify(**kwargs)`` shim the named-field path is used; otherwise we
+        fall back to attribute-style child access (``host.<field>.write``).
+        """
+        if field_name is None:
+            self._host.write(amount)
+            return
+
+        modify = getattr(self._host, "modify", None)
+        if callable(modify):
+            modify(**{field_name: amount})
+            return
+
+        target = getattr(self._host, field_name, None)
+        if target is not None and hasattr(target, "write"):
+            target.write(amount)
+            return
+
+        raise NotSupportedError(f"{_path_of(self._host)}: cannot reach field {field_name!r} for counter step")
+
+
+# ---------------------------------------------------------------------------
+# Singlepulse
+# ---------------------------------------------------------------------------
+
+
+def pulse(field: object) -> None:
+    """Issue the §12.2 singlepulse write (``write(1)``) to ``field``.
+
+    Free-function form used by tests and ad-hoc callers. Generated field
+    classes get a method-form via :func:`attach_pulse`.
+    """
+    field.write(1)
+
+
+def attach_pulse(field_class: type) -> bool:
+    """Attach a ``pulse()`` method to a singlepulse field class.
+
+    Returns ``True`` if the method was attached, ``False`` if the class
+    already has one or the field is not declared singlepulse. Idempotent.
+
+    The function looks at the class' ``info.tags.singlepulse`` UDP (or the
+    explicit ``singlepulse = True`` attribute) so callers can either lean on
+    Unit 4's metadata extraction or set the marker by hand in tests.
+    """
+    if getattr(field_class, "pulse", None) is not None:
+        return False
+    if not _is_singlepulse(field_class):
+        return False
+
+    def pulse_method(self: object) -> None:
+        # ``write(1)`` collapses to one bus write; hardware self-clears.
+        self.write(1)
+
+    field_class.pulse = pulse_method  # type: ignore[attr-defined]
+    return True
+
+
+def _is_singlepulse(node_class_or_instance: object) -> bool:
+    """Return ``True`` if a class/instance is annotated as singlepulse."""
+    direct = getattr(node_class_or_instance, "singlepulse", None)
+    if direct:
+        return True
+    info = getattr(node_class_or_instance, "info", None)
+    if info is not None:
+        tags = getattr(info, "tags", None)
+        if tags is not None and getattr(tags, "singlepulse", None):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Reset semantics
+# ---------------------------------------------------------------------------
+
+
+def reset_value(reg: object) -> int:
+    """Return the static reset value declared for ``reg`` (no bus traffic)."""
+    info = _info_of(reg)
+    val = getattr(info, "reset", None)
+    if val is None:
+        # Allow an explicit attribute on the wrapper for tests/stubs.
+        val = getattr(reg, "_reset_value", None)
+    return int(val) if val is not None else 0
+
+
+def is_at_reset(reg: object) -> bool:
+    """Return ``True`` when ``reg.read() == reg.reset_value`` (one bus read)."""
+    expected = reset_value(reg)
+    actual = int(reg.read())
+    return actual == expected
+
+
+def reset_all_regfile(regfile: object, *, rw_only: bool = True) -> int:
+    """Restore every register under ``regfile`` to its reset value.
+
+    Walks every child register/regfile (including arrays) and writes
+    ``reg.reset_value`` to it. Read-only registers are skipped when
+    ``rw_only=True`` (the default).
+
+    Returns the number of registers actually written. The walk is
+    breadth-first via :func:`_walk_registers`.
+    """
+    written = 0
+    for reg in _walk_registers(regfile):
+        if rw_only and _is_read_only(reg):
+            continue
+        try:
+            reg.write(reset_value(reg))
+        except Exception:
+            # Best-effort: a child without ``write`` (e.g. a pure status reg)
+            # is silently skipped; the rw_only path catches most cases.
+            continue
+        written += 1
+    return written
+
+
+def reset_all_soc(soc: object, *, rw_only: bool = True) -> int:
+    """Reset every register under the whole SoC tree.
+
+    Emits a :class:`UserWarning` if any register being restored has an
+    ``rclr`` field combined with RW access (per §12.3 "ambiguous reset"
+    safety check).
+    """
+    flagged = list(_iter_rclr_rw_conflicts(soc))
+    if flagged:
+        warnings.warn(
+            "soc.reset_all() touching registers whose RW fields also clear on read: " + ", ".join(flagged),
+            UserWarning,
+            stacklevel=2,
+        )
+    return reset_all_regfile(soc, rw_only=rw_only)
+
+
+def attach_reset_helpers(reg_class: type) -> None:
+    """Attach ``reset_value`` (property) and ``is_at_reset()`` to a register class.
+
+    Idempotent: re-attaching is a no-op when the methods already exist.
+    """
+    if "reset_value" not in reg_class.__dict__:
+
+        def _reset_value_getter(self: object) -> int:
+            return reset_value(self)
+
+        reg_class.reset_value = property(_reset_value_getter)  # type: ignore[attr-defined]
+
+    if "is_at_reset" not in reg_class.__dict__:
+
+        def _is_at_reset_method(self: object) -> bool:
+            return is_at_reset(self)
+
+        reg_class.is_at_reset = _is_at_reset_method  # type: ignore[attr-defined]
+
+
+def attach_regfile_reset_all(regfile_class: type) -> None:
+    """Attach ``reset_all(rw_only=True)`` to a regfile class."""
+    if "reset_all" in regfile_class.__dict__:
+        return
+
+    def _reset_all_method(self: object, *, rw_only: bool = True) -> int:
+        return reset_all_regfile(self, rw_only=rw_only)
+
+    regfile_class.reset_all = _reset_all_method  # type: ignore[attr-defined]
+
+
+def attach_soc_reset_all(soc_class: type) -> None:
+    """Attach a tree-walking ``reset_all()`` to a SoC top-level class."""
+    if "reset_all" in soc_class.__dict__:
+        return
+
+    def _reset_all_method(self: object, *, rw_only: bool = True) -> int:
+        return reset_all_soc(self, rw_only=rw_only)
+
+    soc_class.reset_all = _reset_all_method  # type: ignore[attr-defined]
+
+
+def _is_read_only(reg: object) -> bool:
+    """Return ``True`` when the register is read-only per its access mode."""
+    info = _info_of(reg)
+    access = getattr(info, "access", None)
+    if isinstance(access, str):
+        return access.lower() == "r"
+    return False
+
+
+def _walk_registers(node: object) -> Iterable[object]:
+    """Yield every register descendant of ``node``.
+
+    A node is treated as a register when it exposes both ``read`` and
+    ``write`` callables. Otherwise ``node._children()`` (or, failing that,
+    iteration over ``getattr(node, "_registers", [])`` and friends) is used
+    to descend further. The function tolerates a wide range of generated
+    shapes -- the typical generated module exposes children as attributes
+    or as a ``children`` iterable.
+    """
+    seen: set[int] = set()
+    stack: list[object] = [node]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        if _looks_like_register(current):
+            yield current
+            continue
+
+        children = _children_of(current)
+        # Reverse so the natural iteration order is preserved when popping.
+        stack.extend(reversed(list(children)))
+
+
+def _looks_like_register(node: object) -> bool:
+    """Return ``True`` if ``node`` quacks like a register (has read & write)."""
+    if not callable(getattr(node, "read", None)):
+        return False
+    if not callable(getattr(node, "write", None)):
+        return False
+    # Excluding fields: a field also has read/write but is a child of a
+    # register; if the node looks like a field (has ``lsb``/``width``),
+    # the parent register has already been or will be seen via the walk.
+    if hasattr(node, "lsb") and hasattr(node, "width"):
+        return False
+    return True
+
+
+def _children_of(node: object) -> Iterable[object]:
+    """Best-effort iteration of ``node``'s descendants.
+
+    Looks for, in order:
+
+    1. ``node._children()`` (callable returning an iterable).
+    2. ``node.children`` (attribute that is iterable).
+    3. ``node._registers``, ``node._regfiles`` (lists set by generated code).
+    4. Any attribute on the instance whose value also looks register-shaped.
+    """
+    children_fn = getattr(node, "_children", None)
+    if callable(children_fn):
+        try:
+            yield from children_fn()
+            return
+        except TypeError:
+            pass
+
+    children_attr = getattr(node, "children", None)
+    if children_attr is not None and not isinstance(children_attr, type):
+        try:
+            yield from list(children_attr)
+            return
+        except TypeError:
+            pass
+
+    yielded_any = False
+    for attr in ("_registers", "_regfiles", "_addrmaps"):
+        coll = getattr(node, attr, None)
+        if coll is None:
+            continue
+        try:
+            for child in coll:
+                yielded_any = True
+                yield child
+        except TypeError:
+            continue
+    if yielded_any:
+        return
+
+    # Final fallback: scan ``__dict__`` for register-shaped attributes. Used
+    # by hand-rolled stubs and by generated top-level SoC objects whose
+    # children are bound directly as public attributes.
+    instance_dict = getattr(node, "__dict__", None) or {}
+    for name, value in instance_dict.items():
+        if name.startswith("_"):
+            continue
+        if value is node or value is None:
+            continue
+        if _looks_like_register(value) or _looks_like_container(value):
+            yield value
+
+
+def _looks_like_container(node: object) -> bool:
+    """Return ``True`` if ``node`` looks like a regfile/addrmap container."""
+    if hasattr(node, "_children") or hasattr(node, "children"):
+        return True
+    if hasattr(node, "_registers") or hasattr(node, "_regfiles"):
+        return True
+    return False
+
+
+def _iter_rclr_rw_conflicts(soc: object) -> Iterable[str]:
+    """Yield register paths whose RW fields are also ``rclr``."""
+    for reg in _walk_registers(soc):
+        info = _info_of(reg)
+        access = getattr(info, "access", None)
+        if isinstance(access, str) and access.lower() != "rw":
+            continue
+        fields_map = getattr(info, "fields", {}) or {}
+        for field_info in fields_map.values():
+            on_read = getattr(field_info, "on_read", None)
+            f_access = getattr(field_info, "access", None)
+            f_is_rw = isinstance(f_access, str) and f_access.lower() == "rw"
+            if on_read == "rclr" and f_is_rw:
+                yield _path_of(reg)
+                break
+
+
+class ResetMixin:
+    """Mixin that exposes ``reset_value`` / ``is_at_reset()`` as methods.
+
+    Generated bindings can opt in by inheriting from this mixin instead of
+    using :func:`attach_reset_helpers`. Both paths produce the same surface;
+    the mixin form is preferred when the generated class is authored by
+    template (one less call site).
+    """
+
+    @property
+    def reset_value(self) -> int:
+        return reset_value(self)
+
+    def is_at_reset(self) -> bool:
+        return is_at_reset(self)
+
+
+# ---------------------------------------------------------------------------
+# Lock
+# ---------------------------------------------------------------------------
+
+
+class LockController:
+    """Wrap a lock register with §12.4 ``lock`` / ``is_locked`` /
+    ``unlock_sequence`` accessors.
+
+    Construction parameters:
+
+    * ``host`` — the register node carrying the lock-bits.
+    * ``key_field`` — name of the field that receives the LCKK key
+      (typically ``"LCKK"`` per the STM32 GPIO LCKR pattern).
+    * ``key_sequence`` — the sequence of values written to ``key_field``
+      after the lock-bits are programmed. The canonical STM32 sequence is
+      ``(1, 0, 1)`` -- write key, write 0, write key again, then read back.
+    * ``unlock_sequence_fn`` — optional callable invoked by
+      :meth:`unlock_sequence`. When ``None`` the method raises
+      :class:`NotSupportedError` per the sketch -- many parts deliberately
+      do not support unlock.
+    * ``field_setter`` — optional callable ``(host, names, on) -> None``
+      used to set/clear the named lock-bits. Defaults to writing each
+      field via attribute-style access.
+
+    The wrapper does not synthesise transactions on its own beyond the
+    dispatch; see :meth:`lock` for the exact write order.
+    """
+
+    __slots__ = (
+        "_field_setter",
+        "_host",
+        "_key_field",
+        "_key_sequence",
+        "_unlock_sequence_fn",
+    )
+
+    def __init__(
+        self,
+        host: object,
+        *,
+        key_field: str | None = None,
+        key_sequence: Sequence[int] = (1,),
+        unlock_sequence_fn: Callable[[object], None] | None = None,
+        field_setter: Callable[[object, Sequence[str], bool], None] | None = None,
+    ) -> None:
+        self._host = host
+        self._key_field = key_field
+        self._key_sequence = tuple(key_sequence)
+        self._unlock_sequence_fn = unlock_sequence_fn
+        self._field_setter = field_setter
+
+    @property
+    def host(self) -> object:
+        """The wrapped lock-register node."""
+        return self._host
+
+    def __repr__(self) -> str:
+        key = f", key={self._key_field!r}" if self._key_field else ""
+        return f"<LockController {_path_of(self._host)}{key}>"
+
+    def lock(self, names: Iterable[str]) -> None:
+        """Program the named lock-bits and run the key sequence.
+
+        Issues two logical phases:
+
+        1. Set the requested lock-bits to 1 (one or more bus writes,
+           coalesced through ``field_setter`` when possible).
+        2. Write the key field with each value from ``key_sequence``.
+
+        Per the sketch §12.4 contract, the *minimum* observable bus traffic
+        is two writes -- one for the lock-bits, one for the key.
+        """
+        names_list = list(names)
+        if not names_list:
+            raise ValueError("LockController.lock() requires at least one field name")
+        self._set_locks(names_list, on=True)
+        self._drive_key_sequence()
+
+    def is_locked(self, name: str) -> bool:
+        """Return whether ``name``'s lock-bit is currently set (one bus read)."""
+        target = getattr(self._host, name, None)
+        if target is None:
+            raise AttributeError(f"{_path_of(self._host)}: no lock-field named {name!r}")
+        return bool(int(target.read()))
+
+    def unlock_sequence(self) -> None:
+        """Run the vendor-specific unlock path, if any.
+
+        Raises :class:`NotSupportedError` when no ``unlock_sequence_fn`` was
+        registered. Many parts intentionally have no unlock path; the error
+        makes that visible at the call site rather than silently no-op'ing.
+        """
+        if self._unlock_sequence_fn is None:
+            raise NotSupportedError(f"{_path_of(self._host)}: no unlock_sequence is declared for this lock")
+        self._unlock_sequence_fn(self._host)
+
+    # -- internals -----------------------------------------------------------
+
+    def _set_locks(self, names: Sequence[str], *, on: bool) -> None:
+        """Set or clear the named lock-bits."""
+        if self._field_setter is not None:
+            self._field_setter(self._host, names, on)
+            return
+
+        modify = getattr(self._host, "modify", None)
+        if callable(modify):
+            modify(**{name: int(on) for name in names})
+            return
+
+        # Attribute-style fallback: write each field individually.
+        for name in names:
+            target = getattr(self._host, name, None)
+            if target is None:
+                raise AttributeError(f"{_path_of(self._host)}: no lock-field named {name!r}")
+            target.write(int(on))
+
+    def _drive_key_sequence(self) -> None:
+        """Write each value in ``key_sequence`` to the key field."""
+        if self._key_field is None:
+            return
+        modify = getattr(self._host, "modify", None)
+        target = getattr(self._host, self._key_field, None)
+        for value in self._key_sequence:
+            if target is not None and hasattr(target, "write"):
+                target.write(int(value))
+            elif callable(modify):
+                modify(**{self._key_field: int(value)})
+            else:
+                raise NotSupportedError(f"{_path_of(self._host)}: no key-field {self._key_field!r} to drive")
+
+
+# ---------------------------------------------------------------------------
+# Wiring helpers
+# ---------------------------------------------------------------------------
+
+
+def attach_counter(reg_or_field: object, **counter_kwargs: Any) -> Counter:  # noqa: ANN401
+    """Build and attach a :class:`Counter` wrapper to ``reg_or_field``.
+
+    The wrapper is also stored as ``reg_or_field.counter`` for discoverability.
+    Returns the constructed wrapper so callers can use it directly.
+    """
+    counter = Counter(reg_or_field, **counter_kwargs)
+    reg_or_field.counter = counter  # type: ignore[attr-defined]
+    return counter
+
+
+def attach_lock_controller(reg: object, **lock_kwargs: Any) -> LockController:  # noqa: ANN401
+    """Construct a :class:`LockController` and bind it onto ``reg``.
+
+    Adds ``reg.lock``, ``reg.is_locked``, and ``reg.unlock_sequence`` as
+    bound method-style aliases of the controller's methods.
+    """
+    controller = LockController(reg, **lock_kwargs)
+    # Methods are exposed directly on the host so user code reads
+    # ``soc.gpio_a.lckr.lock([...])`` rather than ``...lckr.controller.lock(...)``.
+    reg.lock = controller.lock  # type: ignore[attr-defined]
+    reg.is_locked = controller.is_locked  # type: ignore[attr-defined]
+    reg.unlock_sequence = controller.unlock_sequence  # type: ignore[attr-defined]
+    reg._lock_controller = controller  # type: ignore[attr-defined]
+    return controller
+
+
+def attach_specialized(cls: type, metadata: dict[str, object]) -> None:
+    """Inspect ``metadata`` for counter / singlepulse / lock UDPs and wire helpers.
+
+    This is the registry callback invoked by Unit 1's ``register_register_enhancement``.
+    ``metadata`` is the per-register dict produced by the template and may
+    carry the keys:
+
+    * ``"counter"`` — dict of counter spec kwargs (forwarded to :class:`Counter`).
+    * ``"lock"``    — dict of lock spec kwargs (forwarded to :class:`LockController`).
+    * ``"singlepulse_fields"`` — iterable of field names to attach ``pulse()`` to.
+
+    Each entry is best-effort: missing metadata keys are simply skipped.
+    """
+    attach_reset_helpers(cls)
+
+    counter_spec = metadata.get("counter")
+    if counter_spec:
+        # Counter is host-bound at construction; here we install a class-level
+        # property that materialises a per-instance wrapper on first access.
+        _install_counter_property(cls, counter_spec)
+
+    lock_spec = metadata.get("lock")
+    if lock_spec:
+        _install_lock_property(cls, lock_spec)
+
+    pulse_fields = metadata.get("singlepulse_fields") or ()
+    for field_name in pulse_fields:
+        field_cls = getattr(cls, field_name, None)
+        if isinstance(field_cls, type):
+            attach_pulse(field_cls)
+
+
+def _install_counter_property(cls: type, spec: dict[str, object]) -> None:
+    """Install a lazily-constructed ``counter`` property on ``cls``."""
+    if "counter" in cls.__dict__:
+        return
+    cache_key = "_counter_wrapper"
+
+    def _getter(self: object) -> Counter:
+        cached = self.__dict__.get(cache_key)
+        if cached is not None:
+            return cached
+        wrapper = Counter(self, **spec)
+        self.__dict__[cache_key] = wrapper
+        return wrapper
+
+    cls.counter = property(_getter)  # type: ignore[attr-defined]
+
+
+def _install_lock_property(cls: type, spec: dict[str, object]) -> None:
+    """Install lock-controller methods on ``cls`` (lazy; one wrapper per instance)."""
+    if "lock" in cls.__dict__:
+        return
+    cache_key = "_lock_controller_wrapper"
+
+    def _ensure(self: object) -> LockController:
+        cached = self.__dict__.get(cache_key)
+        if cached is not None:
+            return cached
+        wrapper = LockController(self, **spec)
+        self.__dict__[cache_key] = wrapper
+        return wrapper
+
+    def _lock(self: object, names: Iterable[str]) -> None:
+        _ensure(self).lock(names)
+
+    def _is_locked(self: object, name: str) -> bool:
+        return _ensure(self).is_locked(name)
+
+    def _unlock_sequence(self: object) -> None:
+        _ensure(self).unlock_sequence()
+
+    cls.lock = _lock  # type: ignore[attr-defined]
+    cls.is_locked = _is_locked  # type: ignore[attr-defined]
+    cls.unlock_sequence = _unlock_sequence  # type: ignore[attr-defined]
+
+
+def attach_post_create(soc: object) -> None:
+    """Wire SoC-level helpers (the §12.3 ``soc.reset_all()`` entry point).
+
+    Idempotent. Called by Unit 1's ``register_post_create`` seam.
+    """
+    if not hasattr(soc, "reset_all"):
+        soc.reset_all = lambda *, rw_only=True: reset_all_soc(soc, rw_only=rw_only)
+
+
+# ---------------------------------------------------------------------------
+# Optional registration with the runtime registry (Unit 1's seam).
+# When Unit 1 is not yet merged the import fails and we silently skip;
+# this keeps the file importable in isolation.
+# ---------------------------------------------------------------------------
+
+
+def _noop_decorator(fn: Callable[..., object]) -> Callable[..., object]:
+    """No-op decorator used when the registry is unavailable."""
+    return fn
+
+
+try:  # pragma: no cover - import shim
+    from peakrdl_pybind11.runtime._registry import (  # type: ignore[import-not-found]
+        register_post_create as _registry_register_post_create,
+    )
+    from peakrdl_pybind11.runtime._registry import (  # type: ignore[import-not-found]
+        register_register_enhancement as _registry_register_register_enhancement,
+    )
+except ImportError:  # pragma: no cover - sibling unit may not exist yet
+    register_register_enhancement: Callable[..., object] = _noop_decorator
+    register_post_create: Callable[..., object] = _noop_decorator
+else:
+    register_register_enhancement = _registry_register_register_enhancement
+    register_post_create = _registry_register_post_create
+    register_register_enhancement(attach_specialized)  # type: ignore[arg-type]
+    register_post_create(attach_post_create)  # type: ignore[arg-type]

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for peakrdl_pybind11.runtime helpers."""

--- a/tests/runtime/test_specialized.py
+++ b/tests/runtime/test_specialized.py
@@ -1,0 +1,752 @@
+"""Tests for ``peakrdl_pybind11.runtime.specialized`` (sketch §12)."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+
+from peakrdl_pybind11.runtime.specialized import (
+    Counter,
+    LockController,
+    NotSupportedError,
+    ResetMixin,
+    attach_counter,
+    attach_lock_controller,
+    attach_post_create,
+    attach_pulse,
+    attach_reset_helpers,
+    attach_specialized,
+    is_at_reset,
+    pulse,
+    reset_all_regfile,
+    reset_all_soc,
+    reset_value,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock infrastructure
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeBus:
+    """Track every read / write that goes through the mock plumbing."""
+
+    log: list[tuple[str, str, int]] = field(default_factory=list)
+
+    def record_read(self, path: str, value: int) -> None:
+        self.log.append(("read", path, value))
+
+    def record_write(self, path: str, value: int) -> None:
+        self.log.append(("write", path, value))
+
+    def writes(self) -> list[tuple[str, int]]:
+        return [(p, v) for op, p, v in self.log if op == "write"]
+
+
+@dataclass
+class FakeField:
+    """A field-like object with read/write that talks to ``FakeBus``."""
+
+    bus: FakeBus
+    path: str
+    lsb: int
+    width: int = 1
+    state: int = 0
+    info: SimpleNamespace = field(default_factory=lambda: SimpleNamespace())
+
+    def __post_init__(self) -> None:
+        if not getattr(self.info, "path", ""):
+            self.info.path = self.path
+        if not hasattr(self.info, "tags"):
+            self.info.tags = SimpleNamespace()
+
+    def read(self) -> int:
+        self.bus.record_read(self.path, self.state)
+        return self.state
+
+    def write(self, value: int) -> None:
+        masked = int(value) & ((1 << self.width) - 1)
+        self.state = masked
+        self.bus.record_write(self.path, masked)
+
+
+class FakeRegister:
+    """A register-like object that records writes and supports modify."""
+
+    def __init__(
+        self,
+        bus: FakeBus,
+        path: str,
+        *,
+        reset: int = 0,
+        access: str = "rw",
+        regwidth: int = 32,
+        fields_info: dict[str, Any] | None = None,
+        tags: SimpleNamespace | None = None,
+    ) -> None:
+        self.bus = bus
+        self.path = path
+        self.state = int(reset)
+        self.info = SimpleNamespace(
+            path=path,
+            name=path.rsplit(".", 1)[-1],
+            address=0,
+            reset=int(reset),
+            access=access,
+            regwidth=regwidth,
+            fields=fields_info or {},
+            tags=tags or SimpleNamespace(),
+        )
+
+    def read(self) -> int:
+        self.bus.record_read(self.path, self.state)
+        return self.state
+
+    def write(self, value: int) -> None:
+        self.state = int(value)
+        self.bus.record_write(self.path, self.state)
+
+    def modify(self, **kwargs: Any) -> None:
+        # Sum of named-field updates. Each child field is set; the host's
+        # state is updated to reflect the new combined value.
+        for name, value in kwargs.items():
+            target = getattr(self, name, None)
+            if target is None:
+                raise KeyError(name)
+            target.state = int(value) & ((1 << target.width) - 1)
+        # Recompose state.
+        new_state = 0
+        for attr_name, attr_val in self.__dict__.items():
+            if isinstance(attr_val, FakeField):
+                new_state |= (attr_val.state & ((1 << attr_val.width) - 1)) << attr_val.lsb
+        self.state = new_state
+        self.bus.record_write(self.path, new_state)
+
+    def attach_field(self, name: str, lsb: int, width: int = 1) -> FakeField:
+        f = FakeField(self.bus, f"{self.path}.{name}", lsb, width)
+        setattr(self, name, f)
+        return f
+
+
+class FakeRegfile:
+    """A regfile-like container holding a few registers."""
+
+    def __init__(self, bus: FakeBus, path: str) -> None:
+        self.bus = bus
+        self.path = path
+        self.info = SimpleNamespace(path=path, name=path, tags=SimpleNamespace())
+        self._registers: list[FakeRegister] = []
+
+    def attach_register(
+        self,
+        name: str,
+        *,
+        reset: int = 0,
+        access: str = "rw",
+        regwidth: int = 32,
+        fields_info: dict[str, Any] | None = None,
+    ) -> FakeRegister:
+        reg = FakeRegister(
+            self.bus,
+            f"{self.path}.{name}",
+            reset=reset,
+            access=access,
+            regwidth=regwidth,
+            fields_info=fields_info,
+        )
+        self._registers.append(reg)
+        setattr(self, name, reg)
+        return reg
+
+
+class FakeSoc:
+    """An SoC-like top-level container holding regfiles."""
+
+    def __init__(self, bus: FakeBus) -> None:
+        self.bus = bus
+        self.info = SimpleNamespace(path="soc", name="soc", tags=SimpleNamespace())
+        self._regfiles: list[FakeRegfile] = []
+
+    def attach_regfile(self, name: str) -> FakeRegfile:
+        rf = FakeRegfile(self.bus, name)
+        self._regfiles.append(rf)
+        setattr(self, name, rf)
+        return rf
+
+
+# ---------------------------------------------------------------------------
+# Counter — value / reset / increment
+# ---------------------------------------------------------------------------
+
+
+class TestCounter:
+    def test_value_returns_current_count_via_one_read(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.event_counter")
+        host.state = 7
+        c = Counter(host)
+        assert c.value() == 7
+        assert bus.log == [("read", "p.event_counter", 7)]
+
+    def test_reset_writes_zero_by_default(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.event_counter")
+        host.state = 99
+        Counter(host).reset()
+        assert host.state == 0
+        assert bus.writes() == [("p.event_counter", 0)]
+
+    def test_reset_uses_custom_reset_method(self) -> None:
+        called: list[int] = []
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+
+        def custom_reset() -> None:
+            called.append(1)
+            host.write(0xDEAD)
+
+        Counter(host, reset_method=custom_reset).reset()
+        assert called == [1]
+        assert bus.writes() == [("p.cnt", 0xDEAD)]
+
+    def test_increment_with_named_field_and_amount(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        host.attach_field("incrvalue", lsb=8, width=8)
+
+        c = Counter(host, can_increment=True, incrvalue_field="incrvalue")
+        c.increment(by=2)
+
+        # increment via modify() -> records one host-level write.
+        writes = bus.writes()
+        assert ("p.cnt", 2 << 8) in writes
+
+    def test_increment_default_by_one(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        host.attach_field("incrvalue", lsb=0, width=4)
+        c = Counter(host, can_increment=True, incrvalue_field="incrvalue")
+        c.increment()
+        assert ("p.cnt", 1) in bus.writes()
+
+    def test_increment_raises_when_unsupported(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        c = Counter(host, can_increment=False)
+        with pytest.raises(NotSupportedError, match="software increment"):
+            c.increment()
+
+    def test_increment_negative_amount_rejected(self) -> None:
+        c = Counter(FakeRegister(FakeBus(), "p.cnt"), can_increment=True)
+        with pytest.raises(ValueError):
+            c.increment(by=-1)
+
+    def test_decrement_writes_correct_amount(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        host.attach_field("decrvalue", lsb=16, width=8)
+        c = Counter(host, can_decrement=True, decrvalue_field="decrvalue")
+        c.decrement(by=3)
+        assert ("p.cnt", 3 << 16) in bus.writes()
+
+    def test_decrement_raises_when_unsupported(self) -> None:
+        c = Counter(FakeRegister(FakeBus(), "p.cnt"), can_decrement=False)
+        with pytest.raises(NotSupportedError, match="software decrement"):
+            c.decrement()
+
+    def test_threshold_returns_static_value(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        c = Counter(host, threshold=True, threshold_value=42)
+        assert c.threshold() == 42
+
+    def test_threshold_raises_without_property(self) -> None:
+        c = Counter(FakeRegister(FakeBus(), "p.cnt"))
+        with pytest.raises(NotSupportedError, match="incrthreshold"):
+            c.threshold()
+
+    def test_is_saturated_compares_against_explicit_ceiling(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        host.state = 0xFE
+        c = Counter(host, saturate=True, saturate_value=0xFF)
+        assert c.is_saturated() is False
+        host.state = 0xFF
+        assert c.is_saturated() is True
+
+    def test_is_saturated_uses_regwidth_when_no_explicit_ceiling(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt", regwidth=8)
+        host.state = 0xFF
+        c = Counter(host, saturate=True)
+        assert c.is_saturated() is True
+
+    def test_is_saturated_raises_without_property(self) -> None:
+        c = Counter(FakeRegister(FakeBus(), "p.cnt"))
+        with pytest.raises(NotSupportedError, match="incrsaturate"):
+            c.is_saturated()
+
+    def test_increment_with_no_modify_falls_back_to_attribute_write(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        host.attach_field("incrvalue", lsb=0, width=8)
+        # Strip ``modify`` so the wrapper falls back to attribute-style.
+        host.modify = None  # type: ignore[assignment]
+        Counter(host, can_increment=True, incrvalue_field="incrvalue").increment(by=4)
+        # The fallback writes through the named field directly.
+        assert ("p.cnt.incrvalue", 4) in bus.writes()
+
+    def test_attach_counter_binds_wrapper_on_node(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "p.cnt")
+        wrapper = attach_counter(host, can_increment=True)
+        assert host.counter is wrapper
+        assert isinstance(wrapper, Counter)
+        assert "Counter" in repr(wrapper)
+
+
+# ---------------------------------------------------------------------------
+# Singlepulse
+# ---------------------------------------------------------------------------
+
+
+class TestPulse:
+    def test_pulse_function_writes_one(self) -> None:
+        bus = FakeBus()
+        f = FakeField(bus, "p.start", lsb=0)
+        pulse(f)
+        assert bus.writes() == [("p.start", 1)]
+
+    def test_attach_pulse_skips_when_not_singlepulse(self) -> None:
+        class FieldClass:
+            pass
+
+        attached = attach_pulse(FieldClass)
+        assert attached is False
+        assert getattr(FieldClass, "pulse", None) is None
+
+    def test_attach_pulse_via_class_attribute(self) -> None:
+        class FieldClass:
+            singlepulse = True
+
+            def __init__(self) -> None:
+                self.bus = FakeBus()
+
+            def write(self, value: int) -> None:
+                self.bus.record_write("f", int(value))
+
+        assert attach_pulse(FieldClass) is True
+        instance = FieldClass()
+        instance.pulse()
+        assert instance.bus.writes() == [("f", 1)]
+
+    def test_attach_pulse_via_info_tags(self) -> None:
+        class FieldClass:
+            info = SimpleNamespace(tags=SimpleNamespace(singlepulse=True))
+
+            def __init__(self) -> None:
+                self.bus = FakeBus()
+
+            def write(self, value: int) -> None:
+                self.bus.record_write("f", int(value))
+
+        assert attach_pulse(FieldClass) is True
+
+    def test_attach_pulse_idempotent(self) -> None:
+        class FieldClass:
+            singlepulse = True
+
+            def write(self, value: int) -> None:
+                pass
+
+        assert attach_pulse(FieldClass) is True
+        # Second call: pulse already attached -> no-op.
+        assert attach_pulse(FieldClass) is False
+
+
+# ---------------------------------------------------------------------------
+# Reset semantics
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_value_reads_info(self) -> None:
+        reg = FakeRegister(FakeBus(), "uart.control", reset=0xDEAD)
+        assert reset_value(reg) == 0xDEAD
+
+    def test_reset_value_falls_back_to_zero(self) -> None:
+        reg = SimpleNamespace()  # no .info, no _reset_value
+        assert reset_value(reg) == 0
+
+    def test_is_at_reset_compares_to_static(self) -> None:
+        reg = FakeRegister(FakeBus(), "uart.control", reset=0x1234)
+        # state initialised to reset → matches.
+        assert is_at_reset(reg) is True
+        reg.state = 0x9999
+        assert is_at_reset(reg) is False
+
+    def test_attach_reset_helpers_adds_property_and_method(self) -> None:
+        class _RegClass:
+            def __init__(self) -> None:
+                self.info = SimpleNamespace(reset=0x42)
+                self.state = 0x42
+
+            def read(self) -> int:
+                return self.state
+
+        attach_reset_helpers(_RegClass)
+        instance = _RegClass()
+        assert instance.reset_value == 0x42
+        assert instance.is_at_reset() is True
+
+    def test_reset_all_regfile_writes_to_each_writable_reg(self) -> None:
+        bus = FakeBus()
+        rf = FakeRegfile(bus, "uart")
+        rf.attach_register("control", reset=0xDEAD)
+        rf.attach_register("status", reset=0x0, access="r")  # read-only
+        rf.attach_register("baudrate", reset=0xBEEF)
+
+        # mutate state away from reset before resetting
+        rf.control.state = 0
+        rf.baudrate.state = 0
+
+        written = reset_all_regfile(rf, rw_only=True)
+        assert written == 2  # control + baudrate; status skipped (ro)
+
+        # control + baudrate should be at reset; status untouched.
+        writes = bus.writes()
+        assert ("uart.control", 0xDEAD) in writes
+        assert ("uart.baudrate", 0xBEEF) in writes
+        assert all(p != "uart.status" for p, _ in writes)
+
+    def test_reset_all_regfile_ignores_rw_only_when_false(self) -> None:
+        bus = FakeBus()
+        rf = FakeRegfile(bus, "uart")
+        rf.attach_register("status", reset=0x0, access="r")
+        written = reset_all_regfile(rf, rw_only=False)
+        # Even read-only registers attempted; FakeRegister has write so it succeeds.
+        assert written == 1
+
+    def test_reset_all_regfile_handles_missing_write(self) -> None:
+        bus = FakeBus()
+        rf = FakeRegfile(bus, "uart")
+        rf.attach_register("control", reset=0x1)
+        # Replace .write with a callable that raises.
+        original_write = rf.control.write
+
+        def boom(_value: int) -> None:
+            raise RuntimeError("simulated bus failure")
+
+        rf.control.write = boom  # type: ignore[assignment]
+        written = reset_all_regfile(rf, rw_only=False)
+        assert written == 0  # write raised; counted as skipped
+        # Restore so teardown doesn't affect other tests
+        rf.control.write = original_write  # type: ignore[assignment]
+
+    def test_reset_all_soc_walks_full_tree(self) -> None:
+        bus = FakeBus()
+        soc = FakeSoc(bus)
+        rf_a = soc.attach_regfile("uart")
+        rf_a.attach_register("control", reset=0x1)
+        rf_a.attach_register("baudrate", reset=0x2)
+        rf_b = soc.attach_regfile("spi")
+        rf_b.attach_register("control", reset=0x3)
+
+        rf_a.control.state = 0
+        rf_a.baudrate.state = 0
+        rf_b.control.state = 0
+
+        written = reset_all_soc(soc)
+        assert written == 3
+        writes = dict(bus.writes())
+        assert writes["uart.control"] == 0x1
+        assert writes["uart.baudrate"] == 0x2
+        assert writes["spi.control"] == 0x3
+
+    def test_reset_all_soc_warns_on_rclr_rw_field(self) -> None:
+        bus = FakeBus()
+        soc = FakeSoc(bus)
+        rf = soc.attach_regfile("uart")
+        # Build a register whose info reports an RW field with on_read=rclr.
+        reg = rf.attach_register(
+            "status",
+            reset=0x0,
+            fields_info={
+                "rx_overrun": SimpleNamespace(on_read="rclr", access="rw"),
+            },
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            reset_all_soc(soc)
+        messages = [str(w.message) for w in caught]
+        assert any("uart.status" in m for m in messages)
+        # Sanity: we still issue the writes.
+        assert ("uart.status", 0x0) in bus.writes()
+
+    def test_attach_post_create_binds_reset_all_on_soc(self) -> None:
+        bus = FakeBus()
+        soc = FakeSoc(bus)
+        rf = soc.attach_regfile("uart")
+        rf.attach_register("control", reset=0x55)
+        rf.control.state = 0
+        attach_post_create(soc)
+        assert callable(soc.reset_all)
+        soc.reset_all()
+        assert ("uart.control", 0x55) in bus.writes()
+
+    def test_reset_mixin_methods(self) -> None:
+        class _Reg(ResetMixin):
+            def __init__(self) -> None:
+                self.info = SimpleNamespace(reset=0xAA)
+                self.state = 0xAA
+
+            def read(self) -> int:
+                return self.state
+
+        r = _Reg()
+        assert r.reset_value == 0xAA
+        assert r.is_at_reset() is True
+
+
+# ---------------------------------------------------------------------------
+# Lock
+# ---------------------------------------------------------------------------
+
+
+class TestLockController:
+    def _build(
+        self,
+        bus: FakeBus | None = None,
+        *,
+        unlock: Callable[[Any], None] | None = None,
+    ) -> tuple[FakeRegister, LockController]:
+        bus = bus or FakeBus()
+        host = FakeRegister(bus, "gpio_a.lckr")
+        host.attach_field("pin0", lsb=0)
+        host.attach_field("pin5", lsb=5)
+        host.attach_field("LCKK", lsb=16)
+        controller = LockController(
+            host,
+            key_field="LCKK",
+            key_sequence=(1, 0, 1),
+            unlock_sequence_fn=unlock,
+        )
+        return host, controller
+
+    def test_lock_writes_lock_bits_and_runs_key_sequence(self) -> None:
+        bus = FakeBus()
+        host, controller = self._build(bus)
+        controller.lock(["pin0"])
+
+        writes = bus.writes()
+        # Lock-bits write (host-level via modify) + 3 key-field writes.
+        host_writes = [(p, v) for p, v in writes if p == "gpio_a.lckr"]
+        assert len(host_writes) == 1  # one lock-bits write through modify()
+        key_writes = [(p, v) for p, v in writes if p == "gpio_a.lckr.LCKK"]
+        assert key_writes == [
+            ("gpio_a.lckr.LCKK", 1),
+            ("gpio_a.lckr.LCKK", 0),
+            ("gpio_a.lckr.LCKK", 1),
+        ]
+
+    def test_lock_minimum_two_writes_with_default_key_sequence(self) -> None:
+        # Minimum bus traffic per sketch §12.4: at least one lock-bit write +
+        # one key-field write = two writes.
+        bus = FakeBus()
+        host = FakeRegister(bus, "gpio_a.lckr")
+        host.attach_field("pin0", lsb=0)
+        host.attach_field("LCKK", lsb=16)
+        LockController(host, key_field="LCKK", key_sequence=(1,)).lock(["pin0"])
+        writes = bus.writes()
+        # Exactly: one host modify + one key write = 2.
+        assert len(writes) == 2
+
+    def test_is_locked_returns_field_state(self) -> None:
+        host, controller = self._build()
+        host.pin0.state = 1
+        host.pin5.state = 0
+        assert controller.is_locked("pin0") is True
+        assert controller.is_locked("pin5") is False
+
+    def test_is_locked_after_lock_call(self) -> None:
+        bus = FakeBus()
+        host, controller = self._build(bus)
+        controller.lock(["pin0"])
+        # FakeRegister.modify() sets pin0.state=1
+        assert controller.is_locked("pin0") is True
+
+    def test_is_locked_unknown_field_raises(self) -> None:
+        _, controller = self._build()
+        with pytest.raises(AttributeError):
+            controller.is_locked("nonexistent")
+
+    def test_lock_empty_names_rejected(self) -> None:
+        _, controller = self._build()
+        with pytest.raises(ValueError):
+            controller.lock([])
+
+    def test_unlock_sequence_default_raises(self) -> None:
+        _, controller = self._build()
+        with pytest.raises(NotSupportedError, match="unlock_sequence"):
+            controller.unlock_sequence()
+
+    def test_unlock_sequence_custom_runs(self) -> None:
+        called: list[Any] = []
+
+        def runner(host: Any) -> None:
+            called.append(host)
+
+        host, controller = self._build(unlock=runner)
+        controller.unlock_sequence()
+        assert called == [host]
+
+    def test_lock_with_field_setter_callback(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "gpio_a.lckr")
+        host.attach_field("pin0", lsb=0)
+        host.attach_field("LCKK", lsb=16)
+
+        seen: list[tuple[Any, list[str], bool]] = []
+
+        def setter(target: Any, names: list[str], on: bool) -> None:
+            seen.append((target, list(names), on))
+            target.write(0xCAFE)  # one host write of our choosing
+
+        controller = LockController(
+            host,
+            key_field="LCKK",
+            key_sequence=(1,),
+            field_setter=setter,
+        )
+        controller.lock(["pin0"])
+        assert seen == [(host, ["pin0"], True)]
+        assert ("gpio_a.lckr", 0xCAFE) in bus.writes()
+
+    def test_attach_lock_controller_binds_methods(self) -> None:
+        bus = FakeBus()
+        host = FakeRegister(bus, "gpio_a.lckr")
+        host.attach_field("pin0", lsb=0)
+        host.attach_field("LCKK", lsb=16)
+        attach_lock_controller(host, key_field="LCKK", key_sequence=(1,))
+        assert callable(host.lock)
+        assert callable(host.is_locked)
+        assert callable(host.unlock_sequence)
+        host.lock(["pin0"])
+        assert host.is_locked("pin0") is True
+
+
+# ---------------------------------------------------------------------------
+# Registry-seam integration (attach_specialized) — exercises the per-class
+# wiring used by the generated runtime.
+# ---------------------------------------------------------------------------
+
+
+class TestAttachSpecialized:
+    def test_reset_helpers_always_attached(self) -> None:
+        class _RegClass:
+            pass
+
+        attach_specialized(_RegClass, {})
+        assert "reset_value" in _RegClass.__dict__
+        assert "is_at_reset" in _RegClass.__dict__
+
+    def test_counter_property_attached_when_metadata_present(self) -> None:
+        class _CntReg:
+            def __init__(self) -> None:
+                self.bus = FakeBus()
+                self.state = 0
+
+            def read(self) -> int:
+                return self.state
+
+            def write(self, value: int) -> None:
+                self.state = int(value)
+                self.bus.record_write("cnt", self.state)
+
+            def modify(self, **kwargs: Any) -> None:
+                # Single-field counter: increment writes the named field.
+                # We accept whatever name matches incrvalue_field.
+                self.state = int(next(iter(kwargs.values())))
+                self.bus.record_write("cnt", self.state)
+
+        attach_specialized(
+            _CntReg,
+            {"counter": {"can_increment": True, "incrvalue_field": "incrvalue"}},
+        )
+        instance = _CntReg()
+        assert isinstance(instance.counter, Counter)
+        instance.counter.increment(by=5)
+        assert ("cnt", 5) in instance.bus.writes()
+        # Property is cached: same wrapper on second access.
+        assert instance.counter is instance.counter
+
+    def test_lock_methods_attached_when_metadata_present(self) -> None:
+        class _LockReg:
+            def __init__(self) -> None:
+                self.bus = FakeBus()
+                self.state = 0
+                self.pin0 = FakeField(self.bus, "lckr.pin0", lsb=0)
+                self.LCKK = FakeField(self.bus, "lckr.LCKK", lsb=16)
+
+            def read(self) -> int:
+                return self.state
+
+            def write(self, value: int) -> None:
+                self.state = int(value)
+                self.bus.record_write("lckr", self.state)
+
+            def modify(self, **kwargs: Any) -> None:
+                for name, value in kwargs.items():
+                    target = getattr(self, name)
+                    target.state = int(value) & ((1 << target.width) - 1)
+                self.bus.record_write("lckr", -1)  # marker for combined write
+
+        attach_specialized(
+            _LockReg,
+            {"lock": {"key_field": "LCKK", "key_sequence": (1,)}},
+        )
+        instance = _LockReg()
+        assert callable(instance.lock)
+        instance.lock(["pin0"])
+        assert instance.is_locked("pin0") is True
+
+    def test_singlepulse_field_pulse_attached(self) -> None:
+        class _Field:
+            singlepulse = True
+
+            def __init__(self) -> None:
+                self.bus = FakeBus()
+
+            def write(self, value: int) -> None:
+                self.bus.record_write("start", int(value))
+
+        class _Reg:
+            start = _Field
+
+        attach_specialized(_Reg, {"singlepulse_fields": ("start",)})
+        # The field class should now have a pulse method attached.
+        assert callable(getattr(_Reg.start, "pulse", None))
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: the public API can be imported and exercised end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_smoke() -> None:
+    bus = FakeBus()
+    soc = FakeSoc(bus)
+    uart = soc.attach_regfile("uart")
+    uart.attach_register("control", reset=0xAB)
+    uart.control.state = 0
+    attach_post_create(soc)
+
+    soc.reset_all()
+    assert is_at_reset(uart.control) is True
+    assert reset_value(uart.control) == 0xAB


### PR DESCRIPTION
## Summary

Implements §12 of `docs/IDEAL_API_SKETCH.md` (specialized SystemRDL register kinds) as a pure-Python module under `peakrdl_pybind11.runtime.specialized`:

- **Counters**: `Counter` wrapper with `value()`, `reset()`, `threshold()`, `is_saturated()`, `increment(by=)`, `decrement(by=)` — methods raise `NotSupportedError` (loud) when the underlying capability is absent.
- **Singlepulse**: `pulse(field)` free function and `attach_pulse(field_class)` to hook a `pulse()` method onto singlepulse fields (`info.tags.singlepulse` UDP or class-level marker).
- **Reset**: `reset_value`/`is_at_reset()` per register, `reset_all_regfile(rw_only=True)`, `reset_all_soc(rw_only=True)` with `UserWarning` when restoring registers that combine RW with `rclr` fields. `ResetMixin` for inheritance-style adoption.
- **Lock**: `LockController` for STM32-style LCKR / LCKK key sequences with `lock(names)`, `is_locked(name)`, `unlock_sequence()` (raises `NotSupportedError` by default).
- **Wiring**: `attach_specialized(cls, metadata)` and `attach_post_create(soc)` are registered with Unit 1's `_registry.register_register_enhancement` / `register_post_create` seam. The import is wrapped in `try/except ImportError` so the module remains importable when sibling units (Unit 1's `_registry`, Unit 2's `errors`, Unit 4's `info`) are not yet merged into `exp/api_overhaul`.

The wrappers consume duck-typed register/field nodes (anything with `read()` / `write()` plus an `info` namespace), so they are unit-testable without generated bindings.

## Test plan

- [x] `uv sync --group test`
- [x] `pytest tests/runtime/test_specialized.py -v` — 47 tests pass (counter ops, pulse attachment, reset semantics, regfile/soc walks, rclr/rw warning, lock-key sequence, registry-seam integration)
- [x] `ruff check` and `ruff format --check` clean on the new module
- [x] Existing test suite still green (`pytest tests/ -x` — 119 passed, 14 skipped — no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)