### PR TITLE
feat(runtime): scaffolding & registry seam (Unit 1, gating)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,11 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
-dependencies = ["systemrdl-compiler >= 1.30.1", "jinja2"]
+dependencies = ["systemrdl-compiler >= 1.30.1", "jinja2", "numpy>=1.24"]
 
 [project.optional-dependencies]
 cli = ["peakrdl-cli >= 1.2.3"]
+notebook = ["ipywidgets>=8", "watchdog>=3", "pandas>=2"]
 
 [dependency-groups]
 docs = [
@@ -54,6 +55,12 @@ pybind11 = "peakrdl_pybind11.__peakrdl__:Exporter"
 [tool.setuptools.package-data]
 peakrdl_pybind11 = ["templates/*.jinja", "templates/**/*.jinja"]
 
+# --------------------- PYTEST ---------------------
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that build a generated SoC module via cmake (slow; needs a C++ toolchain)",
+]
+
 # ---------------------- RUFF ----------------------
 [tool.ruff]
 line-length = 110
@@ -76,9 +83,14 @@ ignore = [
     "E501",  # line-too-long
 ]
 
-# Make tests less strict for annotations.
-# [tool.ruff.lint.per-file-ignores]
-# "tests/**/*" = ["ANN*"]
+# The runtime/CLI/exporter-plugin seams are deliberately generic over the
+# generated types produced per-SoC; ``Any`` is the correct annotation for
+# the hook surface. Suppress ANN401 on those files only.
+[tool.ruff.lint.per-file-ignores]
+"src/peakrdl_pybind11/runtime/**/*.py" = ["ANN401"]
+"src/peakrdl_pybind11/cli/**/*.py" = ["ANN401"]
+"src/peakrdl_pybind11/exporter_plugins/**/*.py" = ["ANN401"]
+"src/peakrdl_pybind11/masters/base.py" = ["ANN401"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/peakrdl_pybind11/__init__.py
+++ b/src/peakrdl_pybind11/__init__.py
@@ -12,13 +12,28 @@ if TYPE_CHECKING:
     from .exporter import Pybind11Exporter
     from .int_types import FieldInt, RegisterInt, RegisterIntEnum, RegisterIntFlag
 
+    # Forward-compat aliases (see ``IDEAL_API_SKETCH.md`` §3): RegisterValue
+    # and FieldValue are the names used in the new API surface; they alias
+    # the existing ``RegisterInt`` / ``FieldInt`` types so user code can be
+    # ported to the new vocabulary without behavioural change.
+    RegisterValue = RegisterInt
+    FieldValue = FieldInt
+
 try:
     __version__ = version("peakrdl-pybind11")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 
-__all__ = ["FieldInt", "Pybind11Exporter", "RegisterInt", "RegisterIntEnum", "RegisterIntFlag"]
+__all__ = [
+    "FieldInt",
+    "FieldValue",
+    "Pybind11Exporter",
+    "RegisterInt",
+    "RegisterIntEnum",
+    "RegisterIntFlag",
+    "RegisterValue",
+]
 
 
 def __getattr__(name: str) -> type:
@@ -26,7 +41,7 @@ def __getattr__(name: str) -> type:
         from .exporter import Pybind11Exporter
 
         return Pybind11Exporter
-    if name == "RegisterInt":
+    if name in ("RegisterInt", "RegisterValue"):
         from .int_types import RegisterInt
 
         return RegisterInt
@@ -38,7 +53,7 @@ def __getattr__(name: str) -> type:
         from .int_types import RegisterIntEnum
 
         return RegisterIntEnum
-    if name == "FieldInt":
+    if name in ("FieldInt", "FieldValue"):
         from .int_types import FieldInt
 
         return FieldInt

--- a/src/peakrdl_pybind11/__peakrdl__.py
+++ b/src/peakrdl_pybind11/__peakrdl__.py
@@ -108,6 +108,13 @@ class Exporter(ExporterSubcommandPlugin):
             ),
         )
 
+        # Sibling-unit CLI extensions can attach extra arguments here.
+        # These are *not* new top-level subcommands of ``peakrdl``;
+        # they extend the existing ``peakrdl pybind11`` invocation.
+        from .cli import discover_subcommands
+
+        discover_subcommands(arg_group)
+
     def do_export(self, top_node: "AddrmapNode", options: "argparse.Namespace") -> None:
         """Execute the export"""
         exporter = Pybind11Exporter()
@@ -131,3 +138,10 @@ class Exporter(ExporterSubcommandPlugin):
             split_bindings=split_bindings,
             split_by_hierarchy=split_by_hierarchy,
         )
+
+        # Run sibling-unit CLI handlers after the primary export. Order
+        # matters for some siblings (e.g. ``--explore`` wants to drop
+        # into a REPL only after generated files are on disk).
+        from .cli import run_handlers
+
+        run_handlers(options)

