### PR TITLE
feat(runtime): default shim emits RegisterValue/FieldValue (Unit 1 wire-up)

### DIFF
--- a/src/peakrdl_pybind11/__init__.py
+++ b/src/peakrdl_pybind11/__init__.py
@@ -12,13 +12,7 @@ if TYPE_CHECKING:
     from .exporter import Pybind11Exporter
     from .int_types import FieldInt, RegisterInt, RegisterIntEnum, RegisterIntFlag
     from .runtime.transactions import Burst, Read, Write
-
-    # Forward-compat aliases (see ``IDEAL_API_SKETCH.md`` §3): RegisterValue
-    # and FieldValue are the names used in the new API surface; they alias
-    # the existing ``RegisterInt`` / ``FieldInt`` types so user code can be
-    # ported to the new vocabulary without behavioural change.
-    RegisterValue = RegisterInt
-    FieldValue = FieldInt
+    from .runtime.values import FieldValue, RegisterValue
 
 try:
     __version__ = version("peakrdl-pybind11")

--- a/src/peakrdl_pybind11/runtime/__init__.py
+++ b/src/peakrdl_pybind11/runtime/__init__.py
@@ -20,11 +20,17 @@ Auto-import contract:
   package continues — one bad sibling must not break the whole runtime
   surface for downstream users.
 
-The package also re-exports ``RegisterValue`` / ``FieldValue`` as aliases
-for ``RegisterInt`` / ``FieldInt`` so the new API vocabulary is available
-from a stable import path::
+The package re-exports ``RegisterValue`` / ``FieldValue`` from
+:mod:`peakrdl_pybind11.runtime.values` so the new API vocabulary is
+available from a stable import path::
 
     from peakrdl_pybind11.runtime import RegisterValue, FieldValue
+
+These are the immutable, hashable ``int`` subclasses that the default
+shim (see :mod:`peakrdl_pybind11.runtime._default_shims`) emits from
+``register.read()`` / ``field.read()``. The legacy
+``peakrdl_pybind11.int_types.RegisterInt`` / ``FieldInt`` types remain
+importable for code that constructs them directly.
 """
 
 from __future__ import annotations
@@ -33,9 +39,8 @@ import importlib
 import logging
 import pkgutil
 
-from ..int_types import FieldInt as FieldValue
-from ..int_types import RegisterInt as RegisterValue
 from . import _registry
+from .values import FieldValue, RegisterValue
 
 logger = logging.getLogger("peakrdl_pybind11.runtime")
 

--- a/src/peakrdl_pybind11/runtime/_default_shims.py
+++ b/src/peakrdl_pybind11/runtime/_default_shims.py
@@ -8,9 +8,14 @@ and they will compose: defaults run first (they wrap the bare C++
 ``read``/``write`` into Python shims), then sibling-unit enhancements
 layer on additional behaviour.
 
-The semantics of the default shims are intentionally identical to the
-pre-overhaul template, so the existing ``tests/test_*`` integration suite
-continues to pass.
+This module is the **seam where the new API takes effect**: register
+reads return :class:`peakrdl_pybind11.runtime.values.RegisterValue` and
+field reads return :class:`peakrdl_pybind11.runtime.values.FieldValue`
+(both immutable, hashable ``int`` subclasses with ``.hex()``, ``.bin()``,
+``.replace(**fields)``, ``.table()`` etc.). The legacy
+``RegisterInt`` / ``FieldInt`` types in :mod:`peakrdl_pybind11.int_types`
+remain importable for code that constructs them directly, but the shim
+no longer emits them. See ``docs/IDEAL_API_SKETCH.md`` §3.2.
 """
 
 from __future__ import annotations
@@ -19,8 +24,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from ..int_types import FieldInt, RegisterInt
 from . import _registry
+from .values import FieldValue, RegisterValue
 
 logger = logging.getLogger("peakrdl_pybind11.runtime.default_shims")
 
@@ -42,7 +47,16 @@ def _enhanced_register_read(
             return flag_type(value)
         if enum_type is not None:
             return enum_type(value)
-        return RegisterInt(value, self.offset, self.width, fields_spec)
+        # ``self.width`` from the C++ ``RegisterBase`` is in bytes; the
+        # ``RegisterValue`` constructor masks against ``(1 << width) - 1``
+        # which expects bits. Multiply once at the seam.
+        return RegisterValue(
+            value,
+            address=self.offset,
+            width=self.width * 8,
+            fields=fields_spec,
+            name=getattr(self, "name", None),
+        )
 
     setattr(read, _ENHANCED, True)
     return read
@@ -53,7 +67,7 @@ def _enhanced_register_write(
     original_modify: Callable[[Any, int, int], None],
 ) -> Callable[[Any, Any], None]:
     def write(self: Any, value: Any) -> None:
-        if isinstance(value, FieldInt):
+        if isinstance(value, FieldValue):
             shifted = (int(value) << value.lsb) & value.mask
             original_modify(self, shifted, value.mask)
         else:
@@ -63,9 +77,17 @@ def _enhanced_register_write(
     return write
 
 
-def _enhanced_field_read(original_read: Callable[..., int]) -> Callable[[Any], FieldInt]:
-    def read(self: Any) -> FieldInt:
-        return FieldInt(original_read(self), self.lsb, self.width, self.offset)
+def _enhanced_field_read(original_read: Callable[..., int]) -> Callable[[Any], FieldValue]:
+    def read(self: Any) -> FieldValue:
+        # Field ``width`` from C++ ``FieldBase`` is in bits — feed it to
+        # ``FieldValue`` directly. ``offset`` is the parent register's
+        # address; we surface it as ``register_path`` for diagnostics.
+        return FieldValue(
+            original_read(self),
+            lsb=self.lsb,
+            width=self.width,
+            name=getattr(self, "name", None),
+        )
 
     setattr(read, _ENHANCED, True)
     return read
@@ -146,7 +168,7 @@ def _default_register_shim(cls: type, metadata: dict) -> None:
         return
     cls.read = _enhanced_register_read(raw_read, flag_type, enum_type, fields_spec)  # type: ignore[method-assign]
     cls.write = _enhanced_register_write(raw_write, cls.modify)  # type: ignore[method-assign]
-    # Fast-path scalar accessors: bypass RegisterInt wrapping / FieldInt
+    # Fast-path scalar accessors: bypass RegisterValue wrapping / FieldValue
     # handling. ``read_raw`` returns a plain ``int``; ``write_raw`` accepts
     # a plain ``int`` and writes it directly via the underlying C++ method.
     cls.read_raw = raw_read  # type: ignore[attr-defined]
@@ -178,7 +200,7 @@ def _default_field_shim(cls: type) -> None:
     cls.write = _enhanced_field_write(raw_write)  # type: ignore[method-assign]
     # Fast-path scalar accessors: ``read_raw`` returns a plain ``int`` (the
     # field-space value, identical to what the C++ getter returns -- no
-    # ``FieldInt`` allocation). ``write_raw`` takes a plain ``int`` in
+    # ``FieldValue`` allocation). ``write_raw`` takes a plain ``int`` in
     # field-space and forwards directly to the C++ setter (which performs
     # the shift+mask+modify on the underlying register).
     cls.read_raw = raw_read  # type: ignore[attr-defined]


### PR DESCRIPTION
Recovered from rate-limited agent.