### PR TITLE
docs: wire Extending section into toctree

### DIFF
--- a/docs/extending/index.rst
+++ b/docs/extending/index.rst
@@ -1,0 +1,26 @@
+Extending PeakRDL-pybind11
+==========================
+
+PeakRDL-pybind11 ships three extension points sibling-unit code uses to add
+behaviour without modifying the core. Downstream tooling authors use the same
+seams.
+
+.. toctree::
+   :maxdepth: 1
+
+   runtime
+   exporter
+   cli
+
+Where to start
+--------------
+
+- :doc:`runtime` — register hook callbacks via
+  ``peakrdl_pybind11.runtime._registry`` to enhance generated register/field
+  classes, attach helpers post-create, or extend masters at attach time.
+- :doc:`exporter` — drop a plugin module into
+  ``peakrdl_pybind11.exporter_plugins`` to add a codegen pass (interrupt
+  detection, schema emission, custom output formats) without modifying
+  ``exporter.py``.
+- :doc:`cli` — drop a module into ``peakrdl_pybind11.cli`` to add CLI flags to
+  ``peakrdl pybind11`` (preempt the export, run something post-export, or both).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,6 +104,14 @@ in one place -- is available as a single document.
    concepts/cli_repl
 
 .. toctree::
+   :maxdepth: 1
+   :caption: Extending
+
+   extending/runtime
+   extending/exporter
+   extending/cli
+
+.. toctree::
    :maxdepth: 2
    :caption: API Reference
 


### PR DESCRIPTION
## Summary
- Adds a new "Extending" toctree group to `docs/index.rst` (between Concepts and API Reference) with three explicit entries: `extending/runtime`, `extending/exporter`, `extending/cli`.
- Adds `docs/extending/index.rst` as the section landing page with one-line descriptions of each extension seam.

## Sibling units
- Unit 11 (`docs/extending/runtime.rst`) — PR #115
- Unit 12 (`docs/extending/exporter.rst`) — PR #118
- Unit 13 (`docs/extending/cli.rst`) — PR #119

Sphinx warnings about missing `extending/runtime`, `extending/exporter`, `extending/cli` will resolve once those sibling PRs land.

## Test plan
- [x] `uv sync --group docs` succeeds
- [x] `cd docs && make html` succeeds (warnings about missing extending/* docs are expected until siblings land)
- [x] `_build/html/extending/index.html` renders
- [x] "Extending" caption appears on the index page