--- a/src/peakrdl_pybind11/cli/__init__.py
+++ b/src/peakrdl_pybind11/cli/__init__.py
@@ -1,0 +1,88 @@
+"""CLI extension auto-discovery.
+
+This package is the seam that sibling units of the API overhaul use to
+attach extra arguments to the ``peakrdl pybind11`` invocation and run
+post-export handlers, without touching ``__peakrdl__.py``. Each module
+inside this package may export:
+
+* ``add_arguments(arg_group)`` — called from
+  :py:meth:`Exporter.add_exporter_arguments`. ``arg_group`` is the same
+  argparse action container PeakRDL hands the exporter.
+* ``handle(options)`` — called from :py:meth:`Exporter.do_export` after
+  the exporter has run. ``options`` is the parsed argparse namespace.
+
+Module names beginning with ``_`` are treated as internal and skipped.
+
+Despite the package name, these are *not* new top-level subcommands of
+``peakrdl``; the ``peakrdl pybind11`` subcommand is owned by
+``__peakrdl__.py`` (see :class:`peakrdl_pybind11.__peakrdl__.Exporter`).
+``cli`` modules are sibling-unit extensions that compose with that
+single subcommand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import logging
+import pkgutil
+from typing import Any
+
+logger = logging.getLogger("peakrdl_pybind11.cli")
+
+__all__ = ["discover_subcommands", "run_handlers"]
+
+
+def _iter_modules() -> list[Any]:
+    """Yield every imported sibling-unit CLI module under this package."""
+    package_path = list(__path__)  # type: ignore[name-defined]
+    package_name = __name__
+    modules: list[Any] = []
+    for info in pkgutil.iter_modules(package_path):
+        if info.name.startswith("_"):
+            continue
+        full_name = f"{package_name}.{info.name}"
+        try:
+            modules.append(importlib.import_module(full_name))
+        except Exception:
+            logger.warning("failed to import CLI module %r", full_name, exc_info=True)
+    return modules
+
+
+def discover_subcommands(arg_group: argparse._ActionsContainer) -> None:
+    """Run ``add_arguments`` from every sibling-unit CLI module.
+
+    Args:
+        arg_group: argparse action container to extend. The exporter
+            passes the same group it received from PeakRDL.
+    """
+    for module in _iter_modules():
+        add_arguments = getattr(module, "add_arguments", None)
+        if add_arguments is None:
+            continue
+        try:
+            add_arguments(arg_group)
+        except Exception:
+            logger.warning(
+                "CLI module %r add_arguments() raised", module.__name__, exc_info=True
+            )
+
+
+def run_handlers(options: argparse.Namespace) -> None:
+    """Run ``handle`` from every sibling-unit CLI module.
+
+    Called after :py:meth:`Exporter.do_export` finishes its primary
+    export. Handler exceptions are logged and re-raised so the user sees
+    the failure (a CLI handler is closer to "the user explicitly asked
+    for X" than a runtime hook is, so silent failure is the wrong
+    default here).
+    """
+    for module in _iter_modules():
+        handle = getattr(module, "handle", None)
+        if handle is None:
+            continue
+        try:
+            handle(options)
+        except Exception:
+            logger.exception("CLI module %r handle() raised", module.__name__)
+            raise

--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -188,6 +188,14 @@ class Pybind11Exporter:
         self.output_dir: Path | None = None
         self._name_cache: dict[str, str] = {}
 
+        # Discover sibling-unit exporter plugins. Each plugin's
+        # ``register(self)`` runs immediately so it can install Jinja
+        # filters, store references, etc.; codegen-time hooks (if any)
+        # are scheduled by the plugin via attributes on the exporter.
+        from .exporter_plugins import discover_plugins
+
+        discover_plugins(self)
+
     def export(
         self,
         top_node: RootNode | AddrmapNode,

--- a/src/peakrdl_pybind11/exporter_plugins/__init__.py
+++ b/src/peakrdl_pybind11/exporter_plugins/__init__.py
@@ -1,0 +1,57 @@
+"""Exporter plugin auto-discovery.
+
+This package is the seam that sibling units of the API overhaul use to
+add codegen passes without modifying ``exporter.py``. Each plugin module
+must export a ``register(exporter)`` function. The exporter calls
+:func:`discover_plugins` once during ``__init__`` and the plugin's
+``register`` is called immediately so it can hook into the exporter
+(install Jinja filters, store references, etc.); plugins typically run
+their codegen during ``export()`` via callbacks the exporter exposes.
+
+If a plugin module fails to import it is logged and skipped — one bad
+plugin must not take down the whole exporter for downstream users.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from typing import Any
+
+logger = logging.getLogger("peakrdl_pybind11.exporter_plugins")
+
+__all__ = ["discover_plugins"]
+
+
+def discover_plugins(exporter: Any) -> None:
+    """Discover and register every exporter plugin module under this package.
+
+    Args:
+        exporter: The :class:`peakrdl_pybind11.exporter.Pybind11Exporter`
+            instance. Each plugin's ``register`` callable receives this
+            object so it can attach itself.
+    """
+    package_path = list(__path__)  # type: ignore[name-defined]
+    package_name = __name__
+
+    for info in pkgutil.iter_modules(package_path):
+        if info.name.startswith("_"):
+            # Underscore-prefixed modules are reserved for internals
+            # (test fixtures, helpers); they don't expose ``register``.
+            continue
+        full_name = f"{package_name}.{info.name}"
+        try:
+            module = importlib.import_module(full_name)
+        except Exception:
+            logger.warning("failed to import exporter plugin %r", full_name, exc_info=True)
+            continue
+
+        register = getattr(module, "register", None)
+        if register is None:
+            logger.debug("exporter plugin %r has no register()", full_name)
+            continue
+        try:
+            register(exporter)
+        except Exception:
+            logger.warning("exporter plugin %r register() raised", full_name, exc_info=True)

--- a/src/peakrdl_pybind11/masters/base.py
+++ b/src/peakrdl_pybind11/masters/base.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -34,7 +37,24 @@ class MasterBase(ABC):
        has to be implemented in Python (sockets, REST APIs, exotic hardware
        glue) — at which point per-access overhead is dominated by I/O
        anyway.
+
+    Extension points (no-op defaults; sibling units of the API overhaul
+    override these in ``runtime/bus_policies.py`` and friends):
+
+    * :meth:`peek` — non-snooping read (defaults to :meth:`read`).
+    * :meth:`barrier` — flush in-flight ops (default: no-op).
+    * :meth:`on_disconnect` / :attr:`_on_disconnect_callbacks` — callbacks
+      fired when transport drops.
+    * :meth:`set_retry_policy` / :attr:`_retry_policy` — retry config storage.
+    * :meth:`cache_get` / :meth:`cache_set` — read-cache hooks (default:
+      pass-through, no caching).
     """
+
+    # State buckets are populated lazily so subclass ``__init__`` doesn't
+    # need to call super().__init__(); the existing concrete masters
+    # (MockMaster etc.) keep working unchanged.
+    _on_disconnect_callbacks: list[Callable[[], None]]
+    _retry_policy: dict[str, Any]
 
     @abstractmethod
     def read(self, address: int, width: int) -> int:
@@ -75,3 +95,65 @@ class MasterBase(ABC):
         """Batched write. Default impl loops single-op :meth:`write`."""
         for op in ops:
             self.write(op.address, op.value, op.width)
+
+    # -----------------------------------------------------------------
+    # Extension points
+    # -----------------------------------------------------------------
+
+    def peek(self, address: int, width: int) -> int:
+        """Non-snooping read.
+
+        Default implementation forwards to :meth:`read`. Sibling unit
+        ``runtime/bus_policies.py`` overrides this on caching masters to
+        avoid promoting cache lines.
+        """
+        return self.read(address, width)
+
+    def barrier(self) -> None:
+        """Flush any in-flight operations.
+
+        Default: no-op. Sibling unit ``runtime/bus_policies.py`` provides
+        per-master implementations (e.g. waiting for outstanding write
+        completions on JTAG masters). The ``soc.barrier(scope="all")``
+        SoC-wide form fans this out across every attached master.
+        """
+        return None
+
+    def on_disconnect(self, callback: Callable[[], None]) -> None:
+        """Register ``callback`` to fire when the transport drops.
+
+        Default: store on a per-instance list. Concrete masters that
+        actually have a transport (SSH, OpenOCD, JTAG) override this to
+        wire the callback into their disconnect detection.
+
+        Sibling extension point: ``runtime/bus_policies.py``.
+        """
+        if not hasattr(self, "_on_disconnect_callbacks"):
+            self._on_disconnect_callbacks = []
+        self._on_disconnect_callbacks.append(callback)
+
+    def set_retry_policy(self, **kwargs: Any) -> None:
+        """Configure transient-error retry behaviour.
+
+        Default: stash kwargs on a per-instance dict. Sibling unit
+        ``runtime/bus_policies.py`` consumes the dict in its
+        retry/backoff wrapper.
+        """
+        if not hasattr(self, "_retry_policy"):
+            self._retry_policy = {}
+        self._retry_policy.update(kwargs)
+
+    def cache_get(self, address: int) -> int | None:
+        """Look up ``address`` in the master's read cache.
+
+        Default: ``None`` (no cache). Sibling unit
+        ``runtime/bus_policies.py`` overrides on caching masters.
+        """
+        return None
+
+    def cache_set(self, address: int, value: int) -> None:
+        """Insert ``(address, value)`` into the master's read cache.
+
+        Default: pass-through (no cache).
+        """
+        return None

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -1,0 +1,77 @@
+"""Runtime support package for the PeakRDL-pybind11 generated API.
+
+See ``docs/IDEAL_API_SKETCH.md`` for the full design.
+
+Sibling-unit modules placed inside this package are **auto-imported** at
+package load time. This is the seam that lets each piece of the API
+overhaul (snapshots, observers, interrupt detection, bus policies,
+widgets, etc.) wire itself in without ``runtime.py.jinja`` having to
+know about it.
+
+Auto-import contract:
+
+* Modules whose name starts with ``_`` (e.g. ``_default_shims``,
+  ``_registry``) are part of the runtime's own implementation and are
+  imported first. They are intentionally underscore-prefixed so the
+  generated ``runtime.py`` can rely on the **defaults registering before
+  any sibling unit**.
+* Sibling-unit modules use plain names (e.g. ``snapshots``, ``bus_policies``).
+* If a sibling module fails to import, the failure is logged and the
+  package continues — one bad sibling must not break the whole runtime
+  surface for downstream users.
+
+The package also re-exports ``RegisterValue`` / ``FieldValue`` as aliases
+for ``RegisterInt`` / ``FieldInt`` so the new API vocabulary is available
+from a stable import path::
+
+    from peakrdl_pybind11.runtime import RegisterValue, FieldValue
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+
+from ..int_types import FieldInt as FieldValue
+from ..int_types import RegisterInt as RegisterValue
+from . import _registry
+
+logger = logging.getLogger("peakrdl_pybind11.runtime")
+
+__all__ = [
+    "FieldValue",
+    "RegisterValue",
+    "_registry",
+]
+
+
+def _auto_import_modules() -> None:
+    """Import every submodule under this package.
+
+    Underscore-prefixed modules (the runtime's own internals) are imported
+    first so default hooks register before sibling-unit hooks. A failed
+    sibling import is logged but never raised — one broken sibling unit
+    must not poison the whole runtime.
+    """
+    package_path = list(__path__)  # type: ignore[name-defined]
+    package_name = __name__
+
+    # Two passes: underscore-prefixed first, plain names second. Within
+    # each pass the order is whatever ``pkgutil.iter_modules`` returns
+    # (alphabetical on every reasonable filesystem). Stable enough for
+    # default-then-sibling layering; sibling-unit ordering is not part
+    # of the contract.
+    found = list(pkgutil.iter_modules(package_path))
+    underscore = [info for info in found if info.name.startswith("_")]
+    rest = [info for info in found if not info.name.startswith("_")]
+
+    for info in underscore + rest:
+        full_name = f"{package_name}.{info.name}"
+        try:
+            importlib.import_module(full_name)
+        except Exception:
+            logger.warning("failed to import runtime module %r", full_name, exc_info=True)
+
+
+_auto_import_modules()

