### PR TITLE
feat(runtime): auto-attach observers via post-create hook (Unit 3 wire-up)

### DIFF
--- a/src/peakrdl_pybind11/runtime/observers.py
+++ b/src/peakrdl_pybind11/runtime/observers.py
@@ -30,7 +30,7 @@ from collections import Counter
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -405,3 +405,41 @@ def attach_observers(soc: object, chain: ObserverChain | None = None) -> Observe
     soc.observers = chain  # type: ignore[attr-defined]
     soc.observe = chain.observe  # type: ignore[attr-defined,method-assign]
     return chain
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring (sibling-dep: Unit 1's runtime/_registry).
+#
+# When the registry seam is present we register a post-create hook so every
+# ``MySoc.create()`` automatically gains ``soc.observers`` and
+# ``soc.observe()`` without callers having to invoke
+# ``attach_observers(soc)`` by hand. When the seam isn't yet available
+# (this unit can land before Unit 1), the import quietly fails and callers
+# can still wire the chain explicitly.
+#
+# A thin adapter is registered (rather than ``attach_observers`` directly)
+# so the post-create signature ``(soc) -> None`` is matched exactly: the
+# underlying helper takes an optional ``chain=`` kwarg and returns the
+# chain.
+# ---------------------------------------------------------------------------
+
+
+def _post_create_attach_observers(soc: Any) -> None:
+    """Post-create adapter for :func:`attach_observers`.
+
+    The registry's ``PostCreateHook`` protocol is ``(soc) -> None``;
+    :func:`attach_observers` carries a ``chain=`` kwarg and returns the
+    chain. This shim discards both so the registered callable matches the
+    seam's signature exactly.
+    """
+
+    attach_observers(soc)
+
+
+try:  # pragma: no cover - depends on Unit 1 landing order
+    from . import _registry  # type: ignore[attr-defined]
+except ImportError:
+    _registry = None  # type: ignore[assignment]
+
+if _registry is not None and hasattr(_registry, "register_post_create"):
+    _registry.register_post_create(_post_create_attach_observers)

--- a/tests/runtime/test_observers.py
+++ b/tests/runtime/test_observers.py
@@ -380,3 +380,39 @@ class TestRegistrationHelpers:
         wired_soc.master.read(0x00, 4)
         wired_soc.master.write(0x00, 1, 4)
         assert sentinel == [], "Event constructed despite an empty chain"
+
+
+# ---------------------------------------------------------------------------
+# Auto-attach via the post-create registry seam (Unit 1)
+# ---------------------------------------------------------------------------
+
+
+class TestPostCreateAutoAttach:
+    """``attach_observers`` is registered as a post-create hook so a freshly
+    built ``MySoc.create()`` already exposes ``soc.observers`` / ``soc.observe``
+    without callers having to invoke :func:`attach_observers` themselves.
+    """
+
+    def test_attach_observers_registered_as_post_create_hook(self) -> None:
+        # Importing the runtime package auto-imports ``observers`` which in
+        # turn registers the hook against the ``_registry`` seam.
+        from peakrdl_pybind11.runtime import _registry
+
+        hooks = _registry.get_post_create_hooks()
+        assert any(
+            "observers" in fn.__name__ or "observers" in fn.__qualname__
+            for fn in hooks
+        ), [fn.__qualname__ for fn in hooks]
+
+    def test_post_create_hook_makes_soc_observe_usable(self) -> None:
+        # Build a minimal fake SoC, fire the registry's post-create chain,
+        # and confirm ``soc.observers`` / ``soc.observe()`` work afterwards.
+        from peakrdl_pybind11.runtime import _registry
+
+        soc: Any = type("FakeSoC", (), {})()
+        _registry.fire_post_create_hooks(soc)
+
+        assert isinstance(soc.observers, ObserverChain)
+        with soc.observe() as obs:
+            pass
+        assert isinstance(obs, ObserverScope)


### PR DESCRIPTION
## Summary
- Register a post-create adapter in `runtime/observers.py` so every `MySoc.create()` automatically receives `soc.observers` and `soc.observe()` — no manual `attach_observers(soc)` needed.
- Mirrors the canonical `trace.py` try/except registration pattern; a thin `_post_create_attach_observers` shim matches the registry's `(soc) -> None` post-create signature exactly (since `attach_observers` itself returns the chain and carries an optional `chain=` kwarg).
- Extends `tests/runtime/test_observers.py` with `TestPostCreateAutoAttach`: verifies the hook is registered via `_registry.get_post_create_hooks()` and that firing it on a fake SoC leaves `soc.observers` / `soc.observe()` usable.

## Test plan
- [x] `uvx ruff check src/peakrdl_pybind11/runtime/observers.py` — clean
- [x] `uvx pyrefly check src/` — 0 errors
- [x] `pytest tests/runtime/test_observers.py -v` — 24 passed (including 2 new)
- [x] `pytest tests/runtime/` — 702 passed
- [x] One-liner verification: `from peakrdl_pybind11.runtime import _registry; ...` finds the hook by name

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code