### PR TITLE
feat(runtime): auto-attach snapshot via post-create hook (Unit 2 wire-up)

### DIFF
--- a/src/peakrdl_pybind11/runtime/snapshot.py
+++ b/src/peakrdl_pybind11/runtime/snapshot.py
@@ -706,3 +706,22 @@ def _is_jsonable(value: Any) -> bool:
     if isinstance(value, dict):
         return all(isinstance(k, str) and _is_jsonable(v) for k, v in value.items())
     return False
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring (sibling-dep: Unit 1's runtime/_registry).
+#
+# When the registry seam is present we register ``attach_snapshot`` as a
+# post-create hook so every ``MySoc.create()`` automatically gains the
+# ``soc.snapshot()`` and ``soc.restore()`` helpers. When it isn't (this
+# unit can land before Unit 1), the import quietly fails and callers can
+# still use ``attach_snapshot(soc)`` explicitly.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - depends on Unit 1 landing order
+    from . import _registry  # type: ignore[attr-defined]
+except ImportError:
+    _registry = None  # type: ignore[assignment]
+
+if _registry is not None and hasattr(_registry, "register_post_create"):
+    _registry.register_post_create(attach_snapshot)

--- a/tests/runtime/test_snapshot.py
+++ b/tests/runtime/test_snapshot.py
@@ -549,3 +549,37 @@ class TestHTMLRepr:
         diff = SnapshotDiff(changed={}, added={}, removed={})
         html = diff._repr_html_()
         assert "no differences" in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auto-attach via post-create hook
+# ---------------------------------------------------------------------------
+
+
+class TestAutoAttach:
+    """``attach_snapshot`` must be wired as a registry post-create hook so
+    every ``MySoc.create()`` automatically gains ``soc.snapshot()`` /
+    ``soc.restore()`` without callers having to invoke ``attach_snapshot``
+    by hand."""
+
+    def test_attach_snapshot_is_registered_post_create_hook(self) -> None:
+        from peakrdl_pybind11.runtime import _registry
+
+        names = [fn.__name__ for fn in _registry.get_post_create_hooks()]
+        assert "attach_snapshot" in names, names
+
+    def test_fire_post_create_hooks_binds_snapshot_methods(self) -> None:
+        from peakrdl_pybind11.runtime import _registry
+
+        soc = _Soc()
+        soc.add(_Reg("uart.control", value=0x22, access="rw"))
+        # Sanity: no explicit attach_snapshot(soc) — the registry must do it.
+        assert not hasattr(soc, "snapshot")
+
+        _registry.fire_post_create_hooks(soc)
+
+        assert callable(getattr(soc, "snapshot", None))
+        assert callable(getattr(soc, "restore", None))
+        # Snapshot bound on this fake soc captures the register value.
+        snap = soc.snapshot()
+        assert snap["uart.control"] == 0x22


### PR DESCRIPTION
## Summary
- Register `attach_snapshot` as a post-create hook at module load so every `MySoc.create()` automatically binds `soc.snapshot()` / `soc.restore()` without callers having to invoke `attach_snapshot(soc)` by hand.
- Mirrors the canonical pattern from `trace.py` (try/except import of `_registry`, then `_registry.register_post_create(...)`), so the wiring degrades gracefully when the registry seam isn't importable.
- Re-registration is idempotent via `_register_unique`, so repeated imports are safe.

## Test plan
- [x] `uvx ruff check src/peakrdl_pybind11/runtime/snapshot.py` clean
- [x] `uvx pyrefly check src/` reports 0 errors
- [x] `pytest tests/runtime/test_snapshot.py -v` passes (34 tests, including 2 new `TestAutoAttach` cases)
- [x] Full `pytest tests/runtime/` suite passes (702 tests) — confirms no test-isolation regression
- [x] Smoke check: `from peakrdl_pybind11.runtime import _registry; assert 'attach_snapshot' in [fn.__name__ for fn in _registry.get_post_create_hooks()]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)