--- a/src/peakrdl_pybind11/runtime/_default_shims.py
+++ b/src/peakrdl_pybind11/runtime/_default_shims.py
@@ -1,0 +1,186 @@
+"""
+Default register/field enhancements.
+
+The bulk of what the generated ``runtime.py`` module used to do inline
+lives here. Lifting it into a module that auto-registers means sibling
+units of the API overhaul can simply *also* register more enhancements
+and they will compose: defaults run first (they wrap the bare C++
+``read``/``write`` into Python shims), then sibling-unit enhancements
+layer on additional behaviour.
+
+The semantics of the default shims are intentionally identical to the
+pre-overhaul template, so the existing ``tests/test_*`` integration suite
+continues to pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from ..int_types import FieldInt, RegisterInt
+from . import _registry
+
+logger = logging.getLogger("peakrdl_pybind11.runtime.default_shims")
+
+# Sentinel attribute placed on enhanced read/write callables so we never
+# wrap twice. Mirrors the ``__peakrdl_enhanced__`` marker used in the
+# original template.
+_ENHANCED = "__peakrdl_enhanced__"
+
+
+def _enhanced_register_read(
+    original_read: Callable[..., int],
+    flag_type: type | None,
+    enum_type: type | None,
+    fields_spec: dict[str, tuple[int, int]],
+) -> Callable[[Any], Any]:
+    def read(self: Any) -> Any:
+        value = original_read(self)
+        if flag_type is not None:
+            return flag_type(value)
+        if enum_type is not None:
+            return enum_type(value)
+        return RegisterInt(value, self.offset, self.width, fields_spec)
+
+    setattr(read, _ENHANCED, True)
+    return read
+
+
+def _enhanced_register_write(
+    original_write: Callable[[Any, int], None],
+    original_modify: Callable[[Any, int, int], None],
+) -> Callable[[Any, Any], None]:
+    def write(self: Any, value: Any) -> None:
+        if isinstance(value, FieldInt):
+            shifted = (int(value) << value.lsb) & value.mask
+            original_modify(self, shifted, value.mask)
+        else:
+            original_write(self, int(value))
+
+    setattr(write, _ENHANCED, True)
+    return write
+
+
+def _enhanced_field_read(original_read: Callable[..., int]) -> Callable[[Any], FieldInt]:
+    def read(self: Any) -> FieldInt:
+        return FieldInt(original_read(self), self.lsb, self.width, self.offset)
+
+    setattr(read, _ENHANCED, True)
+    return read
+
+
+def _enhanced_field_write(original_write: Callable[[Any, int], None]) -> Callable[[Any, Any], None]:
+    def write(self: Any, value: Any) -> None:
+        original_write(self, int(value))
+
+    setattr(write, _ENHANCED, True)
+    return write
+
+
+def _make_write_fields(
+    fields_spec: dict[str, tuple[int, int]],
+    writable_spec: dict[str, bool],
+) -> Callable[..., None]:
+    """Build a ``write_fields(**kwargs)`` shim for a generated register class.
+
+    Collapses N per-field writes into a single C++ ``write_fields(mask,
+    value)`` call (1 read + 1 write on the master, regardless of N).
+    Validates field names and writability at the Python boundary so the
+    C++ side stays minimal.
+    """
+
+    def write_fields(self: Any, **kwargs: Any) -> None:
+        combined_mask = 0
+        combined_value = 0
+        for name, raw_value in kwargs.items():
+            spec = fields_spec.get(name)
+            if spec is None:
+                raise KeyError(
+                    f"Unknown field '{name}' on register '{self.name}'. "
+                    f"Known fields: {sorted(fields_spec)}"
+                )
+            if not writable_spec.get(name, False):
+                raise PermissionError(f"Field '{name}' on register '{self.name}' is not writable")
+            lsb, width = spec
+            field_mask = ((1 << width) - 1) << lsb
+            combined_mask |= field_mask
+            combined_value |= (int(raw_value) << lsb) & field_mask
+        # Single C++ entry: native RMW under the hood.
+        self._native_write_fields(combined_mask, combined_value)
+
+    return write_fields
+
+
+@_registry.register_register_enhancement
+def _default_register_shim(cls: type, metadata: dict) -> None:
+    """Wrap the generated register class with typed read/write/write_fields.
+
+    ``metadata`` is the dict the generated runtime passes in. The keys we
+    care about:
+
+    * ``"fields"``      — ``{field_name: (lsb, width)}``
+    * ``"writable"``    — ``{field_name: bool}``
+    * ``"flag_type"``   — optional flag class for this register
+    * ``"enum_type"``   — optional enum class for this register
+
+    Sibling units may add more keys; we ignore them silently.
+
+    If ``cls`` doesn't expose ``read``/``write`` (e.g. a unit test passes
+    a stub class) we bail cleanly — the seam is generic, but the default
+    shim only knows how to handle generated register classes.
+    """
+    raw_read = getattr(cls, "read", None)
+    if raw_read is None:
+        return
+    if getattr(raw_read, _ENHANCED, False):
+        return  # already enhanced (e.g. importing the module twice)
+
+    fields_spec: dict[str, tuple[int, int]] = metadata.get("fields", {})
+    writable_spec: dict[str, bool] = metadata.get("writable", {})
+    flag_type: type | None = metadata.get("flag_type")
+    enum_type: type | None = metadata.get("enum_type")
+
+    raw_write = getattr(cls, "write", None)
+    if raw_write is None:
+        return
+    cls.read = _enhanced_register_read(raw_read, flag_type, enum_type, fields_spec)  # type: ignore[method-assign]
+    cls.write = _enhanced_register_write(raw_write, cls.modify)  # type: ignore[method-assign]
+    # Fast-path scalar accessors: bypass RegisterInt wrapping / FieldInt
+    # handling. ``read_raw`` returns a plain ``int``; ``write_raw`` accepts
+    # a plain ``int`` and writes it directly via the underlying C++ method.
+    cls.read_raw = raw_read  # type: ignore[attr-defined]
+    cls.write_raw = raw_write  # type: ignore[attr-defined]
+    # Preserve the native binding under a private name; expose the Python
+    # shim with validation under the public name.
+    if hasattr(cls, "write_fields"):
+        cls._native_write_fields = cls.write_fields  # type: ignore[attr-defined]
+        cls.write_fields = _make_write_fields(fields_spec, writable_spec)  # type: ignore[method-assign]
+
+
+@_registry.register_field_enhancement
+def _default_field_shim(cls: type) -> None:
+    """Wrap the generated field class with typed read/write.
+
+    Bails cleanly on classes that don't expose ``read``/``write`` so the
+    seam stays generic enough to test in isolation.
+    """
+    raw_read = getattr(cls, "read", None)
+    if raw_read is None:
+        return
+    if getattr(raw_read, _ENHANCED, False):
+        return
+
+    raw_write = getattr(cls, "write", None)
+    if raw_write is None:
+        return
+    cls.read = _enhanced_field_read(raw_read)  # type: ignore[method-assign]
+    cls.write = _enhanced_field_write(raw_write)  # type: ignore[method-assign]
+    # Fast-path scalar accessors: ``read_raw`` returns a plain ``int`` (the
+    # field-space value, identical to what the C++ getter returns -- no
+    # ``FieldInt`` allocation). ``write_raw`` takes a plain ``int`` in
+    # field-space and forwards directly to the C++ setter (which performs
+    # the shift+mask+modify on the underlying register).
+    cls.read_raw = raw_read  # type: ignore[attr-defined]
+    cls.write_raw = raw_write  # type: ignore[attr-defined]

--- a/src/peakrdl_pybind11/runtime/_registry.py
+++ b/src/peakrdl_pybind11/runtime/_registry.py
@@ -1,0 +1,252 @@
+"""
+Central runtime hook registry.
+
+This module is the **stable seam** that every sibling unit of the API
+overhaul plugs into. Sibling units register callables here and the
+generated runtime fires them at well-defined points; nothing in
+``runtime.py.jinja`` (the per-SoC generated module) needs to know which
+units are present.
+
+Five registries live here:
+
+* ``_register_enhancements`` — wrap/extend a generated **register** class
+  with ``apply(cls, fields_spec)``.
+* ``_field_enhancements`` — same idea for generated **field** classes.
+  (Split from register enhancements because the existing template uses
+  different per-field metadata; sibling units almost always target one or
+  the other, not both.)
+* ``_post_create_hooks`` — fire after ``soc = MySoc.create(...)``.
+* ``_master_extensions`` — fire when a master is attached to a SoC.
+* ``_node_attributes`` — lazy attribute factories attached to the node
+  base class. Each factory returns the value for the attribute on first
+  access; later units add ``.info``, ``.snapshot``, ``.watch`` etc.
+
+All registration is thread-safe: a single ``threading.Lock`` guards each
+mutation. Callable invocation is *not* serialized — the caller is
+expected to hold any cross-cutting locks.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger("peakrdl_pybind11.runtime.registry")
+
+# ---------------------------------------------------------------------------
+# Type aliases. Kept loose so sibling units can register callables that take
+# extra optional kwargs without breaking the registry.
+# ---------------------------------------------------------------------------
+
+RegisterEnhancement = Callable[[type, dict], None]
+FieldEnhancement = Callable[[type], None]
+PostCreateHook = Callable[[Any], None]
+MasterExtension = Callable[[Any], None]
+NodeAttributeFactory = Callable[[Any], Any]
+
+# ---------------------------------------------------------------------------
+# Internal registries. Lists preserve registration order so siblings can
+# reason about composition: defaults register first, sibling units extend.
+# ---------------------------------------------------------------------------
+
+_register_enhancements: list[RegisterEnhancement] = []
+_field_enhancements: list[FieldEnhancement] = []
+_post_create_hooks: list[PostCreateHook] = []
+_master_extensions: list[MasterExtension] = []
+_node_attributes: dict[str, NodeAttributeFactory] = {}
+
+# Identity sets so re-registration of the same callable is idempotent.
+# Without these, importing a sibling module twice (rare, but happens with
+# ``importlib.reload`` and the test harness) would double-register hooks.
+_seen_register_enhancements: set[int] = set()
+_seen_field_enhancements: set[int] = set()
+_seen_post_create_hooks: set[int] = set()
+_seen_master_extensions: set[int] = set()
+
+_lock = threading.Lock()
+
+
+def _register_unique(fn: Callable, store: list, seen: set[int]) -> None:
+    """Append ``fn`` to ``store`` once, guarded by ``_lock``."""
+    with _lock:
+        if id(fn) in seen:
+            return
+        seen.add(id(fn))
+        store.append(fn)
+
+
+# ---------------------------------------------------------------------------
+# Decorator API
+# ---------------------------------------------------------------------------
+
+
+def register_register_enhancement(fn: RegisterEnhancement) -> RegisterEnhancement:
+    """Register ``fn`` to be called for every generated register class.
+
+    The callable receives ``(cls, fields_spec)`` where ``fields_spec`` is
+    the per-register ``{field_name: (lsb, width)}`` dict produced by the
+    template. Idempotent on identity: re-registering the same function
+    is a no-op.
+    """
+    _register_unique(fn, _register_enhancements, _seen_register_enhancements)
+    return fn
+
+
+def register_field_enhancement(fn: FieldEnhancement) -> FieldEnhancement:
+    """Register ``fn`` to be called for every generated field class.
+
+    The callable receives the class. Use this for field-only behaviour
+    (typed read return value, raw accessors, etc.).
+    """
+    _register_unique(fn, _field_enhancements, _seen_field_enhancements)
+    return fn
+
+
+def register_post_create(fn: PostCreateHook) -> PostCreateHook:
+    """Register ``fn`` to fire after a SoC instance is created.
+
+    Sibling units use this to attach observers, snapshot tooling,
+    interrupt detection, etc.
+    """
+    _register_unique(fn, _post_create_hooks, _seen_post_create_hooks)
+    return fn
+
+
+def register_master_extension(fn: MasterExtension) -> MasterExtension:
+    """Register ``fn`` to fire when a master attaches to a SoC.
+
+    Sibling units use this to wire bus policies (retry, cache,
+    barriers, tracing) into the master.
+    """
+    _register_unique(fn, _master_extensions, _seen_master_extensions)
+    return fn
+
+
+def register_node_attribute(name: str) -> Callable[[NodeAttributeFactory], NodeAttributeFactory]:
+    """Decorator factory that registers a lazy node attribute.
+
+    The decorated function is called with the node instance the first
+    time the attribute is accessed; the result is cached on the instance.
+    Re-registering the same name silently overwrites the previous factory
+    (the new sibling unit "wins"). A debug log records the replacement.
+    """
+
+    def decorator(fn: NodeAttributeFactory) -> NodeAttributeFactory:
+        with _lock:
+            if name in _node_attributes and _node_attributes[name] is not fn:
+                logger.debug("node attribute %r being overwritten by %r", name, fn)
+            _node_attributes[name] = fn
+        return fn
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Apply API — the generated runtime.py imports and calls these.
+# ---------------------------------------------------------------------------
+
+
+def _fire(store: list, label: str, target: Any, *args: Any) -> None:
+    """Snapshot ``store`` under ``_lock`` and invoke each callable on the targets.
+
+    The snapshot lets a long-running hook avoid blocking new
+    registrations from sibling units imported on demand.
+    """
+    with _lock:
+        funcs = list(store)
+    for fn in funcs:
+        try:
+            fn(target, *args)
+        except Exception:
+            logger.exception("%s %r raised on %r", label, fn, target)
+            raise
+
+
+def apply_register_enhancements(cls: type, metadata: dict) -> None:
+    """Run every registered register enhancement against ``cls``."""
+    _fire(_register_enhancements, "register enhancement", cls, metadata)
+
+
+def apply_field_enhancements(cls: type) -> None:
+    """Run every registered field enhancement against ``cls``."""
+    _fire(_field_enhancements, "field enhancement", cls)
+
+
+def fire_post_create_hooks(soc: Any) -> None:
+    """Fire every registered post-create hook against ``soc``."""
+    _fire(_post_create_hooks, "post-create hook", soc)
+
+
+def fire_master_extensions(master: Any) -> None:
+    """Fire every registered master extension against ``master``."""
+    _fire(_master_extensions, "master extension", master)
+
+
+def attach_node_attributes(node_class: type | None) -> None:
+    """Wire registered lazy attributes onto ``node_class``.
+
+    If ``node_class`` is ``None`` (no shared base in the generated module
+    yet — the current state during early API-overhaul units), this is a
+    no-op so siblings can call it safely.
+    """
+    if node_class is None:
+        return
+
+    with _lock:
+        attrs = dict(_node_attributes)
+
+    for name, factory in attrs.items():
+        # Skip if the class already defines the attribute (sibling unit
+        # explicitly defined it on the class, factory is a fallback).
+        if name in node_class.__dict__:
+            continue
+
+        def _make_property(fn: NodeAttributeFactory, attr_name: str) -> property:
+            cache_key = f"_node_attr_cache_{attr_name}"
+
+            def getter(self: Any) -> Any:
+                cached = self.__dict__.get(cache_key)
+                if cached is not None:
+                    return cached
+                value = fn(self)
+                self.__dict__[cache_key] = value
+                return value
+
+            return property(getter)
+
+        setattr(node_class, name, _make_property(factory, name))
+
+
+# ---------------------------------------------------------------------------
+# Test / introspection helpers. Sibling units do **not** depend on these;
+# they exist so the registry test module can verify behaviour without
+# reaching into private state.
+# ---------------------------------------------------------------------------
+
+
+def _reset_for_tests() -> None:
+    """Clear every registry. Test-only; do **not** call from production."""
+    with _lock:
+        _register_enhancements.clear()
+        _field_enhancements.clear()
+        _post_create_hooks.clear()
+        _master_extensions.clear()
+        _node_attributes.clear()
+        _seen_register_enhancements.clear()
+        _seen_field_enhancements.clear()
+        _seen_post_create_hooks.clear()
+        _seen_master_extensions.clear()
+
+
+def _snapshot() -> dict[str, Any]:
+    """Return a shallow snapshot of every registry. Test-only."""
+    with _lock:
+        return {
+            "register_enhancements": list(_register_enhancements),
+            "field_enhancements": list(_field_enhancements),
+            "post_create_hooks": list(_post_create_hooks),
+            "master_extensions": list(_master_extensions),
+            "node_attributes": dict(_node_attributes),
+        }

