### PR TITLE
feat(runtime): auto-attach async_session via post-create hook (Unit 4 wire-up)

### DIFF
--- a/src/peakrdl_pybind11/runtime/async_session.py
+++ b/src/peakrdl_pybind11/runtime/async_session.py
@@ -384,3 +384,25 @@ def attach_async_session(soc: object) -> object:
     )
     soc.async_session = _factory  # type: ignore[attr-defined]
     return soc
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring (sibling-dep: Unit 1's runtime/_registry).
+#
+# When the registry seam is present we register ``attach_async_session`` as
+# a post-create hook so every ``MySoc.create()`` automatically gains the
+# ``soc.async_session()`` factory. When it isn't (this unit can land before
+# Unit 1), the import quietly fails and callers can still use
+# ``attach_async_session(soc)`` explicitly.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - depends on Unit 1 landing order
+    from . import _registry  # type: ignore[attr-defined]
+except ImportError:
+    _registry = None  # type: ignore[assignment]
+
+if _registry is not None and hasattr(_registry, "register_post_create"):
+    # ``attach_async_session`` returns ``object`` for chaining; the registry
+    # expects a ``Callable[[Any], None]``. The return value is discarded by
+    # ``_fire``, so the mismatch is purely nominal.
+    _registry.register_post_create(attach_async_session)  # type: ignore[arg-type]

--- a/tests/runtime/test_async_session.py
+++ b/tests/runtime/test_async_session.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import pytest
 
+from peakrdl_pybind11.runtime import _registry
 from peakrdl_pybind11.runtime.async_session import (
     AsyncSession,
     attach_async_session,
@@ -128,6 +129,31 @@ class TestRegisterPostCreate:
         attach_async_session(soc)
         attach_async_session(soc)
         assert callable(soc.async_session)  # type: ignore[attr-defined]
+
+
+class TestPostCreateHookWiring:
+    """Verify ``attach_async_session`` is wired as a post-create hook so
+    every generated SoC gains ``soc.async_session()`` automatically.
+    """
+
+    def test_attach_async_session_is_registered_post_create_hook(self) -> None:
+        # Re-register defensively: the registry is idempotent on identity,
+        # but a prior test that called ``_reset_for_tests`` would otherwise
+        # leave us with an empty list.
+        _registry.register_post_create(attach_async_session)
+        hooks = _registry.get_post_create_hooks()
+        assert attach_async_session in hooks
+
+    def test_firing_post_create_hooks_attaches_async_session(self) -> None:
+        # Drive the registry path -- not ``attach_async_session`` directly
+        # -- to prove generated SoCs pick up the factory through Unit 1's
+        # seam.
+        _registry.register_post_create(attach_async_session)
+        bare = _FakeSoc()
+        assert not hasattr(bare, "async_session")
+        _registry.fire_post_create_hooks(bare)
+        assert callable(bare.async_session)  # type: ignore[attr-defined]
+        assert isinstance(bare.async_session(), AsyncSession)  # type: ignore[attr-defined]
 
 
 class TestContextManager:


### PR DESCRIPTION
## Summary
- Register ``attach_async_session`` as a runtime post-create hook at module load, mirroring the wiring pattern in ``runtime/trace.py`` so every generated ``MySoc.create(...)`` gains a working ``soc.async_session()`` factory automatically.
- Keep the existing graceful fallback: the registration is guarded by a ``try/except ImportError`` and a ``hasattr(_registry, "register_post_create")`` check so ``async_session.py`` still imports cleanly on branches where the registry seam has not landed.
- Extend ``tests/runtime/test_async_session.py`` with a ``TestPostCreateHookWiring`` class that asserts (a) ``attach_async_session`` is in ``_registry.get_post_create_hooks()`` and (b) firing the post-create hooks against a bare ``_FakeSoc`` makes ``soc.async_session`` callable and yields a real ``AsyncSession``.

## Test plan
- [x] ``uv sync --group test --extra cli --extra notebook``
- [x] ``uvx ruff check src/peakrdl_pybind11/runtime/async_session.py``
- [x] ``uvx pyrefly check src/`` (0 errors)
- [x] ``.venv/bin/python -m pytest tests/runtime/test_async_session.py -v`` (27 passed)
- [x] ``.venv/bin/python -m pytest tests/runtime/`` (702 passed -- no regressions)
- [x] Smoke check: ``async_session post-create hook registered``

🤖 Generated with [Claude Code](https://claude.com/claude-code)