### PR TITLE
feat: addrmap array support (#137 / #138 follow-up)

### DIFF
--- a/src/peakrdl_pybind11/exporter.py
+++ b/src/peakrdl_pybind11/exporter.py
@@ -22,8 +22,6 @@ from systemrdl.node import (
     SignalNode,
 )
 
-from .runtime.errors import NotSupportedError
-
 # Words that cannot be used as identifiers in either Python or C++.
 #
 # We deliberately use only ``keyword.kwlist`` (hard Python keywords) and skip
@@ -186,7 +184,7 @@ class ArrayInfo(TypedDict):
     """
 
     kind: str
-    node: RegNode | RegfileNode
+    node: RegNode | RegfileNode | AddrmapNode
     dimensions: list[int]
     stride: int
     strides: list[int]
@@ -245,10 +243,10 @@ class Nodes(TypedDict):
     #   post-create hook that swaps the raw C++ array node for an
     #   :class:`ArrayView` wrapper.
     #
-    # Phase 2 scope: 1-D register arrays + 1-D regfile arrays at the
-    # SoC root or under non-arrayed regfiles. Multi-dim, addrmap arrays,
-    # field arrays, and arrays nested inside another array still raise
-    # :class:`NotSupportedError` in ``_collect_nodes``.
+    # Current scope: 1-D and multi-dim register / regfile / addrmap
+    # arrays at the SoC root or under non-arrayed parents. Field arrays
+    # use a separate ``FieldArray`` runtime wrapper (Phase 4 of issue
+    # #138) and aren't tracked here.
     arrays: list["ArrayInfo"]
     # Phase 1 back-compat alias. Populated as the ``kind == "reg"``
     # subset of ``arrays``; downstream code that hasn't been migrated
@@ -827,20 +825,37 @@ class Pybind11Exporter:
                 "reg_arrays": [],
             }
 
-        # Tier 0 stop-gap (issue #137 / #138). Phase 2 handles 1-D
-        # register + regfile arrays; addrmap arrays remain Phase 3+ and
-        # surface a clear error so users see a useful message rather
-        # than a cryptic systemrdl crash deep in the template.
-        if isinstance(node, AddrmapNode) and node.is_array:
-            raise NotSupportedError(
-                f"Addrmap arrays are not yet supported "
-                f"({node.get_path()!r}). Tracked at "
-                f"https://github.com/arnavsacheti/PeakRDL-pybind11/issues/137; "
-                f"design at #138. Phase 3 of the Tier 3 plan lands these."
-            )
-
         if isinstance(node, AddrmapNode):
+            # Arrayed addrmap (issues #137 / #138 follow-up). Treated as
+            # the regfile-array path's twin — same ``ArrayInfo`` shape,
+            # same ``ArrayBase<entry_t>`` C++ codegen, but with
+            # ``kind="addrmap"`` so the descriptor partial routed by
+            # kind picks the right include order (after ``addrmaps.hpp``,
+            # before ``top_node.hpp``).
+            if node.is_array and node != self.top_node:
+                dims = list(node.array_dimensions or [])
+                inner_stride = node.array_stride
+                if inner_stride is None:
+                    inner_stride = int(node.size)
+                strides = _compute_per_axis_strides(dims, int(inner_stride))
+                nodes["arrays"].append(
+                    {
+                        "kind": "addrmap",
+                        "node": node,
+                        "dimensions": dims,
+                        "stride": strides[-1] if strides else int(inner_stride),
+                        "strides": strides,
+                        "relative_offset": int(node.raw_address_offset),
+                    }
+                )
+
             nodes["addrmaps"].append(node)
+            # Descend into children even when the addrmap is arrayed.
+            # ``node.children()`` on an arrayed addrmap yields child
+            # nodes with ``current_idx=0`` unrolled, so the inner
+            # registers / regfiles get a bound index for their own
+            # ``address_offset``. Required so each child's C++ class
+            # is emitted exactly once regardless of array size.
             for child in node.children():
                 # ``SignalNode`` children of an addrmap/regfile have no
                 # relevant descendants for us; track them flat and skip

--- a/src/peakrdl_pybind11/templates/bindings.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings.cpp.jinja
@@ -246,6 +246,13 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     {% endif %}
     {% endfor %}
 
+    // Addrmap array classes (issues #137 / #138 follow-up). Twin of the
+    // regfile-array bindings above — pybind11 needs the addrmap entry
+    // class bound before its array container.
+    {% for array in nodes.arrays if array.kind == "addrmap" %}
+    {{ array_levels_binding(array) }}
+    {% endfor %}
+
     {% for mem in nodes.mems %}
     {%- set entry_reg = mem.children()|list|first %}
     // Memory class: {{ mem.get_path() }}

--- a/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
+++ b/src/peakrdl_pybind11/templates/bindings_main.cpp.jinja
@@ -242,6 +242,13 @@ PYBIND11_MODULE(_{{ soc_name }}_native, m) {
     {% endif %}
     {% endfor %}
 
+    // Addrmap array classes (issues #137 / #138 follow-up). Twin of the
+    // regfile-array bindings above — pybind11 needs the addrmap entry
+    // class bound before its array container.
+    {% for array in nodes.arrays if array.kind == "addrmap" %}
+    {{ array_levels_binding(array) }}
+    {% endfor %}
+
     {% for mem in nodes.mems %}
     {%- set entry_reg = mem.children()|list|first %}
     // Memory class: {{ mem.get_path() }}

--- a/src/peakrdl_pybind11/templates/descriptors.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors.hpp.jinja
@@ -61,6 +61,14 @@ class FieldBase;
 
 {% include "descriptors/addrmaps.hpp.jinja" %}
 
+{# Addrmap-array typedefs land here, *after* ``addrmaps.hpp.jinja``.
+   Same complete-type constraint as ``regfile_arrays.hpp.jinja``:
+   ``ArrayBase<<am>_t>`` carries ``std::vector<<am>_t>`` and needs
+   ``<am>_t`` to be complete. Emitted *before* ``top_node.hpp.jinja``
+   so the SoC class can reference ``<am>_array_t`` member types.
+#}
+{% include "descriptors/addrmap_arrays.hpp.jinja" %}
+
 {% include "descriptors/top_node.hpp.jinja" %}
 
 } // namespace {{ soc_name }}

--- a/src/peakrdl_pybind11/templates/descriptors/addrmap_arrays.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/addrmap_arrays.hpp.jinja
@@ -1,0 +1,62 @@
+{# Per-array C++ class for addrmap arrays. Twin of
+   ``regfile_arrays.hpp.jinja`` but bound to ``kind == "addrmap"``
+   entries. Must be included **after** ``addrmaps.hpp.jinja`` — the
+   ``std::vector<<am>_t>`` inside ``ArrayBase`` needs the addrmap
+   entry type to be complete (sizeof must be known), and forward
+   declarations don't suffice. Must be included **before**
+   ``top_node.hpp.jinja`` so the top SoC class can reference
+   ``<am>_array_t`` as a member type.
+
+   1-D shapes emit a single ``<am>_array_t`` class. Multi-dim shapes
+   emit ``N`` nested ``ArrayBase`` subclasses, one per axis, with
+   the same naming convention (``_inner_<level>_array_t``,
+   innermost = level 0) as the register / regfile paths.
+#}
+{% for array in nodes.arrays if array.kind == "addrmap" %}
+{% set _entry_name = array.node | pybind_name %}
+{% set _entry_t = _entry_name ~ "_t" %}
+{% set _dims = array.dimensions %}
+{% set _strides = array.strides %}
+{% if _dims | length == 1 %}
+// Addrmap array (1-D): {{ array.node.get_path() }}
+class {{ _entry_name }}_array_t : public ArrayBase<{{ _entry_t }}> {
+public:
+    {{ _entry_name }}_array_t(uint64_t base_offset)
+        : ArrayBase<{{ _entry_t }}>(
+              "{{ array.node.inst_name | safe_id }}", base_offset,
+              0x{{ "%x" | format(array.relative_offset) }},
+              {{ _dims[0] }}, {{ _strides[0] }}) {}
+};
+
+{% else %}
+// Addrmap array (multi-dim, {{ _dims | length }}-D): {{ array.node.get_path() }}
+class {{ _entry_name }}_inner_0_array_t : public ArrayBase<{{ _entry_t }}> {
+public:
+    {{ _entry_name }}_inner_0_array_t(uint64_t base_offset)
+        : ArrayBase<{{ _entry_t }}>(
+              "", base_offset, 0x0,
+              {{ _dims[-1] }}, {{ _strides[-1] }}) {}
+};
+
+{% for level in range(1, _dims | length - 1) %}
+{% set axis_idx = _dims | length - 1 - level %}
+class {{ _entry_name }}_inner_{{ level }}_array_t : public ArrayBase<{{ _entry_name }}_inner_{{ level - 1 }}_array_t> {
+public:
+    {{ _entry_name }}_inner_{{ level }}_array_t(uint64_t base_offset)
+        : ArrayBase<{{ _entry_name }}_inner_{{ level - 1 }}_array_t>(
+              "", base_offset, 0x0,
+              {{ _dims[axis_idx] }}, {{ _strides[axis_idx] }}) {}
+};
+
+{% endfor %}
+class {{ _entry_name }}_array_t : public ArrayBase<{{ _entry_name }}_inner_{{ _dims | length - 2 }}_array_t> {
+public:
+    {{ _entry_name }}_array_t(uint64_t base_offset)
+        : ArrayBase<{{ _entry_name }}_inner_{{ _dims | length - 2 }}_array_t>(
+              "{{ array.node.inst_name | safe_id }}", base_offset,
+              0x{{ "%x" | format(array.relative_offset) }},
+              {{ _dims[0] }}, {{ _strides[0] }}) {}
+};
+
+{% endif %}
+{% endfor %}

--- a/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
+++ b/src/peakrdl_pybind11/templates/descriptors/addrmaps.hpp.jinja
@@ -3,8 +3,12 @@
 // Addrmap: {{ addrmap.get_path() }}
 class {{ addrmap | pybind_name }}_t : public NodeBase {
 public:
+    {# An arrayed addrmap's entry class carries no relative offset of its
+       own — its absolute offset is computed by ``ArrayBase`` as
+       ``offset_ + i * stride``. Mirrors the regfiles partial.
+    #}
     {{ addrmap | pybind_name }}_t(uint64_t base_offset)
-        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset, 0x{{ "%x" | format(addrmap.address_offset) }}) {
+        : NodeBase("{{ addrmap.inst_name | safe_id }}", base_offset, 0x{{ "%x" | format(0 if addrmap.is_array else addrmap.address_offset) }}) {
         {% for child in addrmap.children() %}
         {% if child.inst_name %}
         {{ child.inst_name | safe_id }}.set_master(master_);

--- a/tests/test_array_codegen.py
+++ b/tests/test_array_codegen.py
@@ -1,27 +1,18 @@
-"""Unit tests for register- and regfile-array codegen (issue #138).
+"""Unit tests for register / regfile / addrmap array codegen (issue #138).
 
 These exercise the exporter and Jinja templates without building any
 C++. The companion ``test_array_integration.py`` builds the generated
 module and validates the runtime surface; that one is gated on cmake +
 pybind11 availability and may skip in CI.
-
-Stop-gap coverage (addrmap / multi-dim / field arrays) is included
-here because the ``NotSupportedError`` raises directly from the
-exporter — no build needed. Phase 2 (issue #138) flips the regfile-
-array stop-gap from ``NotSupportedError`` to working codegen; the
-unit assertions for that live in :class:`TestRegfileArrayDescriptorEmission`
-and :class:`TestRegfileArrayBindingEmission` below.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from systemrdl import RDLCompiler
 
 from peakrdl_pybind11 import Pybind11Exporter
-from peakrdl_pybind11.runtime.errors import NotSupportedError
 
 
 SIMPLE_ARRAY_RDL = """
@@ -97,6 +88,33 @@ addrmap cube_soc {
     reg {
         field { sw=rw; hw=r; } data[31:0] = 0;
     } cube[2][3][4] @ 0x100;
+};
+"""
+
+# Addrmap array (issues #137 / #138 follow-up). The inner addrmap holds
+# a single register; arraying it produces two indistinguishable blocks
+# with their own ``ctrl`` register at index*stride.
+ADDRMAP_ARRAY_RDL = """
+addrmap inner {
+    reg {
+        field { sw=rw; hw=r; } data[31:0] = 0;
+    } ctrl @ 0x0;
+};
+addrmap am_array_soc {
+    inner blocks[2] @ 0x100;
+};
+"""
+
+# 2-D addrmap array. Inner stride = addrmap size = 4 bytes; outer
+# stride = 3 * 4 = 12 bytes.
+MULTIDIM_ADDRMAP_RDL = """
+addrmap inner_mdim {
+    reg {
+        field { sw=rw; hw=r; } data[31:0] = 0;
+    } ctrl @ 0x0;
+};
+addrmap am_multidim_soc {
+    inner_mdim blocks[2][3] @ 0x200;
 };
 """
 
@@ -233,35 +251,6 @@ class TestStubGeneration:
         out = _export(SIMPLE_ARRAY_RDL, tmpdir=tmp_path)
         pyi = (out / "__init__.pyi").read_text()
         assert "lut: simple_array_soc__lut_array_t" in pyi
-
-
-class TestStopGapErrors:
-    """Tier 0 stop-gap: unsupported shapes raise ``NotSupportedError``.
-
-    Phase 3 (#138) removes the multi-dim register and multi-dim
-    regfile array stop-gaps — those are now working codegen.
-    Remaining stop-gaps:
-
-    * addrmap arrays — out of scope (issue #138)
-    * field arrays — Phase 4
-    """
-
-    def _attempt(self, rdl_text: str, soc_name: str, tmpdir: Path) -> None:
-        _export(rdl_text, soc_name=soc_name, tmpdir=tmpdir)
-
-    def test_addrmap_array_not_supported(self, tmp_path: Path) -> None:
-        rdl_text = """
-        addrmap inner {
-            reg { field { sw=rw; hw=r; } data[31:0] = 0; } ctrl @ 0x0;
-        };
-        addrmap am_array_soc {
-            inner blocks[2] @ 0x0;
-        };
-        """
-        with pytest.raises(NotSupportedError) as exc:
-            self._attempt(rdl_text, "am_array_soc", tmp_path)
-        assert "addrmap arrays" in str(exc.value).lower()
-        assert "#138" in str(exc.value)
 
 
 class TestCollectNodes:
@@ -754,29 +743,141 @@ class TestMultiDimStubGeneration:
         assert "class cube_soc__cube_array_t" in pyi
 
 
-class TestPhase3StopGaps:
-    """Stop-gaps that survive Phase 3."""
+# ---------------------------------------------------------------------------
+# Addrmap arrays (issues #137 / #138 follow-up). The exporter now treats
+# arrayed ``AddrmapNode``s the same way it treats arrayed ``RegfileNode``s
+# — the same ``ArrayInfo`` shape, the same ``ArrayBase<entry_t>`` C++
+# wrapper, the same ``_ARRAY_PATHS`` runtime metadata. These tests
+# mirror the regfile-array suite.
+# ---------------------------------------------------------------------------
 
-    def test_addrmap_array_still_raises(self, tmp_path: Path) -> None:
-        """Addrmap arrays remain out of scope (P5 / followup, #138)."""
-        rdl_text = """
-        addrmap inner {
-            reg { field { sw=rw; hw=r; } data[31:0] = 0; } ctrl @ 0x0;
-        };
-        addrmap am_array_soc {
-            inner blocks[2] @ 0x0;
-        };
-        """
-        rdl_path = tmp_path / "x.rdl"
+
+class TestAddrmapArrayCollection:
+    def _collect(self, rdl_text: str, soc_name: str, tmpdir: Path):
+        rdl_path = tmpdir / f"{soc_name}.rdl"
         rdl_path.write_text(rdl_text)
         rdl = RDLCompiler()
         rdl.compile_file(str(rdl_path))
         root = rdl.elaborate()
-        out = tmp_path / "out"
-        out.mkdir()
-        with pytest.raises(NotSupportedError) as exc:
-            Pybind11Exporter().export(root.top, str(out), soc_name="am_array_soc")
-        assert "addrmap arrays" in str(exc.value).lower()
+        ex = Pybind11Exporter()
+        ex.soc_name = soc_name
+        ex.top_node = root.top
+        return ex._collect_nodes(root.top)
+
+    def test_addrmap_array_recorded(self, tmp_path: Path) -> None:
+        nodes = self._collect(ADDRMAP_ARRAY_RDL, "am_array_soc", tmp_path)
+        addrmap_arrays = [a for a in nodes["arrays"] if a["kind"] == "addrmap"]
+        assert len(addrmap_arrays) == 1
+        meta = addrmap_arrays[0]
+        assert meta["dimensions"] == [2]
+        # Stride: addrmap size = single 4-byte register = 4.
+        assert meta["stride"] == 4
+        assert meta["relative_offset"] == 0x100
+
+    def test_addrmap_array_entry_in_addrmaps_list(self, tmp_path: Path) -> None:
+        """Arrayed addrmap's entry type is emitted as a regular ``<am>_t``."""
+        nodes = self._collect(ADDRMAP_ARRAY_RDL, "am_array_soc", tmp_path)
+        # ``addrmaps`` carries the inner addrmap (entry type) plus the
+        # top addrmap; the top is filtered out by template guards.
+        inner_paths = {a.get_path() for a in nodes["addrmaps"]}
+        assert any("blocks" in p for p in inner_paths)
+        # Children of the arrayed addrmap walked once (current_idx=0).
+        reg_paths = {r.get_path() for r in nodes["regs"]}
+        assert any("ctrl" in p for p in reg_paths)
+
+
+class TestAddrmapArrayDescriptorEmission:
+    def test_addrmap_array_class_emitted(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        desc = (out / "am_array_soc_descriptors.hpp").read_text()
+        assert "class am_array_soc__blocks_array_t;" in desc
+        assert "class am_array_soc__blocks_array_t :" in desc
+        # Entry-type class emitted exactly once.
+        assert desc.count("class am_array_soc__blocks_t :") == 1
+        # Inherits from ArrayBase<entry_t>.
+        assert "ArrayBase<am_array_soc__blocks_t>" in desc
+
+    def test_addrmap_array_constructor_uses_stride_and_size(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        desc = (out / "am_array_soc_descriptors.hpp").read_text()
+        assert '"blocks", base_offset,' in desc
+        assert "0x100," in desc
+        # 2 entries, 4-byte stride.
+        assert "2, 4" in desc
+
+    def test_addrmap_array_definition_after_entry(self, tmp_path: Path) -> None:
+        """``<am>_array_t`` class body lands *after* its ``<am>_t`` entry."""
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        desc = (out / "am_array_soc_descriptors.hpp").read_text()
+        entry_pos = desc.index("class am_array_soc__blocks_t :")
+        array_pos = desc.index("class am_array_soc__blocks_array_t :")
+        assert entry_pos < array_pos
+
+    def test_parent_instantiates_addrmap_array_type(self, tmp_path: Path) -> None:
+        """The SoC class member is ``<am>_array_t``, not ``<am>_t``."""
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        desc = (out / "am_array_soc_descriptors.hpp").read_text()
+        assert "am_array_soc__blocks_array_t blocks{offset_};" in desc
+
+    def test_addrmap_entry_uses_zero_relative_offset(self, tmp_path: Path) -> None:
+        """Arrayed addrmap entry class passes ``0`` to ``NodeBase``."""
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        desc = (out / "am_array_soc_descriptors.hpp").read_text()
+        assert 'NodeBase("blocks", base_offset, 0x0)' in desc
+
+
+class TestAddrmapArrayBindingEmission:
+    def test_addrmap_array_binding_present(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        bindings = (out / "am_array_soc_bindings.cpp").read_text()
+        assert "py::class_<am_array_soc__blocks_array_t, NodeBase>" in bindings
+        assert '"am_array_soc__blocks_array_t"' in bindings
+
+    def test_addrmap_array_binding_exposes_indexing(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        bindings = (out / "am_array_soc_bindings.cpp").read_text()
+        assert "am_array_soc__blocks_array_t::size" in bindings
+        assert "am_array_soc__blocks_array_t::stride" in bindings
+
+
+class TestAddrmapArrayRuntimeWiring:
+    def test_array_paths_metadata_includes_addrmap(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        runtime = (out / "am_array_soc" / "__init__.py").read_text()
+        assert "_ARRAY_PATHS" in runtime
+        assert '("am_array_soc.blocks[]"' in runtime
+        assert "(2," in runtime
+
+
+class TestAddrmapArrayStubGeneration:
+    def test_addrmap_array_class_stub_emitted(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        pyi = (out / "__init__.pyi").read_text()
+        assert "class am_array_soc__blocks_array_t" in pyi
+        assert "def __len__(self) -> int" in pyi
+
+    def test_parent_attribute_uses_addrmap_array_type(self, tmp_path: Path) -> None:
+        out = _export(ADDRMAP_ARRAY_RDL, soc_name="am_array_soc", tmpdir=tmp_path)
+        pyi = (out / "__init__.pyi").read_text()
+        assert "blocks: am_array_soc__blocks_array_t" in pyi
+
+
+class TestMultiDimAddrmapArray:
+    def test_2d_descriptors_emit_two_levels(self, tmp_path: Path) -> None:
+        out = _export(MULTIDIM_ADDRMAP_RDL, soc_name="am_multidim_soc", tmpdir=tmp_path)
+        desc = (out / "am_multidim_soc_descriptors.hpp").read_text()
+        # 2-D arrays emit one inner-axis subclass plus the outer.
+        assert "class am_multidim_soc__blocks_inner_0_array_t :" in desc
+        assert "class am_multidim_soc__blocks_array_t :" in desc
+
+    def test_2d_strides_chain_correctly(self, tmp_path: Path) -> None:
+        nodes = TestAddrmapArrayCollection()._collect(
+            MULTIDIM_ADDRMAP_RDL, "am_multidim_soc", tmp_path
+        )
+        meta = [a for a in nodes["arrays"] if a["kind"] == "addrmap"][0]
+        assert meta["dimensions"] == [2, 3]
+        # Inner stride = entry size (4); outer stride = inner_size * inner = 3*4 = 12.
+        assert meta["strides"] == [12, 4]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_array_integration.py
+++ b/tests/test_array_integration.py
@@ -99,6 +99,20 @@ addrmap cube_soc {
 };
 """
 
+# Addrmap-array fixture (issues #137 / #138 follow-up). The inner
+# addrmap holds a single register; arraying it produces two
+# addressable blocks that each own their own ``ctrl`` register.
+ADDRMAP_ARRAY_RDL = """
+addrmap inner {
+    reg {
+        field { sw=rw; hw=r; } data[31:0] = 0;
+    } ctrl @ 0x0;
+};
+addrmap am_array_soc {
+    inner blocks[2] @ 0x100;
+};
+"""
+
 
 def _build_test_module(
     workdir: Path,
@@ -227,6 +241,25 @@ def mixed_array_module(tmp_path_factory):
 def mixed_soc(mixed_array_module):
     s = mixed_array_module.create()
     s.attach_master(mixed_array_module.MockMaster())
+    return s
+
+
+@pytest.fixture(scope="module")
+def addrmap_array_module(tmp_path_factory):
+    """Build the addrmap-array fixture C++ module."""
+    workdir = tmp_path_factory.mktemp("addrmap_array_integration")
+    module = _build_test_module(
+        workdir, rdl_text=ADDRMAP_ARRAY_RDL, soc_name="am_array_soc"
+    )
+    if module is None:
+        pytest.skip("Could not build test module (cmake/pybind11 unavailable)")
+    return module
+
+
+@pytest.fixture
+def am_soc(addrmap_array_module):
+    s = addrmap_array_module.create()
+    s.attach_master(addrmap_array_module.MockMaster())
     return s
 
 
@@ -388,6 +421,59 @@ class TestRegfileArraySurface:
         """``dma_soc.channel`` is wrapped in an :class:`ArrayView`."""
         from peakrdl_pybind11.runtime.arrays import ArrayView
         assert isinstance(dma_soc.channel, ArrayView)
+
+
+class TestAddrmapArraySurface:
+    """Addrmap-array end-to-end (issues #137 / #138 follow-up).
+
+    Twin of :class:`TestRegfileArraySurface`. Confirms that an arrayed
+    addrmap exposes the same sequence-protocol surface plus per-entry
+    member access through to its register children.
+    """
+
+    def test_length(self, am_soc) -> None:
+        assert len(am_soc.blocks) == 2
+
+    def test_shape_is_one_dim_tuple(self, am_soc) -> None:
+        assert tuple(am_soc.blocks.shape) == (2,)
+
+    def test_stride_is_addrmap_size(self, am_soc) -> None:
+        """Stride between blocks = addrmap size = single 4-byte register."""
+        assert int(am_soc.blocks.stride) == 4
+
+    def test_indexed_access_returns_same_instance(self, am_soc) -> None:
+        a = am_soc.blocks[1]
+        b = am_soc.blocks[1]
+        assert a is b
+
+    def test_iteration(self, am_soc) -> None:
+        entries = list(am_soc.blocks)
+        assert len(entries) == 2
+
+    def test_slice_returns_subset(self, am_soc) -> None:
+        sliced = am_soc.blocks[0:2]
+        assert len(sliced) == 2
+
+    def test_per_entry_member_access(self, am_soc) -> None:
+        """``blocks[i].ctrl.write(...)`` round-trips via the bus."""
+        am_soc.blocks[1].ctrl.write(0xBBBB)
+        assert int(am_soc.blocks[1].ctrl.read()) == 0xBBBB
+
+    def test_entries_are_independent(self, am_soc) -> None:
+        am_soc.blocks[0].ctrl.write(0xAAAA)
+        am_soc.blocks[1].ctrl.write(0xBBBB)
+        assert int(am_soc.blocks[0].ctrl.read()) == 0xAAAA
+        assert int(am_soc.blocks[1].ctrl.read()) == 0xBBBB
+
+    def test_entry_addresses_follow_stride(self, am_soc) -> None:
+        base = int(am_soc.blocks[0].ctrl.offset)
+        stride = int(am_soc.blocks.stride)
+        for i in range(2):
+            assert int(am_soc.blocks[i].ctrl.offset) == base + i * stride
+
+    def test_blocks_is_array_view(self, am_soc) -> None:
+        from peakrdl_pybind11.runtime.arrays import ArrayView
+        assert isinstance(am_soc.blocks, ArrayView)
 
 
 class TestMixedArraysIntegration:


### PR DESCRIPTION
The Tier 3 plan implemented register / regfile / multi-dim / field
arrays in #138, but arrayed AddrmapNodes were left raising
NotSupportedError. Extend the existing array machinery so an arrayed
addrmap (``inner blocks[N]``) emits a parallel ``<am>_array_t`` C++
class with the same ``ArrayBase<entry_t>`` shape used for regfile
arrays, exposes the sequence-protocol surface on the SoC, and round-
trips through ``soc.blocks[i].ctrl.write/read``.

Reuses ``ArrayInfo``, ``_compute_per_axis_strides``,
``_array_base_address``, ``array_levels_binding``, the C++
``ArrayBase`` template, and ``runtime/arrays.py:ArrayView`` — addrmap
arrays slot in as ``kind="addrmap"`` and share every downstream path
with regfile arrays. New descriptor partial
``descriptors/addrmap_arrays.hpp.jinja`` is included between
``addrmaps.hpp.jinja`` and ``top_node.hpp.jinja`` so
``ArrayBase<<am>_t>`` sees a complete entry type. Stop-gap tests for
``"addrmap arrays are not yet supported"`` are removed; replaced with
codegen and cmake-built integration tests covering 1-D and 2-D
addrmap arrays.

https://claude.ai/code/session_01FXPV1wHXm4GkqPnVZsuYsK