--- a/src/peakrdl_pybind11/templates/runtime.py.jinja
+++ b/src/peakrdl_pybind11/templates/runtime.py.jinja
@@ -14,7 +14,14 @@ except ImportError as e:
     print(f"  cd <output_dir> && python setup.py build_ext --inplace", file=sys.stderr)
     raise
 
+# Importing the runtime package both auto-loads the default shims and
+# every sibling-unit module so they can register their hooks before we
+# fire ``apply_register_enhancements`` below. ``_registry`` is the seam
+# documented in ``IDEAL_API_SKETCH.md`` §1-§3.
+from peakrdl_pybind11 import runtime as _peakrdl_runtime
+from peakrdl_pybind11.runtime import _registry as _peakrdl_registry
 from peakrdl_pybind11.int_types import RegisterInt, FieldInt, RegisterIntFlag, RegisterIntEnum
+from peakrdl_pybind11.runtime import RegisterValue, FieldValue  # forward-compat aliases
 
 __all__ = [
     '{{ soc_name }}_t',
@@ -29,12 +36,17 @@ __all__ = [
     'FieldInt',
     'RegisterIntFlag',
     'RegisterIntEnum',
+    'RegisterValue',
+    'FieldValue',
 ]
 
 
 def create():
     """Create a new instance of the {{ soc_name }} register map."""
-    return {{ soc_name }}_t()
+    soc = {{ soc_name }}_t()
+    # Sibling units can attach observers, snapshot tooling, etc.
+    _peakrdl_registry.fire_post_create_hooks(soc)
+    return soc
 
 
 def wrap_master(master_impl):
@@ -73,7 +85,9 @@ def wrap_master(master_impl):
                 return impl_read_many(ops)
             return [self.impl.read(op.address, op.width) for op in ops]
 
-    return WrappedMaster()
+    wrapped = WrappedMaster()
+    _peakrdl_registry.fire_master_extensions(wrapped)
+    return wrapped
 
 
 # Generated flag/enum types from SystemRDL fields
@@ -109,11 +123,9 @@ __all__.append('{{ reg | pybind_name }}_e')
 
 
 # ---------------------------------------------------------------------------
-# Read/write enhancement
-#
-# Each generated register/field class is rewrapped at module-load time so
-# that .read() returns RegisterInt/FieldInt (instead of bare ints) and
-# .write() accepts FieldInt for read-modify-write.
+# Per-register field metadata. Consumed by the default register
+# enhancement (``runtime/_default_shims.py``) and by sibling units that
+# want to introspect register layout without re-parsing RDL.
 # ---------------------------------------------------------------------------
 
 _REGISTER_FIELDS: dict[type, dict[str, tuple[int, int]]] = {
@@ -158,115 +170,27 @@ _FIELD_CLASSES: tuple = (
 )
 
 
-def _enhanced_register_read(original_read, flag_type, enum_type, fields_spec):
-    def read(self):
-        value = original_read(self)
-        if flag_type is not None:
-            return flag_type(value)
-        if enum_type is not None:
-            return enum_type(value)
-        return RegisterInt(value, self.offset, self.width, fields_spec)
-    read.__peakrdl_enhanced__ = True
-    return read
-
-
-def _enhanced_register_write(original_write, original_modify):
-    def write(self, value):
-        if isinstance(value, FieldInt):
-            shifted = (int(value) << value.lsb) & value.mask
-            original_modify(self, shifted, value.mask)
-        else:
-            original_write(self, int(value))
-    write.__peakrdl_enhanced__ = True
-    return write
-
-
-def _enhanced_field_read(original_read):
-    def read(self):
-        return FieldInt(original_read(self), self.lsb, self.width, self.offset)
-    read.__peakrdl_enhanced__ = True
-    return read
-
-
-def _enhanced_field_write(original_write):
-    def write(self, value):
-        original_write(self, int(value))
-    write.__peakrdl_enhanced__ = True
-    return write
-
-
-def _make_write_fields(fields_spec, writable_spec):
-    """Build a ``write_fields(**kwargs)`` shim for a generated register class.
-
-    Collapses N per-field writes into a single C++ ``write_fields(mask, value)``
-    call (1 read + 1 write on the master, regardless of N). Validates field
-    names and writability at the Python boundary so the C++ side stays minimal.
-    """
-    def write_fields(self, **kwargs):
-        combined_mask = 0
-        combined_value = 0
-        for name, raw_value in kwargs.items():
-            spec = fields_spec.get(name)
-            if spec is None:
-                raise KeyError(
-                    f"Unknown field '{name}' on register '{self.name}'. "
-                    f"Known fields: {sorted(fields_spec)}"
-                )
-            if not writable_spec.get(name, False):
-                raise PermissionError(
-                    f"Field '{name}' on register '{self.name}' is not writable"
-                )
-            lsb, width = spec
-            field_mask = ((1 << width) - 1) << lsb
-            combined_mask |= field_mask
-            combined_value |= (int(raw_value) << lsb) & field_mask
-        # Single C++ entry: native RMW under the hood.
-        self._native_write_fields(combined_mask, combined_value)
-    return write_fields
-
-
-def _enhance_register_class(cls, fields_spec):
-    if getattr(cls.read, "__peakrdl_enhanced__", False):
-        return
-    raw_read = cls.read
-    raw_write = cls.write
-    cls.read = _enhanced_register_read(
-        raw_read,
-        _FLAG_REG_TYPES.get(cls),
-        _ENUM_REG_TYPES.get(cls),
-        fields_spec,
-    )
-    cls.write = _enhanced_register_write(raw_write, cls.modify)
-    # Fast-path scalar accessors: bypass RegisterInt wrapping / FieldInt
-    # handling. ``read_raw`` returns a plain ``int``; ``write_raw`` accepts
-    # a plain ``int`` and writes it directly via the underlying C++ method.
-    cls.read_raw = raw_read
-    cls.write_raw = raw_write
-    # Preserve native binding under a private name; expose Python shim with
-    # validation under the public name.
-    cls._native_write_fields = cls.write_fields
-    cls.write_fields = _make_write_fields(
-        fields_spec, _REGISTER_FIELD_WRITABLE.get(cls, {})
-    )
-
-
-def _enhance_field_class(cls):
-    if getattr(cls.read, "__peakrdl_enhanced__", False):
-        return
-    raw_read = cls.read
-    raw_write = cls.write
-    cls.read = _enhanced_field_read(raw_read)
-    cls.write = _enhanced_field_write(raw_write)
-    # Fast-path scalar accessors: ``read_raw`` returns a plain ``int`` (the
-    # field-space value, identical to what the C++ getter returns -- no
-    # ``FieldInt`` allocation). ``write_raw`` takes a plain ``int`` in
-    # field-space and forwards directly to the C++ setter (which performs
-    # the shift+mask+modify on the underlying register).
-    cls.read_raw = raw_read
-    cls.write_raw = raw_write
-
-
+# Apply every registered enhancement (defaults + sibling units). The
+# metadata dict carries everything the defaults need plus an open
+# extension surface so sibling units can read additional keys.
+# Wrapping is idempotent: each enhancement checks for ``__peakrdl_enhanced__``
+# (set by ``runtime/_default_shims.py``) and bails out on the second pass.
 for _reg_cls, _spec in _REGISTER_FIELDS.items():
-    _enhance_register_class(_reg_cls, _spec)
+    _peakrdl_registry.apply_register_enhancements(
+        _reg_cls,
+        {
+            "fields": _spec,
+            "writable": _REGISTER_FIELD_WRITABLE.get(_reg_cls, {}),
+            "flag_type": _FLAG_REG_TYPES.get(_reg_cls),
+            "enum_type": _ENUM_REG_TYPES.get(_reg_cls),
+        },
+    )
+
 for _field_cls in _FIELD_CLASSES:
-    _enhance_field_class(_field_cls)
+    _peakrdl_registry.apply_field_enhancements(_field_cls)
+
+# Wire any registered lazy node attributes onto the shared node base, if
+# one exists in this generated module. Sibling units that introduce a
+# base class will export it as ``_PEAKRDL_NODE_BASE``; until then we
+# pass ``None`` and the registry no-ops.
+_peakrdl_registry.attach_node_attributes(globals().get("_PEAKRDL_NODE_BASE"))

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PeakRDL-pybind11 runtime package and registry seam."""

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,169 @@
+"""Shared fixtures for ``tests/runtime/``.
+
+Three session-scoped fixtures are exposed:
+
+* ``tiny_rdl`` — yields the path to a small (3-register) RDL file written
+  to a tmpdir. Used by every unit-level test that needs *something* to
+  feed the exporter.
+* ``tiny_soc_built`` — exports ``tiny_rdl`` via
+  :class:`peakrdl_pybind11.exporter.Pybind11Exporter`, builds the C++
+  extension via cmake, imports the resulting module, and yields the SoC
+  handle. Skipped automatically if cmake is missing or the build fails.
+* ``mock_master`` — instantiates a :class:`MockMaster` and attaches it to
+  ``tiny_soc_built``.
+
+Tests that depend on ``tiny_soc_built`` should be marked
+``@pytest.mark.integration`` so the default unit-test run can opt out
+via ``-m "not integration"``. (Pytest 9 disallows applying marks to
+fixtures themselves, so the mark belongs on the test.)
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# A deliberately small RDL: three registers across two regfiles is enough
+# to exercise hierarchy, multiple field shapes, and a flag/enum register
+# without paying for cmake on every test that just needs the exporter.
+_TINY_RDL = """
+addrmap tiny_soc {
+    name = "Tiny SoC";
+    desc = "Three-register fixture for runtime unit tests";
+
+    reg {
+        name = "Control Register";
+        field { sw = rw; hw = r; } enable[0:0] = 0;
+        field { sw = rw; hw = r; } mode[3:1] = 0;
+    } control @ 0x0;
+
+    reg {
+        name = "Status Register";
+        field { sw = r; hw = w; } ready[0:0] = 0;
+    } status @ 0x4;
+
+    reg {
+        name = "Data Register";
+        field { sw = rw; hw = rw; } data[31:0] = 0;
+    } data @ 0x8;
+};
+"""
+
+
+@pytest.fixture(scope="session")
+def tiny_rdl(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Yield the path to a session-scoped 3-register RDL file."""
+    tmp_dir = tmp_path_factory.mktemp("tiny_rdl")
+    rdl_path = tmp_dir / "tiny.rdl"
+    rdl_path.write_text(_TINY_RDL)
+    return rdl_path
+
+
+def _have_cmake() -> bool:
+    return shutil.which("cmake") is not None
+
+
+@pytest.fixture(scope="session")
+def tiny_soc_built(
+    tiny_rdl: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
+) -> Iterator[Any]:
+    """Export ``tiny_rdl`` and build the C++ extension; yield the imported SoC.
+
+    Tests that depend on this fixture should be marked
+    ``@pytest.mark.integration`` so the default unit-test run can opt out
+    via ``-m "not integration"``. (Pytest 9 disallows marking fixtures
+    directly, so the marker lives on the test, not the fixture.)
+    Skipped if cmake is unavailable or the build fails.
+    """
+    if not _have_cmake():
+        pytest.skip("cmake not available; skipping native build fixture")
+
+    out_dir = tmp_path_factory.mktemp("tiny_soc_build")
+
+    # 1. Compile the RDL.
+    try:
+        from systemrdl import RDLCompiler
+
+        from peakrdl_pybind11.exporter import Pybind11Exporter
+    except ImportError as exc:
+        pytest.skip(f"required imports unavailable: {exc}")
+
+    rdlc = RDLCompiler()
+    Pybind11Exporter.register_udps(rdlc)
+    rdlc.compile_file(str(tiny_rdl))
+    root = rdlc.elaborate()
+
+    # 2. Export.
+    Pybind11Exporter().export(
+        root, output_dir=str(out_dir), soc_name="tiny_soc", split_bindings=0
+    )
+
+    # 3. Build via cmake (release / Python's discovered cmake).
+    try:
+        subprocess.run(
+            ["cmake", "-S", str(out_dir), "-B", str(out_dir / "build")],
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+        subprocess.run(
+            ["cmake", "--build", str(out_dir / "build"), "--config", "Release"],
+            check=True,
+            capture_output=True,
+            timeout=600,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f"cmake build failed: {exc}")
+
+    # 4. Move the built shared object next to the runtime so import works.
+    pkg_dir = out_dir / "tiny_soc"
+    build_dir = out_dir / "build"
+    found = list(build_dir.glob("**/_tiny_soc_native*"))
+    if not found:
+        pytest.skip("native module not found after cmake build")
+    for src in found:
+        if src.is_file():
+            shutil.copy2(src, pkg_dir / src.name)
+
+    # 5. Import.
+    sys.path.insert(0, str(out_dir))
+    try:
+        import importlib
+
+        module = importlib.import_module("tiny_soc")
+        soc = module.create()
+        yield soc
+    finally:
+        sys.path.remove(str(out_dir))
+
+
+@pytest.fixture()
+def mock_master(tiny_soc_built: Any) -> Any:
+    """A :class:`MockMaster` already attached to ``tiny_soc_built``.
+
+    Tests using this fixture should also be marked
+    ``@pytest.mark.integration``.
+    """
+    # The MockMaster class lives inside the generated module; per the
+    # docstring on ``masters/base.py`` we prefer the C++ trampoline-free
+    # version for in-memory fixtures.
+    soc = tiny_soc_built
+    master = soc.MockMaster() if hasattr(soc, "MockMaster") else None
+    if master is None:
+        pytest.skip("generated module exposes no MockMaster")
+    # ``soc.attach()`` is the API in IDEAL_API_SKETCH.md §13; sibling
+    # units may add it before any test actually exercises this fixture.
+    # If it's missing today, fall back to the existing ``set_master`` shape.
+    if hasattr(soc, "attach"):
+        soc.attach(master)
+    elif hasattr(soc, "set_master"):
+        soc.set_master(master)
+    return master

--- a/tests/runtime/test_registry.py
+++ b/tests/runtime/test_registry.py
@@ -1,0 +1,307 @@
+"""Unit tests for ``peakrdl_pybind11.runtime._registry``.
+
+These tests exercise the seam itself — no generated module, no cmake.
+They run by default and never opt into the ``integration`` mark.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from peakrdl_pybind11.runtime import _registry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Any:
+    """Snapshot every registry, run the test, then restore.
+
+    Without this every test would leave global state behind that the
+    next test would observe — and the registry is intentionally a
+    process-wide singleton (sibling units register at import time).
+    """
+    snap = _registry._snapshot()
+    yield
+    # Restore by replacing the lists/dicts in-place so any reference
+    # held elsewhere keeps pointing at the same object.
+    with _registry._lock:
+        _registry._register_enhancements[:] = snap["register_enhancements"]
+        _registry._field_enhancements[:] = snap["field_enhancements"]
+        _registry._post_create_hooks[:] = snap["post_create_hooks"]
+        _registry._master_extensions[:] = snap["master_extensions"]
+        _registry._node_attributes.clear()
+        _registry._node_attributes.update(snap["node_attributes"])
+        _registry._seen_register_enhancements.clear()
+        _registry._seen_register_enhancements.update(
+            id(fn) for fn in snap["register_enhancements"]
+        )
+        _registry._seen_field_enhancements.clear()
+        _registry._seen_field_enhancements.update(id(fn) for fn in snap["field_enhancements"])
+        _registry._seen_post_create_hooks.clear()
+        _registry._seen_post_create_hooks.update(id(fn) for fn in snap["post_create_hooks"])
+        _registry._seen_master_extensions.clear()
+        _registry._seen_master_extensions.update(id(fn) for fn in snap["master_extensions"])
+
+
+# ---------------------------------------------------------------------------
+# Decorator stores callable
+# ---------------------------------------------------------------------------
+
+
+def test_register_register_enhancement_stores_callable() -> None:
+    @_registry.register_register_enhancement
+    def hook(cls: type, metadata: dict) -> None:
+        pass
+
+    assert hook in _registry._snapshot()["register_enhancements"]
+
+
+def test_register_field_enhancement_stores_callable() -> None:
+    @_registry.register_field_enhancement
+    def hook(cls: type) -> None:
+        pass
+
+    assert hook in _registry._snapshot()["field_enhancements"]
+
+
+def test_register_post_create_stores_callable() -> None:
+    @_registry.register_post_create
+    def hook(soc: Any) -> None:
+        pass
+
+    assert hook in _registry._snapshot()["post_create_hooks"]
+
+
+def test_register_master_extension_stores_callable() -> None:
+    @_registry.register_master_extension
+    def hook(master: Any) -> None:
+        pass
+
+    assert hook in _registry._snapshot()["master_extensions"]
+
+
+def test_register_node_attribute_stores_callable() -> None:
+    @_registry.register_node_attribute("my_attr")
+    def factory(node: Any) -> str:
+        return "value"
+
+    assert "my_attr" in _registry._snapshot()["node_attributes"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-registering the same callable is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_re_registering_register_enhancement_does_not_duplicate() -> None:
+    def hook(cls: type, metadata: dict) -> None:
+        pass
+
+    _registry.register_register_enhancement(hook)
+    _registry.register_register_enhancement(hook)
+    matches = [fn for fn in _registry._snapshot()["register_enhancements"] if fn is hook]
+    assert len(matches) == 1
+
+
+def test_re_registering_field_enhancement_does_not_duplicate() -> None:
+    def hook(cls: type) -> None:
+        pass
+
+    _registry.register_field_enhancement(hook)
+    _registry.register_field_enhancement(hook)
+    matches = [fn for fn in _registry._snapshot()["field_enhancements"] if fn is hook]
+    assert len(matches) == 1
+
+
+def test_re_registering_post_create_does_not_duplicate() -> None:
+    def hook(soc: Any) -> None:
+        pass
+
+    _registry.register_post_create(hook)
+    _registry.register_post_create(hook)
+    matches = [fn for fn in _registry._snapshot()["post_create_hooks"] if fn is hook]
+    assert len(matches) == 1
+
+
+def test_re_registering_master_extension_does_not_duplicate() -> None:
+    def hook(master: Any) -> None:
+        pass
+
+    _registry.register_master_extension(hook)
+    _registry.register_master_extension(hook)
+    matches = [fn for fn in _registry._snapshot()["master_extensions"] if fn is hook]
+    assert len(matches) == 1
+
+
+# ---------------------------------------------------------------------------
+# Apply / fire functions actually invoke the registered callables
+# ---------------------------------------------------------------------------
+
+
+def test_apply_register_enhancements_invokes_hook() -> None:
+    seen: list[tuple[type, dict]] = []
+
+    @_registry.register_register_enhancement
+    def hook(cls: type, metadata: dict) -> None:
+        seen.append((cls, metadata))
+
+    class FakeReg:
+        pass
+
+    _registry.apply_register_enhancements(FakeReg, {"fields": {"a": (0, 1)}})
+    # The default shim plus our hook both ran; both received the same args.
+    matches = [item for item in seen if item[0] is FakeReg]
+    assert len(matches) == 1
+    assert matches[0][1] == {"fields": {"a": (0, 1)}}
+
+
+def test_apply_field_enhancements_invokes_hook() -> None:
+    seen: list[type] = []
+
+    @_registry.register_field_enhancement
+    def hook(cls: type) -> None:
+        seen.append(cls)
+
+    class FakeField:
+        pass
+
+    _registry.apply_field_enhancements(FakeField)
+    assert FakeField in seen
+
+
+def test_fire_post_create_hooks_invokes_hook() -> None:
+    seen: list[Any] = []
+
+    @_registry.register_post_create
+    def hook(soc: Any) -> None:
+        seen.append(soc)
+
+    fake_soc = object()
+    _registry.fire_post_create_hooks(fake_soc)
+    assert seen == [fake_soc]
+
+
+def test_fire_master_extensions_invokes_hook() -> None:
+    seen: list[Any] = []
+
+    @_registry.register_master_extension
+    def hook(master: Any) -> None:
+        seen.append(master)
+
+    fake_master = object()
+    _registry.fire_master_extensions(fake_master)
+    assert seen == [fake_master]
+
+
+# ---------------------------------------------------------------------------
+# attach_node_attributes wires lazy properties
+# ---------------------------------------------------------------------------
+
+
+def test_attach_node_attributes_with_none_is_noop() -> None:
+    # Should not raise.
+    _registry.attach_node_attributes(None)
+
+
+def test_attach_node_attributes_installs_lazy_property() -> None:
+    counter = {"calls": 0}
+
+    @_registry.register_node_attribute("computed")
+    def factory(node: Any) -> int:
+        counter["calls"] += 1
+        return 42
+
+    class Node:
+        pass
+
+    _registry.attach_node_attributes(Node)
+    n = Node()
+    assert n.computed == 42
+    assert n.computed == 42  # cached
+    assert counter["calls"] == 1
+
+
+def test_attach_node_attributes_does_not_overwrite_existing() -> None:
+    @_registry.register_node_attribute("info")
+    def factory(node: Any) -> str:
+        return "from-registry"
+
+    class Node:
+        info = "preset"  # explicit class attribute should win
+
+    _registry.attach_node_attributes(Node)
+    assert Node.info == "preset"
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery picks up modules under runtime/
+# ---------------------------------------------------------------------------
+
+
+def test_default_shims_are_registered() -> None:
+    """Importing ``peakrdl_pybind11.runtime`` must auto-load the default shims."""
+    # The runtime package is already loaded by the test session; verify
+    # the default shim functions are in the registries.
+    snap = _registry._snapshot()
+    register_names = {fn.__name__ for fn in snap["register_enhancements"]}
+    field_names = {fn.__name__ for fn in snap["field_enhancements"]}
+    assert "_default_register_shim" in register_names
+    assert "_default_field_shim" in field_names
+
+
+def test_auto_import_picks_up_fake_module() -> None:
+    """A new module dropped into ``runtime/`` is auto-imported on package load."""
+    import peakrdl_pybind11.runtime as runtime_pkg
+
+    fake_marker = "_test_auto_import_marker_42"
+
+    # Drop a fake sibling module next to ``_default_shims.py``.
+    pkg_dir = Path(runtime_pkg.__file__).parent
+    fake_path = pkg_dir / "_test_fake_sibling.py"
+    fake_path.write_text(
+        textwrap.dedent(
+            f"""
+            from peakrdl_pybind11.runtime import _registry
+
+            @_registry.register_register_enhancement
+            def {fake_marker}(cls, metadata):
+                pass
+            """
+        )
+    )
+
+    try:
+        # Reload the package so ``_auto_import_modules`` runs again.
+        importlib.reload(runtime_pkg)
+        snap = _registry._snapshot()
+        assert any(fn.__name__ == fake_marker for fn in snap["register_enhancements"])
+    finally:
+        fake_path.unlink(missing_ok=True)
+        # Pop the imported module so subsequent reloads don't see a stale
+        # cached copy.
+        sys.modules.pop(f"{runtime_pkg.__name__}._test_fake_sibling", None)
+
+
+# ---------------------------------------------------------------------------
+# Forward-compat aliases at the package level
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_re_exports_register_value_alias() -> None:
+    from peakrdl_pybind11 import int_types
+    from peakrdl_pybind11.runtime import FieldValue, RegisterValue
+
+    assert RegisterValue is int_types.RegisterInt
+    assert FieldValue is int_types.FieldInt
+
+
+def test_top_level_init_re_exports_value_aliases() -> None:
+    from peakrdl_pybind11 import FieldInt, FieldValue, RegisterInt, RegisterValue
+
+    assert RegisterValue is RegisterInt
+    assert FieldValue is FieldInt


### PR DESCRIPTION
## GATING UNIT — sibling units cannot pass tests until this lands

This is Unit 1 of the API overhaul (\`exp/api_overhaul\`). It establishes
the stable seam that 23 sibling units add to without conflict. Sibling
units that depend on \`runtime/\` modules, CLI/exporter-plugin discovery,
\`MasterBase\` extension methods, or the \`RegisterValue\`/\`FieldValue\`
forward-compat aliases need this merged first.

## Summary

- Central thread-safe hook registry (\`runtime/_registry.py\`) with
  decorator and apply/fire APIs for register/field enhancements,
  post-create hooks, master extensions, and lazy node attributes.
- Default register/field shims extracted from \`runtime.py.jinja\` into
  \`runtime/_default_shims.py\` so siblings can compose on top of (not
  replace) the existing typed-read/write/write_fields semantics.
- \`runtime/__init__.py\`, \`exporter_plugins/__init__.py\`,
  \`cli/__init__.py\` all use \`pkgutil.iter_modules\` auto-discovery so
  sibling-unit modules wire themselves automatically by simply existing.
  One bad sibling logs and is skipped — never breaks the package.
- \`runtime.py.jinja\` refactored to a thin shim that delegates to
  \`_registry.apply_*\`; per-register field metadata still baked in.
- \`MasterBase\` gains no-op \`peek\` / \`barrier\` / \`on_disconnect\` /
  \`set_retry_policy\` / \`cache_get\` / \`cache_set\` defaults so the
  \`runtime/bus_policies.py\` sibling can override without breaking
  existing concrete masters.
- \`pyproject.toml\` adds numpy as a hard dep (per §22.2), notebook extra
  (per §5.5), and a pytest \`integration\` marker.
- \`__init__.py\` re-exports \`RegisterValue\`/\`FieldValue\` aliases for
  forward-compat with the new vocabulary in §3 of the sketch.
- \`tests/runtime/test_registry.py\` (20 tests) verifies the seam in
  isolation; \`conftest.py\` provides session-scoped \`tiny_rdl\`,
  \`tiny_soc_built\`, \`mock_master\` fixtures that integration tests in
  sibling PRs can opt into via \`@pytest.mark.integration\`.

## Test plan

- [x] \`pytest tests/runtime/test_registry.py -v\` — 20/20 pass
- [x] \`pytest tests/\` — 96 pass, 27 skipped (pre-existing skip rate)
- [x] \`peakrdl pybind11 examples/example.rdl -o /tmp/smoke --soc-name SmokeSoC\`
      generates the expected \`__init__.py\` / \`__init__.pyi\`
- [x] \`python -c "from peakrdl_pybind11.runtime._registry import register_register_enhancement; print('seam ok')"\`
- [x] \`ruff check src/\` — clean (ANN401 selectively ignored on seam files)

## Notes for sibling units

- Default shims register **before** sibling-unit modules (underscore-prefix
  ordering in \`_auto_import_modules\`). Compose on top, don't replace.
- Failed sibling imports are logged and skipped, not raised. If your
  unit is silently inert, check the \`peakrdl_pybind11.runtime\` logger.
- \`attach_node_attributes(...)\` accepts \`None\` so siblings can call it
  unconditionally; it becomes meaningful once a sibling exposes
  \`_PEAKRDL_NODE_BASE\` from the generated module.
- \`mock_master\` fixture probes for \`soc.attach\`/\`soc.set_master\` —
  whichever your bus-layer unit actually exposes will be used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)